### PR TITLE
Allocate IDs for CommitLog writes from a pool.

### DIFF
--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -104,9 +104,10 @@ type commitLogWrite struct {
 
 // NewCommitLog creates a new commit log
 func NewCommitLog(opts Options) CommitLog {
-	iops := opts.InstrumentOptions()
-	iops = iops.SetMetricsScope(iops.MetricsScope().SubScope("commitlog"))
-	scope := iops.MetricsScope()
+	iopts := opts.InstrumentOptions().SetMetricsScope(
+		opts.InstrumentOptions().MetricsScope().SubScope("commitlog"))
+	scope := iopts.MetricsScope()
+
 	commitLog := &commitLog{
 		opts:  opts,
 		nowFn: opts.ClockOptions().NowFn(),
@@ -120,7 +121,7 @@ func NewCommitLog(opts Options) CommitLog {
 			flushErrors: scope.Counter("writes.flush-errors"),
 			flushDone:   scope.Counter("writes.flush-done"),
 		},
-		log:                  iops.Logger(),
+		log:                  iopts.Logger(),
 		newCommitLogWriterFn: newCommitLogWriter,
 		writes:               make(chan commitLogWrite, opts.BacklogQueueSize()),
 		closeErr:             make(chan error),
@@ -145,23 +146,26 @@ func (l *commitLog) Open() error {
 	// https://github.com/apache/cassandra/blob/6dfc1e7eeba539774784dfd650d3e1de6785c938/conf/cassandra.yaml#L232
 	// Right now it is a large amount of coordination to implement something similiar.
 	var fails int64
+
 	l.commitLogFailFn = func(err error) {
 		currFails := atomic.AddInt64(&fails, 1)
+
 		if currFails < 3 {
 			go func() {
 				time.Sleep(time.Second)
 				atomic.AddInt64(&fails, -1)
 			}()
+
 			return
 		}
+
 		l.log.Fatalf("fatal commit log error: %v", err)
 	}
 
 	// Asynchronously write
 	go l.write()
 
-	flushInterval := l.opts.FlushInterval()
-	if flushInterval > 0 {
+	if flushInterval := l.opts.FlushInterval(); flushInterval > 0 {
 		// Continually flush the commit log at given interval if set
 		go l.flushEvery(flushInterval)
 	}
@@ -173,9 +177,12 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 	// Periodically flush the underlying commit log writer to cover
 	// the case when writes stall for a considerable time
 	var sleepForOverride time.Duration
+
 	for {
 		l.metrics.queued.Update(int64(len(l.writes)))
+
 		sleepFor := interval
+
 		if sleepForOverride > 0 {
 			sleepFor = sleepForOverride
 			sleepForOverride = 0
@@ -187,10 +194,9 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 		lastFlushAt := l.lastFlushAt
 		l.flushMutex.RUnlock()
 
-		sinceLastFlush := l.nowFn().Sub(lastFlushAt)
-		if sinceLastFlush < interval {
+		if sinceFlush := l.nowFn().Sub(lastFlushAt); sinceFlush < interval {
 			// Flushed already recently, sleep until we would next consider flushing
-			sleepForOverride = interval - sinceLastFlush
+			sleepForOverride = interval - sinceFlush
 			continue
 		}
 
@@ -200,23 +206,14 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 			l.RUnlock()
 			return
 		}
+
 		l.writes <- commitLogWrite{valueType: flushValueType}
 		l.RUnlock()
 	}
 }
 
 func (l *commitLog) write() {
-	var (
-		write commitLogWrite
-		err   error
-		open  bool
-	)
-	for {
-		write, open = <-l.writes
-		if !open {
-			break
-		}
-
+	for write := range l.writes {
 		// For writes requiring acks add to pending acks
 		if write.completionFn != nil {
 			l.pendingFlushFns = append(l.pendingFlushFns, write.completionFn)
@@ -227,26 +224,32 @@ func (l *commitLog) write() {
 			continue
 		}
 
-		now := l.nowFn()
-		if !now.Before(l.writerExpireAt) {
-			if err = l.openWriter(now); err != nil {
+		if now := l.nowFn(); !now.Before(l.writerExpireAt) {
+			if err := l.openWriter(now); err != nil {
 				l.metrics.errors.Inc(1)
 				l.metrics.openErrors.Inc(1)
 				l.log.Errorf("failed to open commit log: %v", err)
+
 				if l.commitLogFailFn != nil {
 					l.commitLogFailFn(err)
 				}
+
 				continue
 			}
 		}
 
-		err = l.writer.Write(write.series, write.datapoint, write.unit, write.annotation)
+		err := l.writer.Write(
+			write.series, write.datapoint, write.unit, write.annotation)
+		write.series.ID.OnClose()
+
 		if err != nil {
 			l.metrics.errors.Inc(1)
 			l.log.Errorf("failed to write to commit log: %v", err)
+
 			if l.commitLogFailFn != nil {
 				l.commitLogFailFn(err)
 			}
+
 			continue
 		}
 
@@ -270,6 +273,7 @@ func (l *commitLog) onFlush(err error) {
 		l.metrics.errors.Inc(1)
 		l.metrics.flushErrors.Inc(1)
 		l.log.Errorf("failed to flush commit log: %v", err)
+
 		if l.commitLogFailFn != nil {
 			l.commitLogFailFn(err)
 		}
@@ -297,21 +301,25 @@ func (l *commitLog) openWriter(now time.Time) error {
 		if err := l.writer.Close(); err != nil {
 			l.metrics.closeErrors.Inc(1)
 			l.log.Errorf("failed to close commit log: %v", err)
+
 			// If we failed to close then create a new commit log writer
 			l.writer = nil
 		}
 	}
+
 	if l.writer == nil {
 		l.writer = l.newCommitLogWriterFn(l.onFlush, l.opts)
 	}
 
 	blockSize := l.opts.RetentionOptions().BlockSize()
 	start := now.Truncate(blockSize)
+
 	if err := l.writer.Open(start, blockSize); err != nil {
 		return err
 	}
 
 	l.writerExpireAt = start.Add(blockSize)
+
 	return nil
 }
 
@@ -323,7 +331,6 @@ func (l *commitLog) Write(
 	annotation ts.Annotation,
 ) error {
 	l.RLock()
-
 	if l.closed {
 		l.RUnlock()
 		return errCommitLogClosed
@@ -360,7 +367,6 @@ func (l *commitLog) Write(
 	l.RUnlock()
 
 	if !enqueued {
-		l.RUnlock()
 		return errCommitLogQueueFull
 	}
 
@@ -377,7 +383,6 @@ func (l *commitLog) WriteBehind(
 	annotation ts.Annotation,
 ) error {
 	l.RLock()
-
 	if l.closed {
 		l.RUnlock()
 		return errCommitLogClosed
@@ -398,12 +403,12 @@ func (l *commitLog) WriteBehind(
 	default:
 	}
 
+	l.RUnlock()
+
 	if !enqueued {
-		l.RUnlock()
 		return errCommitLogQueueFull
 	}
 
-	l.RUnlock()
 	return nil
 }
 
@@ -417,9 +422,11 @@ func (l *commitLog) Close() error {
 		l.Unlock()
 		return nil
 	}
+
 	l.closed = true
 	close(l.writes)
 	l.Unlock()
+
 	// Receive the result of closing the writer from asynchronous writer
 	return <-l.closeErr
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -69,6 +69,7 @@ type dbShard struct {
 	deleteFilesFn         deleteFilesFn
 	tickSleepIfAheadEvery int
 	sleepFn               func(time.Duration)
+	identifierPool        ts.IdentifierPool
 }
 
 type dbShardEntry struct {
@@ -115,6 +116,7 @@ func newDatabaseShard(
 		deleteFilesFn:         fs.DeleteFiles,
 		tickSleepIfAheadEvery: defaultTickSleepIfAheadEvery,
 		sleepFn:               time.Sleep,
+		identifierPool:        opts.IdentifierPool(),
 	}
 	if !needsBootstrap {
 		d.bs = bootstrapped
@@ -276,7 +278,7 @@ func (s *dbShard) Write(
 	info := commitlog.Series{
 		UniqueIndex: entry.index,
 		Namespace:   s.namespace,
-		ID:          ts.BinaryID(id.Data()),
+		ID:          s.identifierPool.Clone(id),
 		Shard:       s.shard,
 	}
 

--- a/ts/identifier_pool.go
+++ b/ts/identifier_pool.go
@@ -50,3 +50,11 @@ func (p *identifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
 func (p *identifierPool) GetStringID(ctx context.Context, v string) ID {
 	return p.GetBinaryID(ctx, []byte(v))
 }
+
+// Clone replicates given ID into a new ID from the pool
+func (p *identifierPool) Clone(other ID) ID {
+	id := p.pool.Get().(*id)
+	id.data = other.Data()
+
+	return id
+}

--- a/ts/identifier_test.go
+++ b/ts/identifier_test.go
@@ -54,6 +54,15 @@ func TestPooling(t *testing.T) {
 	require.Empty(t, a.Data())
 }
 
+func TestCloning(t *testing.T) {
+	a := StringID("abc")
+
+	p := NewIdentifierPool(pool.NewObjectPoolOptions())
+	b := p.Clone(a)
+
+	require.True(t, a.Equal(b))
+}
+
 func BenchmarkHashing(b *testing.B) {
 	v := []byte{}
 

--- a/ts/types.go
+++ b/ts/types.go
@@ -41,6 +41,9 @@ type ID interface {
 type IdentifierPool interface {
 	GetBinaryID(context.Context, []byte) ID
 	GetStringID(context.Context, string) ID
+
+	// Clone replicates a given ID into a pooled ID
+	Clone(other ID) ID
 }
 
 // Hash represents a form of ID suitable to be used as map keys


### PR DESCRIPTION
This PR introduces pooling to the ID cloning code that happens when we enqueue writes to the CommitLog. Due to the asynchronous nature of the CommitLog, we cannot reuse the IDs passed from the RPC code and using nested contexts and `DependsOn() ` machinery proved to be prohibitively expensive.