### PR TITLE
Add read level consistency of unstrict majority and error metadata

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -35,9 +35,9 @@ import (
 	bootstrap "github.com/m3db/m3db/storage/bootstrap"
 	topology "github.com/m3db/m3db/topology"
 	ts "github.com/m3db/m3db/ts"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time "time"
+	time0 "time"
 )
 
 // Mock of Client interface
@@ -104,7 +104,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,7 +114,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -125,7 +125,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -284,7 +284,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -294,7 +294,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -305,7 +305,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -357,7 +357,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -368,7 +368,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts bootstrap.Options) (bootstrap.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts bootstrap.Options) (bootstrap.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(bootstrap.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -400,7 +400,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -410,7 +410,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -421,7 +421,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -473,7 +473,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -484,7 +484,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts bootstrap.Options) (bootstrap.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts bootstrap.Options) (bootstrap.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(bootstrap.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -812,6 +812,26 @@ func (_mr *_MockOptionsRecorder) ConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConsistencyLevel")
 }
 
+func (_m *MockOptions) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {
+	ret := _m.ctrl.Call(_m, "SetReadConsistencyLevel", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetReadConsistencyLevel(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetReadConsistencyLevel", arg0)
+}
+
+func (_m *MockOptions) ReadConsistencyLevel() ReadConsistencyLevel {
+	ret := _m.ctrl.Call(_m, "ReadConsistencyLevel")
+	ret0, _ := ret[0].(ReadConsistencyLevel)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) ReadConsistencyLevel() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadConsistencyLevel")
+}
+
 func (_m *MockOptions) SetChannelOptions(value *tchannel_go.ChannelOptions) Options {
 	ret := _m.ctrl.Call(_m, "SetChannelOptions", value)
 	ret0, _ := ret[0].(Options)
@@ -872,7 +892,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -882,9 +902,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time.Duration {
+func (_m *MockOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -892,7 +912,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -902,9 +922,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -932,7 +952,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -942,9 +962,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -952,7 +972,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -962,9 +982,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -972,7 +992,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -982,9 +1002,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -992,7 +1012,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1002,9 +1022,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1012,7 +1032,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1022,9 +1042,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1032,7 +1052,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1042,9 +1062,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1052,7 +1072,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1062,9 +1082,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1192,7 +1212,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1202,9 +1222,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1413,6 +1433,26 @@ func (_mr *_MockAdminOptionsRecorder) ConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConsistencyLevel")
 }
 
+func (_m *MockAdminOptions) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {
+	ret := _m.ctrl.Call(_m, "SetReadConsistencyLevel", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetReadConsistencyLevel(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetReadConsistencyLevel", arg0)
+}
+
+func (_m *MockAdminOptions) ReadConsistencyLevel() ReadConsistencyLevel {
+	ret := _m.ctrl.Call(_m, "ReadConsistencyLevel")
+	ret0, _ := ret[0].(ReadConsistencyLevel)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) ReadConsistencyLevel() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadConsistencyLevel")
+}
+
 func (_m *MockAdminOptions) SetChannelOptions(value *tchannel_go.ChannelOptions) Options {
 	ret := _m.ctrl.Call(_m, "SetChannelOptions", value)
 	ret0, _ := ret[0].(Options)
@@ -1473,7 +1513,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1483,9 +1523,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1493,7 +1533,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1503,9 +1543,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1533,7 +1573,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1543,9 +1583,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1553,7 +1593,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1563,9 +1603,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1573,7 +1613,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1583,9 +1623,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1593,7 +1633,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1603,9 +1643,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1613,7 +1653,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1623,9 +1663,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1633,7 +1673,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1643,9 +1683,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1653,7 +1693,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1663,9 +1703,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1793,7 +1833,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1803,9 +1843,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1933,7 +1973,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -1943,9 +1983,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1953,7 +1993,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -1963,9 +2003,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -792,24 +792,24 @@ func (_mr *_MockOptionsRecorder) TopologyInitializer() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyInitializer")
 }
 
-func (_m *MockOptions) SetConsistencyLevel(value topology.ConsistencyLevel) Options {
-	ret := _m.ctrl.Call(_m, "SetConsistencyLevel", value)
+func (_m *MockOptions) SetWriteConsistencyLevel(value topology.ConsistencyLevel) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteConsistencyLevel", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) SetConsistencyLevel(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetConsistencyLevel", arg0)
+func (_mr *_MockOptionsRecorder) SetWriteConsistencyLevel(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteConsistencyLevel", arg0)
 }
 
-func (_m *MockOptions) ConsistencyLevel() topology.ConsistencyLevel {
-	ret := _m.ctrl.Call(_m, "ConsistencyLevel")
+func (_m *MockOptions) WriteConsistencyLevel() topology.ConsistencyLevel {
+	ret := _m.ctrl.Call(_m, "WriteConsistencyLevel")
 	ret0, _ := ret[0].(topology.ConsistencyLevel)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) ConsistencyLevel() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConsistencyLevel")
+func (_mr *_MockOptionsRecorder) WriteConsistencyLevel() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteConsistencyLevel")
 }
 
 func (_m *MockOptions) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {
@@ -1413,24 +1413,24 @@ func (_mr *_MockAdminOptionsRecorder) TopologyInitializer() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyInitializer")
 }
 
-func (_m *MockAdminOptions) SetConsistencyLevel(value topology.ConsistencyLevel) Options {
-	ret := _m.ctrl.Call(_m, "SetConsistencyLevel", value)
+func (_m *MockAdminOptions) SetWriteConsistencyLevel(value topology.ConsistencyLevel) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteConsistencyLevel", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) SetConsistencyLevel(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetConsistencyLevel", arg0)
+func (_mr *_MockAdminOptionsRecorder) SetWriteConsistencyLevel(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteConsistencyLevel", arg0)
 }
 
-func (_m *MockAdminOptions) ConsistencyLevel() topology.ConsistencyLevel {
-	ret := _m.ctrl.Call(_m, "ConsistencyLevel")
+func (_m *MockAdminOptions) WriteConsistencyLevel() topology.ConsistencyLevel {
+	ret := _m.ctrl.Call(_m, "WriteConsistencyLevel")
 	ret0, _ := ret[0].(topology.ConsistencyLevel)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) ConsistencyLevel() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConsistencyLevel")
+func (_mr *_MockAdminOptionsRecorder) WriteConsistencyLevel() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteConsistencyLevel")
 }
 
 func (_m *MockAdminOptions) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {

--- a/client/errors.go
+++ b/client/errors.go
@@ -109,8 +109,12 @@ func newConsistencyResultError(
 ) consistencyResultError {
 	// NB(r): if any errors are bad request errors, encapsulate that error
 	// to ensure the error itself is wholly classified as a bad request error
-	topLevelErr := errs[0]
-	for i := 1; i < len(errs); i++ {
+	var topLevelErr error
+	for i := 0; i < len(errs); i++ {
+		if topLevelErr == nil {
+			topLevelErr = errs[i]
+			continue
+		}
 		if IsBadRequestError(errs[i]) {
 			topLevelErr = errs[i]
 			break
@@ -137,9 +141,9 @@ func (e consistencyResultErr) Error() string {
 }
 
 func (e consistencyResultErr) numResponded() int {
-	return int(e.responded)
+	return e.responded
 }
 
 func (e consistencyResultErr) numSuccess() int {
-	return int(e.success)
+	return e.success
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3x/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsistencyResultError(t *testing.T) {
+	topErr := &rpc.Error{
+		Type: rpc.ErrorType_BAD_REQUEST,
+	}
+
+	err := consistencyResultErr{
+		level:       ReadConsistencyLevelMajority,
+		success:     1,
+		enqueued:    3,
+		responded:   3,
+		topLevelErr: topErr,
+		errs:        []error{topErr, fmt.Errorf("another error")},
+	}
+
+	assert.True(t, strings.HasPrefix(err.Error(),
+		"failed to meet ReadConsistencyLevelMajority with 1/3 success, 3 nodes responded, errors:"))
+	assert.Equal(t, topErr, xerrors.InnerError(err))
+	assert.True(t, IsBadRequestError(err))
+	assert.Equal(t, 3, NumResponded(err))
+	assert.Equal(t, 1, NumSuccess(err))
+	assert.Equal(t, 2, NumError(err))
+}

--- a/client/options.go
+++ b/client/options.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	// defaultConsistencyLevel is the default consistency level
-	defaultConsistencyLevel = topology.ConsistencyLevelMajority
+	// defaultWriteConsistencyLevel is the default write consistency level
+	defaultWriteConsistencyLevel = topology.ConsistencyLevelMajority
 
 	// defaultReadConsistencyLevel is the default read consistency level
 	defaultReadConsistencyLevel = ReadConsistencyLevelMajority
@@ -133,7 +133,7 @@ type options struct {
 	clockOpts                             clock.Options
 	instrumentOpts                        instrument.Options
 	topologyInitializer                   topology.Initializer
-	consistencyLevel                      topology.ConsistencyLevel
+	writeConsistencyLevel                 topology.ConsistencyLevel
 	readConsistencyLevel                  ReadConsistencyLevel
 	channelOptions                        *tchannel.ChannelOptions
 	maxConnectionCount                    int
@@ -181,7 +181,7 @@ func newOptions() *options {
 	opts := &options{
 		clockOpts:                             clock.NewOptions(),
 		instrumentOpts:                        instrument.NewOptions(),
-		consistencyLevel:                      defaultConsistencyLevel,
+		writeConsistencyLevel:                 defaultWriteConsistencyLevel,
 		readConsistencyLevel:                  defaultReadConsistencyLevel,
 		maxConnectionCount:                    defaultMaxConnectionCount,
 		minConnectionCount:                    defaultMinConnectionCount,
@@ -262,14 +262,14 @@ func (o *options) TopologyInitializer() topology.Initializer {
 	return o.topologyInitializer
 }
 
-func (o *options) SetConsistencyLevel(value topology.ConsistencyLevel) Options {
+func (o *options) SetWriteConsistencyLevel(value topology.ConsistencyLevel) Options {
 	opts := *o
-	opts.consistencyLevel = value
+	opts.writeConsistencyLevel = value
 	return &opts
 }
 
-func (o *options) ConsistencyLevel() topology.ConsistencyLevel {
-	return o.consistencyLevel
+func (o *options) WriteConsistencyLevel() topology.ConsistencyLevel {
+	return o.writeConsistencyLevel
 }
 
 func (o *options) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {

--- a/client/options.go
+++ b/client/options.go
@@ -42,6 +42,9 @@ const (
 	// defaultConsistencyLevel is the default consistency level
 	defaultConsistencyLevel = topology.ConsistencyLevelMajority
 
+	// defaultReadConsistencyLevel is the default read consistency level
+	defaultReadConsistencyLevel = ReadConsistencyLevelMajority
+
 	// defaultMaxConnectionCount is the default max connection count
 	defaultMaxConnectionCount = 32
 
@@ -131,6 +134,7 @@ type options struct {
 	instrumentOpts                        instrument.Options
 	topologyInitializer                   topology.Initializer
 	consistencyLevel                      topology.ConsistencyLevel
+	readConsistencyLevel                  ReadConsistencyLevel
 	channelOptions                        *tchannel.ChannelOptions
 	maxConnectionCount                    int
 	minConnectionCount                    int
@@ -178,6 +182,7 @@ func newOptions() *options {
 		clockOpts:                             clock.NewOptions(),
 		instrumentOpts:                        instrument.NewOptions(),
 		consistencyLevel:                      defaultConsistencyLevel,
+		readConsistencyLevel:                  defaultReadConsistencyLevel,
 		maxConnectionCount:                    defaultMaxConnectionCount,
 		minConnectionCount:                    defaultMinConnectionCount,
 		hostConnectTimeout:                    defaultHostConnectTimeout,
@@ -265,6 +270,16 @@ func (o *options) SetConsistencyLevel(value topology.ConsistencyLevel) Options {
 
 func (o *options) ConsistencyLevel() topology.ConsistencyLevel {
 	return o.consistencyLevel
+}
+
+func (o *options) SetReadConsistencyLevel(value ReadConsistencyLevel) Options {
+	opts := *o
+	opts.readConsistencyLevel = value
+	return &opts
+}
+
+func (o *options) ReadConsistencyLevel() ReadConsistencyLevel {
+	return o.readConsistencyLevel
 }
 
 func (o *options) SetChannelOptions(value *tchannel.ChannelOptions) Options {

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -178,7 +178,7 @@ func testWriteConsistencyLevel(
 	expected outcome,
 ) {
 	opts := newSessionTestOptions()
-	opts = opts.SetConsistencyLevel(level)
+	opts = opts.SetWriteConsistencyLevel(level)
 	s, err := newSession(opts)
 	assert.NoError(t, err)
 	session := s.(*session)

--- a/client/types.go
+++ b/client/types.go
@@ -73,7 +73,7 @@ func (l ConnectConsistencyLevel) String() string {
 	case ConnectConsistencyLevelAll:
 		return "ConnectConsistencyLevelAll"
 	}
-	return ""
+	return "ConnectConsistencyLevelUnknown"
 }
 
 // ReadConsistencyLevel is the consistency level for reading from a cluster
@@ -107,7 +107,7 @@ func (l ReadConsistencyLevel) String() string {
 	case ReadConsistencyLevelAll:
 		return "ReadConsistencyLevelAll"
 	}
-	return ""
+	return "ReadConsistencyLevelUnknown"
 }
 
 // Client can create sessions to write and read to a cluster
@@ -276,11 +276,11 @@ type Options interface {
 	// TopologyInitializer returns the TopologyInitializer
 	TopologyInitializer() topology.Initializer
 
-	// SetConsistencyLevel sets the consistency level
-	SetConsistencyLevel(value topology.ConsistencyLevel) Options
+	// SetWriteConsistencyLevel sets the write consistency level
+	SetWriteConsistencyLevel(value topology.ConsistencyLevel) Options
 
-	// ConsistencyLevel returns the consistency level
-	ConsistencyLevel() topology.ConsistencyLevel
+	// WriteConsistencyLevel returns the write consistency level
+	WriteConsistencyLevel() topology.ConsistencyLevel
 
 	// SetReadConsistencyLevel sets the read consistency level
 	SetReadConsistencyLevel(value ReadConsistencyLevel) Options

--- a/client/types.go
+++ b/client/types.go
@@ -59,6 +59,57 @@ const (
 	ConnectConsistencyLevelAll
 )
 
+// String returns the consistency level as a string
+func (l ConnectConsistencyLevel) String() string {
+	switch l {
+	case ConnectConsistencyLevelAny:
+		return "ConnectConsistencyLevelAny"
+	case ConnectConsistencyLevelNone:
+		return "ConnectConsistencyLevelNone"
+	case ConnectConsistencyLevelOne:
+		return "ConnectConsistencyLevelOne"
+	case ConnectConsistencyLevelMajority:
+		return "ConnectConsistencyLevelMajority"
+	case ConnectConsistencyLevelAll:
+		return "ConnectConsistencyLevelAll"
+	}
+	return ""
+}
+
+// ReadConsistencyLevel is the consistency level for reading from a cluster
+type ReadConsistencyLevel int
+
+const (
+	// ReadConsistencyLevelOne corresponds to reading from a single node
+	ReadConsistencyLevelOne ReadConsistencyLevel = iota
+
+	// ReadConsistencyLevelUnstrictMajority corresponds to reading from the majority of nodes
+	// but relaxing the constraint when it cannot be met, falling back to returning success when
+	// reading from at least a single node after attempting reading from the majority of nodes
+	ReadConsistencyLevelUnstrictMajority
+
+	// ReadConsistencyLevelMajority corresponds to reading from the majority of nodes
+	ReadConsistencyLevelMajority
+
+	// ReadConsistencyLevelAll corresponds to reading from all of the nodes
+	ReadConsistencyLevelAll
+)
+
+// String returns the consistency level as a string
+func (l ReadConsistencyLevel) String() string {
+	switch l {
+	case ReadConsistencyLevelOne:
+		return "ReadConsistencyLevelOne"
+	case ReadConsistencyLevelUnstrictMajority:
+		return "ReadConsistencyLevelUnstrictMajority"
+	case ReadConsistencyLevelMajority:
+		return "ReadConsistencyLevelMajority"
+	case ReadConsistencyLevelAll:
+		return "ReadConsistencyLevelAll"
+	}
+	return ""
+}
+
 // Client can create sessions to write and read to a cluster
 type Client interface {
 	// NewSession creates a new session
@@ -225,11 +276,17 @@ type Options interface {
 	// TopologyInitializer returns the TopologyInitializer
 	TopologyInitializer() topology.Initializer
 
-	// SetConsistencyLevel sets the consistencyLevel
+	// SetConsistencyLevel sets the consistency level
 	SetConsistencyLevel(value topology.ConsistencyLevel) Options
 
-	// ConsistencyLevel returns the consistencyLevel
+	// ConsistencyLevel returns the consistency level
 	ConsistencyLevel() topology.ConsistencyLevel
+
+	// SetReadConsistencyLevel sets the read consistency level
+	SetReadConsistencyLevel(value ReadConsistencyLevel) Options
+
+	// ReadConsistencyLevel returns the read consistency level
+	ReadConsistencyLevel() ReadConsistencyLevel
 
 	// SetChannelOptions sets the channelOptions
 	SetChannelOptions(value *tchannel.ChannelOptions) Options

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cbfce3b0de92acf41febe3b03182575cacd87489d76fd7d2258e2100f78be60a
-updated: 2016-09-20T17:50:32.917022273-04:00
+hash: b538a6470832b44af2caadd974c0e56472a47f38fdc8ec79fa2244363a1cdfde
+updated: 2016-10-23T18:44:48.176277065-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -7,6 +7,7 @@ imports:
   - lib/go/thrift
 - name: github.com/davecgh/go-spew
   version: 66f99a29a08158b999b0dc2e7ccacf1131d4e0b4
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -27,7 +28,7 @@ imports:
   - services
   - shard
 - name: github.com/m3db/m3x
-  version: 061fa69eb3dfc2a4fb1202f018039875654a2434
+  version: 87afcb5f1b6e2040d7b6843c51d15e02e67319bb
   subpackages:
   - close
   - errors
@@ -67,6 +68,7 @@ imports:
   version: 2e6e8094ef4745224150c88c16191c7dceaad16f
 - name: golang.org/x/net
   version: 9313baa13d9262e49d07b20ed57dceafcd7240cc
+  version: de35ec43e7a9aabd6a9c54d2898220ea7e44de7d
   subpackages:
   - context
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,7 +42,7 @@ import:
   - services
 
 - package: github.com/m3db/m3x
-  version: 061fa69eb3dfc2a4fb1202f018039875654a2434
+  version: 87afcb5f1b6e2040d7b6843c51d15e02e67319bb
   subpackages:
   - close
   - errors


### PR DESCRIPTION
cc @xichen2020 @martin-mao @cw9 @kobolog 

This introduces the concept of "unstrict majority" for reads such that applications can use to always attempt to achieve majority but in the case when all nodes have answered and less than the majority of nodes have responded successfully to go ahead nonetheless and return with a successful result.  

This means that if two nodes are healthy the application will always read from the majority of nodes to ensure data is merged from both healthy nodes to read what you put in at consistency level majority.  It does mean in an extreme failure case of two nodes being unhealthy that the application can continue to serve reads knowingly with no guarentees of serving partial reads.