### PR TITLE
Refactor dynamic topology

### DIFF
--- a/topology/dynamic.go
+++ b/topology/dynamic.go
@@ -37,7 +37,7 @@ var (
 	errUnexpectedShard           = errors.New("shard is unexpected")
 	errMissingShard              = errors.New("shard is missing")
 	errNotEnoughReplicasForShard = errors.New("replicas of shard is less than expected")
-	errInvalidTopology           = errors.New("could not parse latest topology from config service")
+	errInvalidTopology           = errors.New("could not parse latest value from config service")
 )
 
 type dynamicInitializer struct {

--- a/topology/dynamic.go
+++ b/topology/dynamic.go
@@ -84,7 +84,7 @@ func newDynamicTopology(opts DynamicOptions) (Topology, error) {
 		return nil, err
 	}
 
-	m, err := mapFromServiceInstances(watch.Get(), opts.GetHashGen())
+	m, err := getMapFromUpdate(watch.Get(), opts.GetHashGen())
 	if err != nil {
 		logger.Errorf("dynamic topology received invalid initial value: %v", err)
 		return nil, err
@@ -112,7 +112,7 @@ func (t *dynamicTopology) run() {
 			break
 		}
 
-		m, err := mapFromServiceInstances(t.watch.Get(), t.hashGen)
+		m, err := getMapFromUpdate(t.watch.Get(), t.hashGen)
 		if err != nil {
 			t.logger.Warnf("dynamic topology received invalid update: %v", err)
 			continue
@@ -159,12 +159,12 @@ func waitOnInit(w xwatch.Watch, d time.Duration) error {
 	}
 }
 
-func mapFromServiceInstances(data interface{}, hashGen sharding.HashGen) (Map, error) {
+func getMapFromUpdate(data interface{}, hashGen sharding.HashGen) (Map, error) {
 	service, ok := data.(services.Service)
 	if !ok {
 		return nil, errInvalidTopology
 	}
-	to, err := staticOptionsFromServiceInstances(service, hashGen)
+	to, err := getStaticOptions(service, hashGen)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func mapFromServiceInstances(data interface{}, hashGen sharding.HashGen) (Map, e
 	return newStaticMap(to), nil
 }
 
-func staticOptionsFromServiceInstances(service services.Service, hashGen sharding.HashGen) (StaticOptions, error) {
+func getStaticOptions(service services.Service, hashGen sharding.HashGen) (StaticOptions, error) {
 	if service.Replication() == nil || service.Sharding() == nil || service.Instances() == nil {
 		return nil, errInvalidService
 	}

--- a/topology/dynamic_test.go
+++ b/topology/dynamic_test.go
@@ -73,34 +73,6 @@ func TestInitNoTimeout(t *testing.T) {
 	topo.Close()
 }
 
-func TestBackoffPoll(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	opts := NewDynamicOptions().RetryOptions(xretry.NewOptions().InitialBackoff(time.Millisecond))
-	w := newTestWatch(ctrl, time.Millisecond, time.Millisecond, 10, 10)
-	close(w.(*testWatch).ch)
-	input := newServiceTopologyInput(w, opts.GetHashGen(), opts.GetRetryOptions())
-	data, err := input.Poll()
-	assert.Equal(t, xwatch.ErrSourceClosed, err)
-	assert.Nil(t, data)
-
-	w = newTestWatch(ctrl, time.Millisecond, time.Millisecond, 0, 10)
-	go w.(*testWatch).run()
-	input = newServiceTopologyInput(w, opts.GetHashGen(), opts.GetRetryOptions())
-	data, err = input.Poll()
-	assert.Error(t, err)
-	assert.Nil(t, data)
-
-	w = newTestWatch(ctrl, time.Millisecond, time.Millisecond, 10, 10)
-	go w.(*testWatch).run()
-	input = newServiceTopologyInput(w, opts.GetHashGen(), opts.GetRetryOptions())
-	data, err = input.Poll()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, data.(Map).Replicas())
-	assert.Equal(t, 3, data.(Map).HostsLen())
-}
-
 func TestGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/topology/dynamic_test.go
+++ b/topology/dynamic_test.go
@@ -29,14 +29,12 @@ import (
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
-	"github.com/m3db/m3x/retry"
 	"github.com/m3db/m3x/watch"
 	"github.com/stretchr/testify/assert"
 )
 
 func testSetup(ctrl *gomock.Controller) (DynamicOptions, xwatch.Watch) {
 	opts := NewDynamicOptions()
-	opts = opts.RetryOptions(xretry.NewOptions().InitialBackoff(time.Millisecond))
 
 	watch := newTestWatch(ctrl, time.Millisecond, time.Millisecond, 10, 10)
 	mockCSServices := services.NewMockServices(ctrl)
@@ -71,6 +69,25 @@ func TestInitNoTimeout(t *testing.T) {
 	topo.Close()
 	// safe to close again
 	topo.Close()
+}
+
+func TestBack(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts, w := testSetup(ctrl)
+	go w.(*testWatch).run()
+	topo, err := newDynamicTopology(opts)
+	assert.NoError(t, err)
+	mw, err := topo.Watch()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, mw.Get().Replicas())
+	assert.Equal(t, 3, mw.Get().HostsLen())
+
+	opts, w = testSetup(ctrl)
+	close(w.(*testWatch).ch)
+	topo, err = newDynamicTopology(opts)
+	assert.Error(t, err)
 }
 
 func TestGet(t *testing.T) {

--- a/topology/options.go
+++ b/topology/options.go
@@ -29,7 +29,6 @@ import (
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3db/instrument"
 	"github.com/m3db/m3db/sharding"
-	"github.com/m3db/m3x/retry"
 )
 
 const (
@@ -41,7 +40,7 @@ var (
 	errNoConfigServiceClient   = errors.New("no config service client")
 	errNoServiceDiscoverClient = errors.New("no service discover client")
 	errNoHashGen               = errors.New("no hash gen function defined")
-	errInvalidReplicas = errors.New("replicas must be equal to or greater than 1")
+	errInvalidReplicas         = errors.New("replicas must be equal to or greater than 1")
 )
 
 type staticOptions struct {
@@ -119,7 +118,6 @@ type dynamicOptions struct {
 	configServiceClient client.Client
 	service             string
 	queryOptions        services.QueryOptions
-	retryOptions        xretry.Options
 	instrumentOptions   instrument.Options
 	initTimeout         time.Duration
 	hashGen             sharding.HashGen
@@ -130,7 +128,6 @@ func NewDynamicOptions() DynamicOptions {
 	return &dynamicOptions{
 		service:           defaultServiceName,
 		queryOptions:      services.NewQueryOptions(),
-		retryOptions:      xretry.NewOptions(),
 		instrumentOptions: instrument.NewOptions(),
 		initTimeout:       defaultInitTimeout,
 		hashGen:           sharding.DefaultHashGen,
@@ -175,15 +172,6 @@ func (o *dynamicOptions) QueryOptions(qo services.QueryOptions) DynamicOptions {
 
 func (o *dynamicOptions) GetQueryOptions() services.QueryOptions {
 	return o.queryOptions
-}
-
-func (o *dynamicOptions) RetryOptions(ro xretry.Options) DynamicOptions {
-	o.retryOptions = ro
-	return o
-}
-
-func (o *dynamicOptions) GetRetryOptions() xretry.Options {
-	return o.retryOptions
 }
 
 func (o *dynamicOptions) InstrumentOptions(io instrument.Options) DynamicOptions {

--- a/topology/types.go
+++ b/topology/types.go
@@ -29,7 +29,6 @@ import (
 	"github.com/m3db/m3db/instrument"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3x/close"
-	"github.com/m3db/m3x/retry"
 )
 
 // Host is a container of a host in a topology
@@ -194,12 +193,6 @@ type DynamicOptions interface {
 
 	// GetQueryOptions returns the ConfigService query options
 	GetQueryOptions() services.QueryOptions
-
-	// RetryOptions sets the retry options
-	RetryOptions(value xretry.Options) DynamicOptions
-
-	// GetRetryOptions returns the retry options
-	GetRetryOptions() xretry.Options
 
 	// InstrumentOptions sets the instrumentation options
 	InstrumentOptions(value instrument.Options) DynamicOptions


### PR DESCRIPTION
Originally DynamicTopology was waiting on Source.WaitOnInit() channel, changed to simply wait on watch.C()