### PR TITLE
Add RemoveSeries to the ShardResult interface

### DIFF
--- a/bootstrap/result.go
+++ b/bootstrap/result.go
@@ -74,6 +74,11 @@ func (sr *shardResult) AddResult(other m3db.ShardResult) {
 	}
 }
 
+// RemoveSeries removes a single series of blocks.
+func (sr *shardResult) RemoveSeries(id string) {
+	delete(sr.blocks, id)
+}
+
 // GetAllSeries returns all series in the map.
 func (sr *shardResult) GetAllSeries() map[string]m3db.DatabaseSeriesBlocks {
 	return sr.blocks

--- a/bootstrap/result_test.go
+++ b/bootstrap/result_test.go
@@ -103,3 +103,23 @@ func TestAddResultToResult(t *testing.T) {
 	sr.AddResult(other)
 	require.Len(t, sr.GetAllSeries(), 2)
 }
+
+func TestRemoveSeriesFromResult(t *testing.T) {
+	opts := getTestResultOptions()
+	sr := NewShardResult(opts)
+	inputs := []struct {
+		id     string
+		series m3db.DatabaseSeriesBlocks
+	}{
+		{"foo", storage.NewDatabaseSeriesBlocks(opts)},
+		{"bar", storage.NewDatabaseSeriesBlocks(opts)},
+	}
+	for _, input := range inputs {
+		sr.AddSeries(input.id, input.series)
+	}
+	require.Equal(t, 2, len(sr.GetAllSeries()))
+	sr.RemoveSeries("bar")
+	require.Equal(t, 1, len(sr.GetAllSeries()))
+	sr.RemoveSeries("nonexistent")
+	require.Equal(t, 1, len(sr.GetAllSeries()))
+}

--- a/integration/disk_flush_test.go
+++ b/integration/disk_flush_test.go
@@ -156,7 +156,7 @@ func TestDiskFlush(t *testing.T) {
 	// are flushed to disk asynchronously, need to poll to check
 	// when data are written.
 	testSetup.setNowFn(testSetup.getNowFn().Add(blockSize * 2))
-	waitTimeout := testSetup.dbOpts.GetBufferDrain() * 3
+	waitTimeout := testSetup.dbOpts.GetBufferDrain() * 4
 	require.NoError(t, waitUntilDataFlushed(filePathPrefix, testSetup.shardingScheme, dataMaps, waitTimeout))
 
 	// Verify on-disk data match what we expect

--- a/interfaces/m3db/bootstrap.go
+++ b/interfaces/m3db/bootstrap.go
@@ -44,6 +44,9 @@ type ShardResult interface {
 	// AddResult adds a shard result.
 	AddResult(other ShardResult)
 
+	// RemoveSeries removes a single series of blocks.
+	RemoveSeries(id string)
+
 	// GetAllSeries returns all series of blocks.
 	GetAllSeries() map[string]DatabaseSeriesBlocks
 

--- a/mocks/bootstrap.go
+++ b/mocks/bootstrap.go
@@ -87,6 +87,14 @@ func (_mr *_MockShardResultRecorder) AddResult(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddResult", arg0)
 }
 
+func (_m *MockShardResult) RemoveSeries(id string) {
+	_m.ctrl.Call(_m, "RemoveSeries", id)
+}
+
+func (_mr *_MockShardResultRecorder) RemoveSeries(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveSeries", arg0)
+}
+
 func (_m *MockShardResult) GetAllSeries() map[string]m3db.DatabaseSeriesBlocks {
 	ret := _m.ctrl.Call(_m, "GetAllSeries")
 	ret0, _ := ret[0].(map[string]m3db.DatabaseSeriesBlocks)

--- a/storage/database.go
+++ b/storage/database.go
@@ -276,6 +276,9 @@ func (d *db) splayedTick() {
 	if duration > d.tickDeadline {
 		// TODO(r): log an error and/or increment counter
 		_ = "todo"
+	} else {
+		// throttle to reduce locking overhead during ticking
+		time.Sleep(d.tickDeadline - duration)
 	}
 
 	if d.needDiskFlush(start) {

--- a/storage/database.go
+++ b/storage/database.go
@@ -270,6 +270,10 @@ func (d *db) splayedTick() {
 
 	wg.Wait()
 
+	if d.needDiskFlush(start) {
+		d.flushToDisk(start, true)
+	}
+
 	end := d.nowFn()
 	duration := end.Sub(start)
 	// TODO(r): instrument duration of tick
@@ -279,10 +283,6 @@ func (d *db) splayedTick() {
 	} else {
 		// throttle to reduce locking overhead during ticking
 		time.Sleep(d.tickDeadline - duration)
-	}
-
-	if d.needDiskFlush(start) {
-		d.flushToDisk(start, true)
 	}
 }
 


### PR DESCRIPTION
cc @robskillington 

Add `RemoveSeries` to the `ShardResult` interface.

Also add throttling to `Tick()` to reduce locking overhead observed during bootstrapping.