### PR TITLE
Use a gauge for the commit log writes queued metric

### DIFF
--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -148,7 +148,7 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 	// the case when writes stall for a considerable time
 	var sleepForOverride time.Duration
 	for {
-		l.metrics.IncCounter("writes.queued", int64(len(l.writes)))
+		l.metrics.UpdateGauge("writes.queued", int64(len(l.writes)))
 
 		sleepFor := interval
 		if sleepForOverride > 0 {


### PR DESCRIPTION
cc @xichen2020 @cw9 @martin-mao 