### PR TITLE
Fix race condition when removing series from a shard

### DIFF
--- a/storage/series.go
+++ b/storage/series.go
@@ -201,7 +201,7 @@ func (s *dbSeries) ReadEncoded(
 
 	s.RLock()
 
-	if len(s.blocks.GetAllBlocks()) > 0 {
+	if s.blocks.Len() > 0 {
 		// Squeeze the lookup window by what's available to make range queries like [0, infinity) possible
 		if s.blocks.GetMinTime().After(alignedStart) {
 			alignedStart = s.blocks.GetMinTime()

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/m3db/m3db/interfaces/m3db"
@@ -79,9 +80,24 @@ type dbShard struct {
 }
 
 type dbShardEntry struct {
-	series databaseSeries
-	elem   *list.Element
+	series     databaseSeries
+	elem       *list.Element
+	curWriters int32
 }
+
+func (entry *dbShardEntry) writerCount() int32 {
+	return atomic.LoadInt32(&entry.curWriters)
+}
+
+func (entry *dbShardEntry) incrementWriterCount() {
+	atomic.AddInt32(&entry.curWriters, 1)
+}
+
+func (entry *dbShardEntry) decrementWriterCount() {
+	atomic.AddInt32(&entry.curWriters, -1)
+}
+
+type writeCompletionFn func()
 
 func newDatabaseShard(shard uint32, opts m3db.DatabaseOptions) databaseShard {
 	return &dbShard{
@@ -137,7 +153,9 @@ func (s *dbShard) forBatchWithLock(
 	return nextElem, nil
 }
 
-func (s *dbShard) Tick() {
+// tickForEachSeries ticks through each series in the shard and
+// returns a list of series that might have expired.
+func (s *dbShard) tickForEachSeries() []databaseSeries {
 	// TODO(xichen): pool this.
 	var expired []databaseSeries
 
@@ -151,19 +169,41 @@ func (s *dbShard) Tick() {
 		return err
 	})
 
+	return expired
+}
+
+func (s *dbShard) purgeExpiredSeries(expired []databaseSeries) {
 	if len(expired) == 0 {
 		return
 	}
 
-	// Remove all expired series from lookup and list
+	// Remove all expired series from lookup and list.
 	s.Lock()
 	for _, series := range expired {
 		id := series.ID()
 		entry := s.lookup[id]
+		// If this series is currently being written to, we don't remove
+		// it even though it's empty in that it might become non-empty soon.
+		if entry.writerCount() > 0 {
+			continue
+		}
+		// If there have been datapoints written to the series since its
+		// last empty check, we don't remove it.
+		if !series.Empty() {
+			continue
+		}
+		// NB(xichen): if we get here, we are guaranteed that there can be
+		// no more writes to this series while the lock is held, so it's
+		// safe to remove it.
 		s.list.Remove(entry.elem)
 		delete(s.lookup, id)
 	}
 	s.Unlock()
+}
+
+func (s *dbShard) Tick() {
+	expired := s.tickForEachSeries()
+	s.purgeExpiredSeries(expired)
 }
 
 func (s *dbShard) Write(
@@ -174,8 +214,10 @@ func (s *dbShard) Write(
 	unit xtime.Unit,
 	annotation []byte,
 ) error {
-	series := s.series(id)
-	return series.Write(ctx, timestamp, value, unit, annotation)
+	series, completionFn := s.writableSeries(id)
+	err := series.Write(ctx, timestamp, value, unit, annotation)
+	completionFn()
+	return err
 }
 
 func (s *dbShard) ReadEncoded(
@@ -192,20 +234,21 @@ func (s *dbShard) ReadEncoded(
 	return entry.series.ReadEncoded(ctx, start, end)
 }
 
-func (s *dbShard) series(id string) databaseSeries {
+func (s *dbShard) writableSeries(id string) (databaseSeries, writeCompletionFn) {
 	s.RLock()
-	entry, exists := s.lookup[id]
-	s.RUnlock()
-	if exists {
-		return entry.series
+	if entry, exists := s.lookup[id]; exists {
+		entry.incrementWriterCount()
+		s.RUnlock()
+		return entry.series, entry.decrementWriterCount
 	}
+	s.RUnlock()
 
 	s.Lock()
-	entry, exists = s.lookup[id]
-	if exists {
+	if entry, exists := s.lookup[id]; exists {
+		entry.incrementWriterCount()
 		s.Unlock()
 		// During Rlock -> Wlock promotion the entry was inserted
-		return entry.series
+		return entry.series, entry.decrementWriterCount
 	}
 	bs := bootstrapNotStarted
 	if s.newSeriesBootstrapped {
@@ -213,10 +256,11 @@ func (s *dbShard) series(id string) databaseSeries {
 	}
 	series := newDatabaseSeries(id, bs, s.opts)
 	elem := s.list.PushBack(series)
-	s.lookup[id] = &dbShardEntry{series, elem}
+	entry := &dbShardEntry{series: series, elem: elem, curWriters: 1}
+	s.lookup[id] = entry
 	s.Unlock()
 
-	return series
+	return entry.series, entry.decrementWriterCount
 }
 
 func (s *dbShard) Bootstrap(writeStart time.Time) error {
@@ -240,8 +284,10 @@ func (s *dbShard) Bootstrap(writeStart time.Time) error {
 	cutover := writeStart.Add(s.opts.GetBufferFuture())
 	bootstrappedSeries := sr.GetAllSeries()
 	for id, dbBlocks := range bootstrappedSeries {
-		series := s.series(id)
-		if err := series.Bootstrap(dbBlocks, cutover); err != nil {
+		series, completionFn := s.writableSeries(id)
+		err := series.Bootstrap(dbBlocks, cutover)
+		completionFn()
+		if err != nil {
 			return err
 		}
 	}

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3db/interfaces/m3db"
 	"github.com/m3db/m3db/mocks"
+	xtime "github.com/m3db/m3db/x/time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -109,4 +110,72 @@ func TestShardFlushToDiskSeriesFlushError(t *testing.T) {
 		_, ok := flushed[i]
 		require.True(t, ok)
 	}
+}
+
+func addTestSeries(t *testing.T, shard *dbShard, id string) databaseSeries {
+	series := newDatabaseSeries(id, bootstrapped, shard.opts)
+	elem := shard.list.PushBack(series)
+	entry := &dbShardEntry{series: series, elem: elem, curWriters: 0}
+	shard.lookup[id] = entry
+	return series
+}
+
+// This tests the scenario where an empty series is expired.
+func TestPurgeExpiredSeriesEmptySeries(t *testing.T) {
+	opts := testDatabaseOptions()
+	shard := testDatabaseShard(opts)
+	addTestSeries(t, shard, "foo")
+	shard.Tick()
+	require.Equal(t, 0, len(shard.lookup))
+}
+
+// This tests the scenario where a non-empty series is not expired.
+func TestPurgeExpiredSeriesNonEmptySeries(t *testing.T) {
+	opts := testDatabaseOptions()
+	shard := testDatabaseShard(opts)
+	ctx := opts.GetContextPool().Get()
+	nowFn := opts.GetNowFn()
+	shard.Write(ctx, "foo", nowFn(), 1.0, xtime.Second, nil)
+	expired := shard.tickForEachSeries()
+	require.Len(t, expired, 0)
+}
+
+// This tests the scenario where a series is empty when series.Tick() is called,
+// but receives writes after tickForEachSeries finishes but before purgeExpiredSeries
+// starts. The expected behavior is not to expire series in this case.
+func TestPurgeExpiredSeriesWriteAfterTicking(t *testing.T) {
+	opts := testDatabaseOptions()
+	shard := testDatabaseShard(opts)
+	series := addTestSeries(t, shard, "foo")
+	expired := shard.tickForEachSeries()
+	require.Len(t, expired, 1)
+
+	ctx := opts.GetContextPool().Get()
+	nowFn := opts.GetNowFn()
+	shard.Write(ctx, "foo", nowFn(), 1.0, xtime.Second, nil)
+	require.False(t, series.Empty())
+
+	shard.purgeExpiredSeries(expired)
+	require.Equal(t, 1, len(shard.lookup))
+}
+
+// This tests the scenario where tickForEachSeries finishes, and before purgeExpiredSeries
+// starts, we receive a write for a series, then purgeExpiredSeries runs, then we write to
+// the series. The expected behavior is not to expire series in this case.
+func TestPurgeExpiredSeriesWriteAfterPurging(t *testing.T) {
+	opts := testDatabaseOptions()
+	shard := testDatabaseShard(opts)
+	addTestSeries(t, shard, "foo")
+	expired := shard.tickForEachSeries()
+	require.Len(t, expired, 1)
+
+	ctx := opts.GetContextPool().Get()
+	nowFn := opts.GetNowFn()
+	series, completionFn := shard.writableSeries("foo")
+	shard.purgeExpiredSeries(expired)
+	series.Write(ctx, nowFn(), 1.0, xtime.Second, nil)
+	completionFn()
+
+	require.False(t, series.Empty())
+	require.Equal(t, 1, len(shard.lookup))
 }


### PR DESCRIPTION
cc @robskillington 

Currently there is a race condition in the `shard.Tick()` method. Basically it first iterates over all the series, finds out all the ones that are empty, acquires the shard lock, and removes them from the shard. AFAICT there are two issues that could cause a series with recent data to be removed from the shard:
- If a series is written to after it's determined to be empty when we iterate over all series in `Tick`
- Consider the following sequence of actions:
  - all datapoints for series "foo" have expired 
  - a new datapoint for "foo" comes in, we find the corresponding series by calling `series := shard.series(id)`, but haven't called `series.Write(...)` yet.
  - In the meantime, `shard.Tick()` starts, finds "foo" to be an empty series, and removes it from the shard.
  - `series.Write(...)` now runs
  - The end result is that "foo" has been removed from the shard, even though it has recent datapoints.

This diff attempts to fix the issues by:
- keeping track of the number of active writers to a series so we don't remove a series if it's being written to
- checking if the series is empty inside the shard lock, instead of relying on the possibly outdated information (i.e, the `expired` slice in `Tick`) from when iterating over the series.

Also added test cases to capture those cases.