### PR TITLE
Use digest buffer for read and writing digests in commit log writer/reader

### DIFF
--- a/persist/fs/commitlog/reader.go
+++ b/persist/fs/commitlog/reader.go
@@ -208,8 +208,8 @@ func (r *chunkReader) readHeader() error {
 	checksumSizeStart, checksumSizeEnd := sizeEnd, sizeEnd+chunkHeaderSizeLen
 	checksumDataStart, checksumDataEnd := checksumSizeEnd, checksumSizeEnd+chunkHeaderChecksumDataLen
 	size := endianness.Uint32(header[sizeStart:sizeEnd])
-	checksumSize := endianness.Uint32(header[checksumSizeStart:checksumSizeEnd])
-	checksumData := endianness.Uint32(header[checksumDataStart:checksumDataEnd])
+	checksumSize := digest.Buffer(header[checksumSizeStart:checksumSizeEnd]).ReadDigest()
+	checksumData := digest.Buffer(header[checksumDataStart:checksumDataEnd]).ReadDigest()
 
 	// Verify size checksum
 	if digest.Checksum(header[:4]) != checksumSize {

--- a/persist/fs/commitlog/writer.go
+++ b/persist/fs/commitlog/writer.go
@@ -266,8 +266,8 @@ func (w *chunkWriter) Write(p []byte) (int, error) {
 	checksumData := digest.Checksum(p)
 
 	// Write checksums
-	endianness.PutUint32(w.header[checksumSizeStart:checksumSizeEnd], uint32(checksumSize))
-	endianness.PutUint32(w.header[checksumDataStart:checksumDataEnd], uint32(checksumData))
+	digest.Buffer(w.header[checksumSizeStart:checksumSizeEnd]).WriteDigest(checksumSize)
+	digest.Buffer(w.header[checksumDataStart:checksumDataEnd]).WriteDigest(checksumData)
 
 	// Write header to file descriptor
 	if _, err := w.fd.Write(w.header); err != nil {


### PR DESCRIPTION
cc @xichen2020 