### PR TITLE
Fix a race condition when fetching data

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -403,7 +403,6 @@ func (s *session) FetchAll(ids []string, startInclusive, endExclusive time.Time)
 
 		wg.Add(1)
 		completionFn := func(result interface{}, err error) {
-			remaining := atomic.AddInt32(&pending, -1)
 			if err != nil {
 				n := atomic.AddInt32(&errs, 1)
 				if n == 1 {
@@ -418,7 +417,7 @@ func (s *session) FetchAll(ids []string, startInclusive, endExclusive time.Time)
 				iterIdx := atomic.AddInt32(&success, 1) - 1
 				results[iterIdx] = multiIter
 			}
-			if remaining != 0 {
+			if remaining := atomic.AddInt32(&pending, -1); remaining != 0 {
 				// Requests still pending
 				return
 			}

--- a/client/session.go
+++ b/client/session.go
@@ -417,6 +417,10 @@ func (s *session) FetchAll(ids []string, startInclusive, endExclusive time.Time)
 				iterIdx := atomic.AddInt32(&success, 1) - 1
 				results[iterIdx] = multiIter
 			}
+			// NB(xichen): decrementing pending and checking remaining against zero must
+			// come after incrementing success, otherwise we might end up passing results[:success]
+			// to iter.Reset down below before setting the iterator in the results array,
+			// which would cause a nil pointer exception.
 			if remaining := atomic.AddInt32(&pending, -1); remaining != 0 {
 				// Requests still pending
 				return

--- a/encoding/series_iterator_test.go
+++ b/encoding/series_iterator_test.go
@@ -101,27 +101,6 @@ func TestMultiReaderFiltersToRange(t *testing.T) {
 	assertTestSeriesIterator(t, test)
 }
 
-func TestSeriesIteratorIgnoresNilReplicas(t *testing.T) {
-	start := time.Now().Truncate(time.Minute)
-	end := start.Add(time.Minute)
-
-	values := []testValue{
-		{1.0, start.Add(1 * time.Second), xtime.Second, []byte{1, 2, 3}},
-		{2.0, start.Add(2 * time.Second), xtime.Second, nil},
-		{3.0, start.Add(3 * time.Second), xtime.Second, nil},
-	}
-
-	test := testSeries{
-		id:       "foo",
-		start:    start,
-		end:      end,
-		input:    [][]testValue{values, nil, values},
-		expected: values,
-	}
-
-	assertTestSeriesIterator(t, test)
-}
-
 func TestSeriesIteratorIgnoresEmptyReplicas(t *testing.T) {
 	start := time.Now().Truncate(time.Minute)
 	end := start.Add(time.Minute)


### PR DESCRIPTION
cc @robskillington 

Currently there is a race condition in session.go, which I believe was the culprit of the nil pointer issue we were seeing.

Specifically in session.go, let's say `pending` is 2, and two go routines get to line 418 at the same time. Both of them increment `success`, after which one of them proceeds and the other waits (due to context switch etc). If the proceeding goroutine happens to be the one in which `pending` is 0, it'll reach line 435, sees that `success` is 2, and passes `results[:2]` to `iter.Reset`, even though the other goroutine hasn't set `results[1]` to the corresponding iterator yet, which means `results[1]` is still `nil` at this point, which causes a nil pointer exception when we try to dereference `results[1]` in series_iterator.go. 

By moving the logic that decrements `pending` after the line that increments `success`, we are guaranteed that the goroutine that reaches line 435 will have all the items in the `results` array properly set.