### PR TITLE
Use one time range with two subranges instead of two time ranges for bootstrapping

### DIFF
--- a/x/time/ranges.go
+++ b/x/time/ranges.go
@@ -20,9 +20,7 @@
 
 package time
 
-import (
-	"container/list"
-)
+import "container/list"
 
 // Ranges is a collection of time ranges.
 type Ranges interface {
@@ -76,7 +74,7 @@ func (tr *ranges) Overlaps(r Range) bool {
 	if r.IsEmpty() {
 		return false
 	}
-	_, e := tr.findFirstNotBefore(r)
+	e := tr.findFirstNotBefore(r)
 	if e == nil {
 		return false
 	}
@@ -97,26 +95,11 @@ func (tr *ranges) addRangeInPlace(r Range) {
 		return
 	}
 
-	// if the previous range touches r, merge them
-	pe, e := tr.findFirstNotBefore(r)
-	if pe != nil {
-		pr := pe.Value.(Range)
-		if pr.End == r.Start {
-			r.Start = pr.Start
-			tr.sortedRanges.Remove(pe)
-		}
-	}
-
+	e := tr.findFirstNotBefore(r)
 	for e != nil {
 		lr := e.Value.(Range)
 		ne := e.Next()
 		if !lr.Overlaps(r) {
-			// if r touches the next range, merge them
-			if r.End == lr.Start {
-				r.End = lr.End
-				tr.sortedRanges.Remove(e)
-				e = ne
-			}
 			break
 		}
 		r = r.Merge(lr)
@@ -154,7 +137,7 @@ func (tr *ranges) removeRangeInPlace(r Range) {
 	if r.IsEmpty() {
 		return
 	}
-	_, e := tr.findFirstNotBefore(r)
+	e := tr.findFirstNotBefore(r)
 	for e != nil {
 		lr := e.Value.(Range)
 		ne := e.Next()
@@ -193,15 +176,13 @@ func (tr *ranges) Iter() RangeIter {
 }
 
 // findFirstNotBefore finds the first interval that's not before r.
-func (tr *ranges) findFirstNotBefore(r Range) (*list.Element, *list.Element) {
-	var pe *list.Element
+func (tr *ranges) findFirstNotBefore(r Range) *list.Element {
 	for e := tr.sortedRanges.Front(); e != nil; e = e.Next() {
 		if !e.Value.(Range).Before(r) {
-			return pe, e
+			return e
 		}
-		pe = e
 	}
-	return pe, nil
+	return nil
 }
 
 // clone returns a copy of the time ranges.

--- a/x/time/ranges_test.go
+++ b/x/time/ranges_test.go
@@ -115,8 +115,8 @@ func TestAddRange(t *testing.T) {
 		{rangestoAdd[0], rangestoAdd[1]},
 		{rangestoAdd[2], rangestoAdd[0], rangestoAdd[1]},
 		{rangestoAdd[3], rangestoAdd[2], rangestoAdd[0], rangestoAdd[1]},
-		{rangestoAdd[3], {Start: testStart.Add(-3 * time.Second), End: testStart.Add(time.Second)}, rangestoAdd[1]},
-		{rangestoAdd[3], {Start: testStart.Add(-3 * time.Second), End: testStart.Add(8 * time.Second)}, rangestoAdd[1]},
+		{rangestoAdd[3], rangestoAdd[2], rangestoAdd[4], rangestoAdd[0], rangestoAdd[1]},
+		{rangestoAdd[3], rangestoAdd[2], rangestoAdd[4], rangestoAdd[0], rangestoAdd[5], rangestoAdd[1]},
 		{{Start: testStart.Add(-10 * time.Second), End: testStart.Add(15 * time.Second)}},
 	}
 


### PR DESCRIPTION
cc @robskillington 

We should use one time range with two subranges instead of two time ranges for bootstrapping. Also removed the logic in the `Ranges` implementation that automatically merges adjacent ranges touching on an endpoint.