### PR TITLE
Optimize filesystem bootstrapper performance

### DIFF
--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -139,9 +139,15 @@ func (m *bootstrapManager) Bootstrap() error {
 
 	bs := m.newBootstrapFn()
 	for _, namespace := range m.database.getOwnedNamespaces() {
+		start := m.nowFn()
 		if err := namespace.Bootstrap(bs, targetRanges, writeStart, cutover); err != nil {
 			multiErr = multiErr.Add(err)
 		}
+		end := m.nowFn()
+		m.log.WithFields(
+			xlog.NewLogField("namespace", namespace.Name()),
+			xlog.NewLogField("duration", end.Sub(start).String()),
+		).Info("bootstrap finished")
 	}
 
 	// At this point we have bootstrapped everything between now - retentionPeriod

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -30,6 +30,7 @@ import (
 	retention "github.com/m3db/m3db/retention"
 	block "github.com/m3db/m3db/storage/block"
 	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of Result interface
@@ -160,6 +161,14 @@ func (_m *MockShardResult) AddResult(other ShardResult) {
 
 func (_mr *_MockShardResultRecorder) AddResult(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddResult", arg0)
+}
+
+func (_m *MockShardResult) RemoveBlockAt(id string, t time0.Time) {
+	_m.ctrl.Call(_m, "RemoveBlockAt", id, t)
+}
+
+func (_mr *_MockShardResultRecorder) RemoveBlockAt(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveBlockAt", arg0, arg1)
 }
 
 func (_m *MockShardResult) RemoveSeries(id string) {
@@ -403,4 +412,24 @@ func (_m *MockOptions) DatabaseBlockOptions() block.Options {
 
 func (_mr *_MockOptionsRecorder) DatabaseBlockOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockOptions")
+}
+
+func (_m *MockOptions) SetInitialShardResultCapacity(value int) Options {
+	ret := _m.ctrl.Call(_m, "SetInitialShardResultCapacity", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetInitialShardResultCapacity(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetInitialShardResultCapacity", arg0)
+}
+
+func (_m *MockOptions) InitialShardResultCapacity() int {
+	ret := _m.ctrl.Call(_m, "InitialShardResultCapacity")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) InitialShardResultCapacity() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InitialShardResultCapacity")
 }

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -240,6 +240,16 @@ func (_m *MockBootstrapper) EXPECT() *_MockBootstrapperRecorder {
 	return _m.recorder
 }
 
+func (_m *MockBootstrapper) String() string {
+	ret := _m.ctrl.Call(_m, "String")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockBootstrapperRecorder) String() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "String")
+}
+
 func (_m *MockBootstrapper) Can(strategy Strategy) bool {
 	ret := _m.ctrl.Call(_m, "Can", strategy)
 	ret0, _ := ret[0].(bool)

--- a/storage/bootstrap/bootstrapper/fs/options.go
+++ b/storage/bootstrap/bootstrapper/fs/options.go
@@ -21,13 +21,26 @@
 package fs
 
 import (
+	"math"
+	"runtime"
+
 	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/storage/bootstrap"
+)
+
+const (
+	defaultNumIOWorkers = 1
+)
+
+var (
+	defaultNumProcessors = int(math.Ceil(float64(runtime.NumCPU()) / 2))
 )
 
 type options struct {
 	bootstrapOpts bootstrap.Options
 	fsOpts        fs.Options
+	numIOWorkers  int
+	numProcessors int
 }
 
 // NewOptions creates new bootstrap options
@@ -35,6 +48,8 @@ func NewOptions() Options {
 	return &options{
 		bootstrapOpts: bootstrap.NewOptions(),
 		fsOpts:        fs.NewOptions(),
+		numIOWorkers:  defaultNumIOWorkers,
+		numProcessors: defaultNumProcessors,
 	}
 }
 
@@ -56,4 +71,24 @@ func (o *options) SetFilesystemOptions(value fs.Options) Options {
 
 func (o *options) FilesystemOptions() fs.Options {
 	return o.fsOpts
+}
+
+func (o *options) SetNumIOWorkers(value int) Options {
+	opts := *o
+	opts.numIOWorkers = value
+	return &opts
+}
+
+func (o *options) NumIOWorkers() int {
+	return o.numIOWorkers
+}
+
+func (o *options) SetNumProcessors(value int) Options {
+	opts := *o
+	opts.numProcessors = value
+	return &opts
+}
+
+func (o *options) NumProcessors() int {
+	return o.numProcessors
 }

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -21,9 +21,11 @@
 package fs
 
 import (
+	"sync"
 	"time"
 
 	"github.com/m3db/m3db/persist/fs"
+	"github.com/m3db/m3db/pool"
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
@@ -37,15 +39,25 @@ type fileSystemSource struct {
 	filePathPrefix   string
 	readerBufferSize int
 	newReaderFn      newFileSetReaderFn
+	ioWorkers        pool.WorkerPool
+	processors       pool.WorkerPool
 }
 
 func newFileSystemSource(prefix string, opts Options) bootstrap.Source {
+	ioWorkers := pool.NewWorkerPool(opts.NumIOWorkers())
+	ioWorkers.Init()
+
+	processors := pool.NewWorkerPool(opts.NumProcessors())
+	processors.Init()
+
 	return &fileSystemSource{
 		opts:             opts,
 		log:              opts.BootstrapOptions().InstrumentOptions().Logger(),
 		filePathPrefix:   prefix,
 		readerBufferSize: opts.FilesystemOptions().ReaderBufferSize(),
 		newReaderFn:      fs.NewReader,
+		ioWorkers:        ioWorkers,
+		processors:       processors,
 	}
 }
 
@@ -95,6 +107,170 @@ func (s *fileSystemSource) shardAvailability(
 	return tr
 }
 
+type shardReaders struct {
+	shard   uint32
+	tr      xtime.Ranges
+	readers []fs.FileSetReader
+}
+
+func (s *fileSystemSource) enqueueReaders(
+	namespace string,
+	shardsTimeRanges bootstrap.ShardTimeRanges,
+	readersCh chan<- shardReaders,
+) {
+	var wg sync.WaitGroup
+
+	for shard, tr := range shardsTimeRanges {
+		shard, tr := shard, tr
+		wg.Add(1)
+		s.ioWorkers.Go(func() {
+			defer wg.Done()
+
+			var files []string
+			fs.ForEachInfoFile(s.filePathPrefix, namespace, shard, s.readerBufferSize, func(fname string, _ []byte) {
+				files = append(files, fname)
+			})
+
+			if len(files) == 0 {
+				// Use default readers value to indicate no readers for this shard
+				readersCh <- shardReaders{shard: shard, tr: tr}
+				return
+			}
+
+			readers := make([]fs.FileSetReader, 0, len(files))
+			for i := 0; i < len(files); i++ {
+				t, err := fs.TimeFromFileName(files[i])
+				if err != nil {
+					s.log.WithFields(
+						xlog.NewLogField("shard", shard),
+						xlog.NewLogField("file", files[i]),
+						xlog.NewLogField("error", err),
+					).Error("unable to get time from info file")
+					continue
+				}
+				r := s.newReaderFn(s.filePathPrefix, s.readerBufferSize)
+				if err := r.Open(namespace, shard, t); err != nil {
+					s.log.WithFields(
+						xlog.NewLogField("shard", shard),
+						xlog.NewLogField("time", t.String()),
+						xlog.NewLogField("error", err),
+					).Error("unable to open fileset files")
+					continue
+				}
+				timeRange := r.Range()
+				if !tr.Overlaps(timeRange) {
+					r.Close()
+					continue
+				}
+				readers = append(readers, r)
+			}
+			readersCh <- shardReaders{shard: shard, tr: tr, readers: readers}
+		})
+	}
+
+	wg.Wait()
+	close(readersCh)
+}
+
+func (s *fileSystemSource) bootstrapFromReaders(readersCh <-chan shardReaders) bootstrap.Result {
+	var (
+		wg         sync.WaitGroup
+		resultLock sync.Mutex
+		result     = bootstrap.NewResult()
+		bopts      = s.opts.BootstrapOptions()
+	)
+
+	for shardReaders := range readersCh {
+		shardReaders := shardReaders
+		wg.Add(1)
+		s.processors.Go(func() {
+			defer wg.Done()
+
+			var (
+				seriesMap       bootstrap.ShardResult
+				timesWithErrors []time.Time
+			)
+
+			shard, tr, readers := shardReaders.shard, shardReaders.tr, shardReaders.readers
+			for _, r := range readers {
+				if seriesMap == nil {
+					// Delay initializing seriesMap until we have a good idea of its capacity
+					seriesMap = bootstrap.NewShardResult(bopts.SetInitialShardResultCapacity(r.Entries()))
+				}
+
+				var (
+					timeRange  = r.Range()
+					hasError   = false
+					numEntries = r.Entries()
+				)
+
+				for i := 0; i < numEntries; i++ {
+					id, data, err := r.Read()
+					if err != nil {
+						s.log.WithFields(
+							xlog.NewLogField("shard", shard),
+							xlog.NewLogField("error", err),
+						).Error("reading data file failed")
+						hasError = true
+						break
+					}
+
+					encoder := bopts.DatabaseBlockOptions().EncoderPool().Get()
+					encoder.ResetSetData(timeRange.Start, data, false)
+					block := bopts.DatabaseBlockOptions().DatabaseBlockPool().Get()
+					block.Reset(timeRange.Start, encoder)
+					seriesMap.AddBlock(id, block)
+				}
+				if !hasError {
+					if err := r.Validate(); err != nil {
+						s.log.WithFields(
+							xlog.NewLogField("shard", shard),
+							xlog.NewLogField("error", err),
+						).Error("data validation failed")
+						hasError = true
+					}
+				}
+				r.Close()
+				if !hasError {
+					tr = tr.RemoveRange(timeRange)
+				} else {
+					timesWithErrors = append(timesWithErrors, timeRange.Start)
+				}
+			}
+
+			// NB(xichen): this is the exceptional case where we encountered errors due to files
+			// being corrupted, which should be fairly rare so we can live with the overhead. We
+			// experimented with adding the series to a temporary map and only adding the temporary map
+			// to the final result but adding series to large map with string keys is expensive, and
+			// the current implementation saves the extra overhead of merging temporary map with the
+			// final result.
+			if seriesMap != nil && len(timesWithErrors) > 0 {
+				s.log.WithFields(
+					xlog.NewLogField("shard", shard),
+					xlog.NewLogField("timesWithErrors", timesWithErrors),
+				).Info("deleting entries from results for times with errors")
+
+				allSeries := seriesMap.AllSeries()
+				for id, series := range allSeries {
+					for _, t := range timesWithErrors {
+						series.RemoveBlockAt(t)
+					}
+					if series.Len() == 0 {
+						delete(allSeries, id)
+					}
+				}
+			}
+
+			resultLock.Lock()
+			result.Add(shard, seriesMap, tr)
+			resultLock.Unlock()
+		})
+	}
+
+	wg.Wait()
+	return result
+}
+
 func (s *fileSystemSource) Read(
 	namespace string,
 	shardsTimeRanges bootstrap.ShardTimeRanges,
@@ -103,68 +279,24 @@ func (s *fileSystemSource) Read(
 		return nil, nil
 	}
 
-	result := bootstrap.NewResult()
-	for shard, tr := range shardsTimeRanges {
-		var files []string
-		fs.ForEachInfoFile(s.filePathPrefix, namespace, shard, s.readerBufferSize, func(fname string, _ []byte) {
-			files = append(files, fname)
-		})
-		if len(files) == 0 {
-			result.Add(shard, nil, tr)
-			continue
-		}
+	start := time.Now()
+	s.log.WithFields(
+		xlog.NewLogField("namespace", namespace),
+		xlog.NewLogField("numShards", len(shardsTimeRanges)),
+	).Info("started reading data from filesystem for bootstrapping")
 
-		bopts := s.opts.BootstrapOptions()
-		seriesMap := bootstrap.NewShardResult(bopts)
-		r := s.newReaderFn(s.filePathPrefix, s.readerBufferSize)
-		for i := 0; i < len(files); i++ {
-			t, err := fs.TimeFromFileName(files[i])
-			if err != nil {
-				s.log.Errorf("unable to get time from info file name %s: %v", files[i], err)
-				continue
-			}
-			if err := r.Open(namespace, shard, t); err != nil {
-				s.log.Errorf("unable to open info file for shard %d time %v: %v", shard, t, err)
-				continue
-			}
-			timeRange := r.Range()
-			if !tr.Overlaps(timeRange) {
-				r.Close()
-				continue
-			}
-			hasError := false
-			curMap := bootstrap.NewShardResult(bopts)
-			for i := 0; i < r.Entries(); i++ {
-				id, data, err := r.Read()
-				if err != nil {
-					s.log.Errorf("error reading data file for shard %d time %v: %v", shard, t, err)
-					hasError = true
-					break
-				}
-				encoder := bopts.DatabaseBlockOptions().EncoderPool().Get()
-				encoder.ResetSetData(timeRange.Start, data, false)
-				block := bopts.DatabaseBlockOptions().DatabaseBlockPool().Get()
-				block.Reset(timeRange.Start, encoder)
-				curMap.AddBlock(id, block)
-			}
-			if !hasError {
-				if err := r.Validate(); err != nil {
-					hasError = true
-					s.log.Errorf("data validation failed for shard %d time %v: %v", shard, t, err)
-				}
-			}
-			r.Close()
+	readersCh := make(chan shardReaders)
 
-			if !hasError {
-				seriesMap.AddResult(curMap)
-				tr = tr.RemoveRange(timeRange)
-			} else {
-				curMap.Close()
-			}
-		}
+	go s.enqueueReaders(namespace, shardsTimeRanges, readersCh)
+	result := s.bootstrapFromReaders(readersCh)
 
-		result.Add(shard, seriesMap, tr)
-	}
+	end := time.Now()
+
+	s.log.WithFields(
+		xlog.NewLogField("namespace", namespace),
+		xlog.NewLogField("numShards", len(shardsTimeRanges)),
+		xlog.NewLogField("duration", end.Sub(start).String()),
+	).Info("finished reading data from filesystem for bootstrapping")
 
 	return result, nil
 }

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -279,24 +279,7 @@ func (s *fileSystemSource) Read(
 		return nil, nil
 	}
 
-	start := time.Now()
-	s.log.WithFields(
-		xlog.NewLogField("namespace", namespace),
-		xlog.NewLogField("numShards", len(shardsTimeRanges)),
-	).Info("started reading data from filesystem for bootstrapping")
-
 	readersCh := make(chan shardReaders)
-
 	go s.enqueueReaders(namespace, shardsTimeRanges, readersCh)
-	result := s.bootstrapFromReaders(readersCh)
-
-	end := time.Now()
-
-	s.log.WithFields(
-		xlog.NewLogField("namespace", namespace),
-		xlog.NewLogField("numShards", len(shardsTimeRanges)),
-		xlog.NewLogField("duration", end.Sub(start).String()),
-	).Info("finished reading data from filesystem for bootstrapping")
-
-	return result, nil
+	return s.bootstrapFromReaders(readersCh), nil
 }

--- a/storage/bootstrap/bootstrapper/fs/types.go
+++ b/storage/bootstrap/bootstrapper/fs/types.go
@@ -38,4 +38,16 @@ type Options interface {
 
 	// GetFilesystemOptions returns the filesystem options
 	FilesystemOptions() fs.Options
+
+	// SetNumIOWorkers sets the number of I/O workers
+	SetNumIOWorkers(value int) Options
+
+	// NumIOWorkers returns the number of I/O workers
+	NumIOWorkers() int
+
+	// SetNumProcessors sets the number of processors for CPU-bound work
+	SetNumProcessors(value int) Options
+
+	// NumProcessors returns the number of processors for CPU-bound work
+	NumProcessors() int
 }

--- a/storage/bootstrap/options.go
+++ b/storage/bootstrap/options.go
@@ -27,20 +27,26 @@ import (
 	"github.com/m3db/m3db/storage/block"
 )
 
+const (
+	defaultInitialShardResultCapacity = 256
+)
+
 type options struct {
-	clockOpts      clock.Options
-	instrumentOpts instrument.Options
-	retentionOpts  retention.Options
-	blockOpts      block.Options
+	clockOpts             clock.Options
+	instrumentOpts        instrument.Options
+	retentionOpts         retention.Options
+	blockOpts             block.Options
+	initialResultCapacity int
 }
 
 // NewOptions creates new bootstrap options
 func NewOptions() Options {
 	return &options{
-		clockOpts:      clock.NewOptions(),
-		instrumentOpts: instrument.NewOptions(),
-		retentionOpts:  retention.NewOptions(),
-		blockOpts:      block.NewOptions(),
+		clockOpts:             clock.NewOptions(),
+		instrumentOpts:        instrument.NewOptions(),
+		retentionOpts:         retention.NewOptions(),
+		blockOpts:             block.NewOptions(),
+		initialResultCapacity: defaultInitialShardResultCapacity,
 	}
 }
 
@@ -82,4 +88,14 @@ func (o *options) SetDatabaseBlockOptions(value block.Options) Options {
 
 func (o *options) DatabaseBlockOptions() block.Options {
 	return o.blockOpts
+}
+
+func (o *options) SetInitialShardResultCapacity(value int) Options {
+	opts := *o
+	opts.initialResultCapacity = value
+	return &opts
+}
+
+func (o *options) InitialShardResultCapacity() int {
+	return o.initialResultCapacity
 }

--- a/storage/bootstrap/process.go
+++ b/storage/bootstrap/process.go
@@ -68,6 +68,7 @@ func (b *bootstrapProcess) Run(
 		}
 
 		logFields := []xlog.LogField{
+			xlog.NewLogField("bootstrapper", b.bootstrapper.String()),
 			xlog.NewLogField("namespace", namespace),
 			xlog.NewLogField("numShards", len(shards)),
 			xlog.NewLogField("from", window.Start.String()),

--- a/storage/bootstrap/process.go
+++ b/storage/bootstrap/process.go
@@ -67,18 +67,22 @@ func (b *bootstrapProcess) Run(
 			shardsTimeRanges[s] = r
 		}
 
-		b.log.WithFields(
+		logFields := []xlog.LogField{
 			xlog.NewLogField("namespace", namespace),
 			xlog.NewLogField("numShards", len(shards)),
 			xlog.NewLogField("from", window.Start.String()),
 			xlog.NewLogField("to", window.End.String()),
 			xlog.NewLogField("length", window.End.Sub(window.Start).String()),
-		).Infof("bootstrapping shards for range")
+		}
+
+		b.log.WithFields(logFields...).Infof("start bootstrapping shards for range")
 
 		res, err := b.bootstrapper.Bootstrap(namespace, shardsTimeRanges)
 		if err != nil {
 			return nil, err
 		}
+
+		b.log.WithFields(logFields...).Infof("finished bootstrapping shards for range")
 		result.AddResult(res)
 	}
 

--- a/storage/bootstrap/result.go
+++ b/storage/bootstrap/result.go
@@ -77,7 +77,7 @@ type shardResult struct {
 func NewShardResult(opts Options) ShardResult {
 	return &shardResult{
 		opts:   opts,
-		blocks: make(map[string]block.DatabaseSeriesBlocks),
+		blocks: make(map[string]block.DatabaseSeriesBlocks, opts.InitialShardResultCapacity()),
 	}
 }
 
@@ -115,6 +115,15 @@ func (sr *shardResult) AddResult(other ShardResult) {
 	for id, rawSeries := range otherSeries {
 		sr.AddSeries(id, rawSeries)
 	}
+}
+
+// RemoveBlockAt removes a data block at a given timestamp
+func (sr *shardResult) RemoveBlockAt(id string, t time.Time) {
+	curSeries, exists := sr.blocks[id]
+	if !exists {
+		return
+	}
+	curSeries.RemoveBlockAt(t)
 }
 
 // RemoveSeries removes a single series of blocks.

--- a/storage/bootstrap/types.go
+++ b/storage/bootstrap/types.go
@@ -21,6 +21,8 @@
 package bootstrap
 
 import (
+	"time"
+
 	"github.com/m3db/m3db/clock"
 	"github.com/m3db/m3db/instrument"
 	"github.com/m3db/m3db/retention"
@@ -65,6 +67,9 @@ type ShardResult interface {
 
 	// AddResult adds a shard result.
 	AddResult(other ShardResult)
+
+	// RemoveBlockAt removes a data block at a given timestamp
+	RemoveBlockAt(id string, t time.Time)
 
 	// RemoveSeries removes a single series of blocks.
 	RemoveSeries(id string)
@@ -147,4 +152,10 @@ type Options interface {
 
 	// DatabaseBlockOptions returns the database block options
 	DatabaseBlockOptions() block.Options
+
+	// SetInitialShardResultCapacity sets the initial shard result capacity
+	SetInitialShardResultCapacity(value int) Options
+
+	// InitialShardResultCapacity returns the initial shard result capacity
+	InitialShardResultCapacity() int
 }

--- a/storage/bootstrap/types.go
+++ b/storage/bootstrap/types.go
@@ -102,6 +102,9 @@ const (
 
 // Bootstrapper is the interface for different bootstrapping mechanisms.
 type Bootstrapper interface {
+	// String returns the name of the bootstrapper
+	String() string
+
 	// Can returns whether a specific bootstrapper strategy can be applied.
 	Can(strategy Strategy) bool
 

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -46,6 +46,7 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 
 	namespace := NewMockdatabaseNamespace(ctrl)
 	namespace.EXPECT().Bootstrap(nil, gomock.Any(), now, cutover).Return(fmt.Errorf("an error"))
+	namespace.EXPECT().Name().Return("test")
 
 	namespaces := map[string]databaseNamespace{
 		"test": namespace,

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -211,10 +211,6 @@ func (n *dbNamespace) Bootstrap(
 		return nil
 	}
 
-	start := n.nowFn()
-	namespaceLogField := xlog.NewLogField("namespace", n.name)
-	n.log.WithFields(namespaceLogField).Info("start bootstrapping")
-
 	shards := n.getOwnedShards()
 	shardIDs := make([]uint32, len(shards))
 	for i, shard := range shards {
@@ -228,8 +224,6 @@ func (n *dbNamespace) Bootstrap(
 		return err
 	}
 	n.metrics.bootstrap.Success.Inc(1)
-
-	n.log.WithFields(namespaceLogField).Info("finished reading external data")
 
 	// Bootstrap shards using at least half the CPUs available
 	workers := pool.NewWorkerPool(int(math.Ceil(float64(runtime.NumCPU()) / 2)))
@@ -272,12 +266,6 @@ func (n *dbNamespace) Bootstrap(
 
 	err = multiErr.FinalError()
 	n.metrics.bootstrap.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
-
-	end := n.nowFn()
-	n.log.WithFields(
-		namespaceLogField,
-		xlog.NewLogField("duration", end.Sub(start).String()),
-	).Info("finished bootstrapping")
 
 	return err
 }


### PR DESCRIPTION
cc @robskillington @martin-mao 

This reduces the time to bootstrap 48 hours of data from disk on a single node from 30 mins to 3-4 mins.