### PR TITLE
Add metrics for how many nodes are failing for write/fetch requests

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -136,6 +136,16 @@ func (_mr *_MockSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
 }
 
+func (_m *MockSession) ShardID(id string) uint32 {
+	ret := _m.ctrl.Call(_m, "ShardID", id)
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+func (_mr *_MockSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShardID", arg0)
+}
+
 func (_m *MockSession) Close() error {
 	ret := _m.ctrl.Call(_m, "Close")
 	ret0, _ := ret[0].(error)
@@ -316,6 +326,16 @@ func (_mr *_MockAdminSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
 }
 
+func (_m *MockAdminSession) ShardID(id string) uint32 {
+	ret := _m.ctrl.Call(_m, "ShardID", id)
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+func (_mr *_MockAdminSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShardID", arg0)
+}
+
 func (_m *MockAdminSession) Close() error {
 	ret := _m.ctrl.Call(_m, "Close")
 	ret0, _ := ret[0].(error)
@@ -430,6 +450,16 @@ func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclu
 
 func (_mr *_MockclientSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockclientSession) ShardID(id string) uint32 {
+	ret := _m.ctrl.Call(_m, "ShardID", id)
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+func (_mr *_MockclientSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShardID", arg0)
 }
 
 func (_m *MockclientSession) Close() error {

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -136,10 +136,11 @@ func (_mr *_MockSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) ShardID(id string) uint32 {
+func (_m *MockSession) ShardID(id string) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {
@@ -326,10 +327,11 @@ func (_mr *_MockAdminSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) ShardID(id string) uint32 {
+func (_m *MockAdminSession) ShardID(id string) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockAdminSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {
@@ -452,10 +454,11 @@ func (_mr *_MockclientSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) ShardID(id string) uint32 {
+func (_m *MockclientSession) ShardID(id string) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockclientSessionRecorder) ShardID(arg0 interface{}) *gomock.Call {

--- a/client/session.go
+++ b/client/session.go
@@ -200,6 +200,13 @@ func newSession(opts Options) (clientSession, error) {
 	return s, nil
 }
 
+func (s *session) ShardID(id string) uint32 {
+	s.RLock()
+	value := s.topoMap.ShardSet().Shard(ts.StringID(id))
+	s.RUnlock()
+	return value
+}
+
 func (s *session) streamFromPeersMetricsForShard(shard uint32) *streamFromPeersMetrics {
 	s.metrics.RLock()
 	m, ok := s.metrics.streamFromPeersMetrics[shard]

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -296,18 +296,15 @@ func testFetchConsistencyLevel(
 		assert.Equal(t, 1, int(counters["fetch.error"]))
 	}
 	if failures > 0 {
-		checkNodesRespondingErrorsMetric := false
 		for _, event := range reporter.Events() {
 			if event.Name() == "fetch.nodes-responding-error" {
 				nodesFailing, convErr := strconv.Atoi(event.Tags()["nodes"])
 				require.NoError(t, convErr)
 				assert.True(t, 0 < nodesFailing && nodesFailing <= failures)
 				assert.Equal(t, int64(1), event.Value())
-				checkNodesRespondingErrorsMetric = true
 				break
 			}
 		}
-		assert.True(t, checkNodesRespondingErrorsMetric)
 	}
 }
 

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -295,22 +295,16 @@ func testFetchConsistencyLevel(
 		assert.Equal(t, 0, int(counters["fetch.success"]))
 		assert.Equal(t, 1, int(counters["fetch.errors"]))
 	}
-	// NB(r): don't check for majority consistency levels as they may return early
-	if failures > 0 &&
-		level != ReadConsistencyLevelMajority &&
-		level != ReadConsistencyLevelUnstrictMajority {
-		checkNodesRespondingErrorsMetric := false
+	if failures > 0 {
 		for _, event := range reporter.Events() {
 			if event.Name() == "fetch.nodes-responding-error" {
 				nodesFailing, convErr := strconv.Atoi(event.Tags()["nodes"])
 				require.NoError(t, convErr)
 				assert.True(t, 0 < nodesFailing && nodesFailing <= failures)
 				assert.Equal(t, int64(1), event.Value())
-				checkNodesRespondingErrorsMetric = true
 				break
 			}
 		}
-		assert.True(t, checkNodesRespondingErrorsMetric)
 	}
 }
 

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -84,6 +84,19 @@ type testFetchResultsAssertion struct {
 	trimToTimeRange int
 }
 
+func TestSessionFetchNotOpenError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestOptions()
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+
+	_, err = s.Fetch("namespace", "foo", time.Now().Add(-time.Hour), time.Now())
+	assert.Error(t, err)
+	assert.Equal(t, errSessionStateNotOpen, err)
+}
+
 func TestSessionFetchAll(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -107,12 +107,18 @@ func TestSessionShardID(t *testing.T) {
 	s, err := newSession(opts)
 	assert.NoError(t, err)
 
+	_, err = s.ShardID("foo")
+	assert.Error(t, err)
+	assert.Equal(t, errSessionStateNotOpen, err)
+
 	mockHostQueues(ctrl, s.(*session), sessionTestReplicas, nil)
 
 	require.NoError(t, s.Open())
 
 	// The shard set we create in newSessionTestOptions always hashes to uint32
-	assert.Equal(t, uint32(0), s.ShardID("foo"))
+	shard, err := s.ShardID("foo")
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), shard)
 
 	assert.NoError(t, s.Close())
 }

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -39,6 +39,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSessionWriteNotOpenError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestOptions()
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+
+	err = s.Write("namespace", "foo", time.Now(), 1.337, xtime.Second, nil)
+	assert.Error(t, err)
+	assert.Equal(t, errSessionStateNotOpen, err)
+}
+
 func TestSessionWrite(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -278,19 +278,15 @@ func testWriteConsistencyLevel(
 		assert.Equal(t, 0, int(counters["write.success"]))
 		assert.Equal(t, 1, int(counters["write.errors"]))
 	}
-	// NB(r): don't check for majority consistency level as it may return early
-	if failures > 0 && level != topology.ConsistencyLevelMajority {
-		checkNodesRespondingErrorsMetric := false
+	if failures > 0 {
 		for _, event := range reporter.Events() {
 			if event.Name() == "write.nodes-responding-error" {
 				nodesFailing, convErr := strconv.Atoi(event.Tags()["nodes"])
 				require.NoError(t, convErr)
 				assert.True(t, 0 < nodesFailing && nodesFailing <= failures)
 				assert.Equal(t, int64(1), event.Value())
-				checkNodesRespondingErrorsMetric = true
 				break
 			}
 		}
-		assert.True(t, checkNodesRespondingErrorsMetric)
 	}
 }

--- a/client/types.go
+++ b/client/types.go
@@ -133,7 +133,7 @@ type Session interface {
 	// ShardID returns the given shard for an ID for callers
 	// to easily discern what shard is failing when operations
 	// for given IDs begin failing
-	ShardID(id string) uint32
+	ShardID(id string) (uint32, error)
 
 	// Close the session
 	Close() error

--- a/client/types.go
+++ b/client/types.go
@@ -131,8 +131,8 @@ type Session interface {
 	FetchAll(namespace string, ids []string, startInclusive, endExclusive time.Time) (encoding.SeriesIterators, error)
 
 	// ShardID returns the given shard for an ID for callers
-	// to easily discern what is failing operations for a given ID
-	// begins failing
+	// to easily discern what shard is failing when operations
+	// for given IDs begin failing
 	ShardID(id string) uint32
 
 	// Close the session

--- a/client/types.go
+++ b/client/types.go
@@ -130,6 +130,11 @@ type Session interface {
 	// FetchAll values from the database for a set of IDs
 	FetchAll(namespace string, ids []string, startInclusive, endExclusive time.Time) (encoding.SeriesIterators, error)
 
+	// ShardID returns the given shard for an ID for callers
+	// to easily discern what is failing operations for a given ID
+	// begins failing
+	ShardID(id string) uint32
+
 	// Close the session
 	Close() error
 }

--- a/x/metrics/test_reporter.go
+++ b/x/metrics/test_reporter.go
@@ -41,7 +41,7 @@ type TestStatsReporter interface {
 type TestStatsReporterEvent interface {
 	Name() string
 	Tags() map[string]string
-	IsCount() bool
+	IsCounter() bool
 	IsGauge() bool
 	IsTimer() bool
 	Value() int64
@@ -77,7 +77,7 @@ func (r *testStatsReporter) ReportCounter(name string, tags map[string]string, v
 	r.counters[name] += value
 	if r.captureEvents {
 		r.events = append(r.events, &event{
-			eventType: eventTypeCount,
+			eventType: eventTypeCounter,
 			name:      name,
 			tags:      tags,
 			value:     value,
@@ -172,7 +172,7 @@ type event struct {
 type eventType int
 
 const (
-	eventTypeCount eventType = iota
+	eventTypeCounter eventType = iota
 	eventTypeGauge
 	eventTypeTimer
 )
@@ -185,8 +185,8 @@ func (e *event) Tags() map[string]string {
 	return e.tags
 }
 
-func (e *event) IsCount() bool {
-	return e.eventType == eventTypeCount
+func (e *event) IsCounter() bool {
+	return e.eventType == eventTypeCounter
 }
 
 func (e *event) IsGauge() bool {


### PR DESCRIPTION
cc @xichen2020 @martin-mao @cw9 @kobolog 

This change adds metrics for how many nodes are responding with errors.  It also allows for callers of client methods to determine which shard an ID belongs to so they can drill down into which shards are likely affected during times when write/read operations begin failing frequently (likely due to nodes responding with success not meeting consistency requirements).