### PR TITLE
Lazily get context from pool for database blocks

### DIFF
--- a/storage/block/block.go
+++ b/storage/block/block.go
@@ -97,10 +97,7 @@ func (b *dbBlock) Stream(blocker context.Context) (xio.SegmentReader, error) {
 		return nil, errReadFromClosedBlock
 	}
 	if blocker != nil {
-		if b.ctx == nil {
-			b.ctx = b.opts.ContextPool().Get()
-		}
-		b.ctx.DependsOn(blocker)
+		b.context().DependsOn(blocker)
 	}
 	if b.writable {
 		return b.encoder.Stream(), nil
@@ -113,6 +110,13 @@ func (b *dbBlock) Stream(blocker context.Context) (xio.SegmentReader, error) {
 	s := b.opts.SegmentReaderPool().Get()
 	s.Reset(b.segment)
 	return s, nil
+}
+
+func (b *dbBlock) context() context.Context {
+	if b.ctx == nil {
+		b.ctx = b.opts.ContextPool().Get()
+	}
+	return b.ctx
 }
 
 // close closes internal context and returns encoder and stream to pool.

--- a/storage/block/block.go
+++ b/storage/block/block.go
@@ -61,7 +61,6 @@ func NewDatabaseBlock(start time.Time, encoder encoding.Encoder, opts Options) D
 		opts:     opts,
 		start:    start,
 		encoder:  encoder,
-		ctx:      opts.ContextPool().Get(),
 		closed:   false,
 		writable: true,
 	}
@@ -98,6 +97,9 @@ func (b *dbBlock) Stream(blocker context.Context) (xio.SegmentReader, error) {
 		return nil, errReadFromClosedBlock
 	}
 	if blocker != nil {
+		if b.ctx == nil {
+			b.ctx = b.opts.ContextPool().Get()
+		}
 		b.ctx.DependsOn(blocker)
 	}
 	if b.writable {
@@ -157,7 +159,6 @@ func (b *dbBlock) Reset(startTime time.Time, encoder encoding.Encoder) {
 	b.encoder = encoder
 	b.segment = ts.Segment{}
 	b.checksum = 0
-	b.ctx = b.opts.ContextPool().Get()
 	b.closed = false
 	b.writable = true
 }

--- a/storage/block/block_test.go
+++ b/storage/block/block_test.go
@@ -69,6 +69,7 @@ func validateBlocks(t *testing.T, blocks *databaseSeriesBlocks, minTime, maxTime
 
 func closeTestDatabaseBlock(t *testing.T, block *dbBlock) {
 	var finished uint32
+	block.ctx = block.opts.ContextPool().Get()
 	block.ctx.RegisterCloser(func() { atomic.StoreUint32(&finished, 1) })
 	block.Close()
 	// waiting for the goroutine that closes context to finish


### PR DESCRIPTION
cc @robskillington @martin-mao 

Creating context objects and returning contexts to pool shows up in cpu profile during fs bootstrapping and takes roughly 20% of the bootstrap CPU.