### PR TITLE
GC-opaque heap & object pool.

### DIFF
--- a/client/host_queue.go
+++ b/client/host_queue.go
@@ -79,7 +79,9 @@ func newHostQueue(
 	opsArraysLen := opts.HostQueueOpsArrayPoolSize()
 	opArrayPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(opsArraysLen).
-		SetMetricsScope(scope.SubScope("op-array-pool"))
+		SetInstrumentOptions(opts.InstrumentOptions().SetMetricsScope(
+			scope.SubScope("op-array-pool"),
+		))
 	opArrayPoolCapacity := int(math.Max(float64(size), float64(opts.WriteBatchSize())))
 	opArrayPool := newOpArrayPool(opArrayPoolOpts, opArrayPoolCapacity)
 	opArrayPool.Init()

--- a/client/session.go
+++ b/client/session.go
@@ -317,17 +317,23 @@ func (s *session) Open() error {
 	// is already that Open will take some time
 	writeOpPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(s.opts.WriteOpPoolSize()).
-		SetMetricsScope(s.scope.SubScope("write-op-pool"))
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("write-op-pool"),
+		))
 	s.writeOpPool = newWriteOpPool(writeOpPoolOpts)
 	s.writeOpPool.Init()
 	fetchBatchOpPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(s.opts.FetchBatchOpPoolSize()).
-		SetMetricsScope(s.scope.SubScope("fetch-batch-op-pool"))
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("fetch-batch-op-pool"),
+		))
 	s.fetchBatchOpPool = newFetchBatchOpPool(fetchBatchOpPoolOpts, s.fetchBatchSize)
 	s.fetchBatchOpPool.Init()
 	seriesIteratorPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(s.opts.SeriesIteratorPoolSize()).
-		SetMetricsScope(s.scope.SubScope("series-iterator-pool"))
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("series-iterator-pool"),
+		))
 	s.seriesIteratorPool = encoding.NewSeriesIteratorPool(seriesIteratorPoolOpts)
 	s.seriesIteratorPool.Init()
 	s.seriesIteratorsPool = encoding.NewMutableSeriesIteratorsPool(s.opts.SeriesIteratorArrayPoolBuckets())
@@ -463,7 +469,9 @@ func (s *session) setTopologyWithLock(topologyMap topology.Map, queues []hostQue
 		s.fetchBatchOpArrayArrayPool.Entries() != len(queues) {
 		poolOpts := pool.NewObjectPoolOptions().
 			SetSize(s.opts.FetchBatchOpPoolSize()).
-			SetMetricsScope(s.scope.SubScope("fetch-batch-op-array-array-pool"))
+			SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+				s.scope.SubScope("fetch-batch-op-array-array-pool"),
+			))
 		s.fetchBatchOpArrayArrayPool = newFetchBatchOpArrayArrayPool(
 			poolOpts,
 			len(queues),
@@ -485,7 +493,9 @@ func (s *session) setTopologyWithLock(topologyMap topology.Map, queues []hostQue
 		size := replicas * s.opts.SeriesIteratorPoolSize()
 		poolOpts := pool.NewObjectPoolOptions().
 			SetSize(size).
-			SetMetricsScope(s.scope.SubScope("reader-slice-of-slices-iterator-pool"))
+			SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+				s.scope.SubScope("reader-slice-of-slices-iterator-pool"),
+			))
 		s.readerSliceOfSlicesIteratorPool = newReaderSliceOfSlicesIteratorPool(poolOpts)
 		s.readerSliceOfSlicesIteratorPool.Init()
 	}
@@ -494,7 +504,9 @@ func (s *session) setTopologyWithLock(topologyMap topology.Map, queues []hostQue
 		size := replicas * s.opts.SeriesIteratorPoolSize()
 		poolOpts := pool.NewObjectPoolOptions().
 			SetSize(size).
-			SetMetricsScope(s.scope.SubScope("multi-reader-iterator-pool"))
+			SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+				s.scope.SubScope("multi-reader-iterator-pool"),
+			))
 		s.multiReaderIteratorPool = encoding.NewMultiReaderIteratorPool(poolOpts)
 		s.multiReaderIteratorPool.Init(s.opts.ReaderIteratorAllocate())
 	}
@@ -542,12 +554,16 @@ func (s *session) newHostQueue(host topology.Host, topologyMap topology.Map) hos
 	hostBatches := int(math.Ceil(float64(totalBatches) / float64(topologyMap.HostsLen())))
 	writeBatchRequestPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(hostBatches).
-		SetMetricsScope(s.scope.SubScope("write-batch-request-pool"))
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("write-batch-request-pool"),
+		))
 	writeBatchRequestPool := newWriteBatchRawRequestPool(writeBatchRequestPoolOpts)
 	writeBatchRequestPool.Init()
 	writeBatchRawRequestElementArrayPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(hostBatches).
-		SetMetricsScope(s.scope.SubScope("id-datapoint-array-pool"))
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("id-datapoint-array-pool"),
+		))
 	writeBatchRawRequestElementArrayPool := newWriteBatchRawRequestElementArrayPool(
 		writeBatchRawRequestElementArrayPoolOpts, s.opts.WriteBatchSize())
 	writeBatchRawRequestElementArrayPool.Init()

--- a/encoding/m3tsz/encoder.go
+++ b/encoding/m3tsz/encoder.go
@@ -485,6 +485,9 @@ func (enc *encoder) Reset(start time.Time, capacity int) {
 	var newBuffer []byte
 	bytesPool := enc.opts.BytesPool()
 	if bytesPool != nil {
+		if b, _ := enc.os.Rawbytes(); b != nil {
+			bytesPool.Put(b)
+		}
 		newBuffer = bytesPool.Get(capacity)
 	} else {
 		newBuffer = make([]byte, 0, capacity)

--- a/encoding/m3tsz/encoder.go
+++ b/encoding/m3tsz/encoder.go
@@ -485,9 +485,6 @@ func (enc *encoder) Reset(start time.Time, capacity int) {
 	var newBuffer []byte
 	bytesPool := enc.opts.BytesPool()
 	if bytesPool != nil {
-		if b, _ := enc.os.Rawbytes(); b != nil {
-			bytesPool.Put(b)
-		}
 		newBuffer = bytesPool.Get(capacity)
 	} else {
 		newBuffer = make([]byte, 0, capacity)

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+	"unsafe"
+)
+
+// NewNativeHeap constructs a new BytesPool based on NativePool.
+func NewNativeHeap(sizes []Bucket) BytesPool {
+	var (
+		slots = make([]*slot, len(sizes))
+		T     = reflect.TypeOf((byte)(0))
+	)
+
+	sort.Sort(BucketByCapacity(sizes))
+
+	for i, cfg := range sizes {
+		ns := &slot{class: cfg.Capacity, cfg: NativePoolOptions{
+			Size: uint(cfg.Count),
+			Type: reflect.ArrayOf(cfg.Capacity, T)}}
+		slots[i] = ns
+	}
+
+	return heap(slots)
+}
+
+type heap []*slot
+
+type slot struct {
+	sync.RWMutex
+
+	class int
+	cfg   NativePoolOptions
+	pools []NativePool
+}
+
+func (s *slot) get() interface{} {
+	if segment := s.getOr(s.RLocker(), func() interface{} {
+		return nil
+	}); segment != nil {
+		return segment
+	}
+
+	// Slow path - double-check that there are no segments left,
+	// then grow while holding an exclusive lock.
+	return s.getOr(s, func() interface{} {
+		s.pools = append(
+			[]NativePool{NewNativePool(s.cfg)}, s.pools...)
+		return s.pools[0].Get()
+	})
+}
+
+func (s *slot) getOr(l sync.Locker, fn OverflowFn) interface{} {
+	var segment interface{}
+
+	l.Lock()
+
+	for _, pool := range s.pools {
+		if segment = pool.GetOr(func() interface{} {
+			return nil
+		}); segment != nil {
+			l.Unlock()
+			return segment
+		}
+	}
+
+	segment = fn()
+
+	l.Unlock()
+
+	return segment
+}
+
+func (s *slot) put(segment interface{}) {
+	s.RLock()
+
+	for i := range s.pools {
+		if s.pools[i].Owns(segment) {
+			s.pools[i].Put(segment)
+			break
+		}
+	}
+
+	s.RUnlock()
+}
+
+func (p heap) Init() {
+	for _, slot := range p {
+		slot.pools = append(slot.pools, NewNativePool(slot.cfg))
+	}
+}
+
+func (p heap) pick(class int, action func(*slot)) bool {
+	for _, slot := range p {
+		if class <= slot.class {
+			action(slot)
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p heap) Get(n int) []byte {
+	var head []byte
+
+	if !p.pick(n, func(slot *slot) {
+		head = *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+			Data: reflect.ValueOf(slot.get()).Pointer(),
+			Len:  0,
+			Cap:  slot.class}))
+	}) {
+		// Allocate a segment directly from the system heap.
+		head = mmap(n)[0:0:n]
+	}
+
+	return head
+}
+
+func (p heap) Put(head []byte) {
+	if !p.pick(cap(head), func(slot *slot) {
+		slot.put(unsafe.Pointer(
+			(*reflect.SliceHeader)(unsafe.Pointer(&head)).Data))
+	}) {
+		// Nothing fits so it must be a system heap segment.
+		munmap(head[:cap(head)])
+	}
+}

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -59,8 +59,8 @@ func NewNativeHeap(b []Bucket, po ObjectPoolOptions) BytesPool {
 			Size: uint(cfg.Count),
 			Type: reflect.ArrayOf(cfg.Capacity, ByteType),
 		}, m: slotMetrics{
-			used: m.Gauge("used"),
-			size: m.Gauge("size"),
+			free: m.Gauge("free"),
+			size: m.Gauge("total"),
 		}}
 
 		h.slots = append(h.slots, s)
@@ -92,7 +92,7 @@ type slot struct {
 }
 
 type slotMetrics struct {
-	used tally.Gauge
+	free tally.Gauge
 	size tally.Gauge
 }
 
@@ -158,20 +158,20 @@ func (s *slot) updateMetrics() {
 		return
 	}
 
-	var used, size int64
+	var free, size int64
 
 	s.RLock()
 
 	for i := range s.pools {
 		a, b := s.pools[i].Size()
 
-		used += int64(a)
+		free += int64(a)
 		size += int64(b)
 	}
 
 	s.RUnlock()
 
-	s.m.used.Update(used)
+	s.m.free.Update(free)
 	s.m.size.Update(size)
 }
 

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -51,7 +51,7 @@ func NewNativeHeap(b []Bucket, po ObjectPoolOptions) BytesPool {
 
 	for _, cfg := range b {
 		m := m.Tagged(map[string]string{
-			"class": strconv.Itoa(cfg.Capacity),
+			"bucket-capacity": strconv.Itoa(cfg.Capacity),
 		})
 
 		s := &slot{class: cfg.Capacity, opts: NativePoolOptions{

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -106,9 +106,9 @@ func (s *slot) get() interface{} {
 	// Slow path - double-check that there are no segments left,
 	// then grow while holding an exclusive lock.
 	return s.getOr(s, func() interface{} {
-		s.pools = append(
-			[]NativePool{NewNativePool(s.opts)}, s.pools...)
-		return s.pools[0].Get()
+		p := NewNativePool(s.opts)
+		s.pools = append([]NativePool{p}, s.pools...)
+		return p.Get()
 	})
 }
 

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -21,9 +21,9 @@
 package pool
 
 import (
-	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 	"unsafe"
@@ -50,7 +50,9 @@ func NewNativeHeap(b []Bucket, po ObjectPoolOptions) BytesPool {
 	}}
 
 	for _, cfg := range b {
-		m := m.SubScope(fmt.Sprintf("slot-%d", cfg.Capacity))
+		m := m.Tagged(map[string]string{
+			"class": strconv.Itoa(cfg.Capacity),
+		})
 
 		v := &slot{class: cfg.Capacity, opts: NativePoolOptions{
 			Size: uint(cfg.Count),

--- a/pool/heap_test.go
+++ b/pool/heap_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeHeapBasics(t *testing.T) {
+	heap := NewNativeHeap([]Bucket{
+		Bucket{Capacity: 128, Count: 4},
+		Bucket{Capacity: 256, Count: 4},
+	})
+
+	heap.Init()
+
+	b := heap.Get(192)[:192]
+	b[128] = 'x'
+
+	runtime.GC()
+
+	require.Equal(t, byte('x'), b[128])
+
+	heap.Put(b)
+}
+
+func TestNativeHeapDirect(t *testing.T) {
+	heap := NewNativeHeap([]Bucket{
+		Bucket{Capacity: 128, Count: 4},
+		Bucket{Capacity: 256, Count: 4},
+	})
+
+	heap.Init()
+
+	require.NotPanics(t, func() {
+		heap.Put(heap.Get(4096))
+	})
+}
+
+func TestNativeHeapOverflow(t *testing.T) {
+	heap := NewNativeHeap([]Bucket{
+		Bucket{Capacity: 128, Count: 2},
+		Bucket{Capacity: 256, Count: 2},
+	})
+
+	heap.Init()
+
+	for i := 0; i < 5; i++ {
+		require.NotNil(t, heap.Get(42))
+	}
+}
+
+func BenchmarkNativeHeap(b *testing.B) {
+	heap := NewNativeHeap([]Bucket{
+		Bucket{Capacity: 128, Count: 4},
+		Bucket{Capacity: 256, Count: 4},
+	})
+
+	heap.Init()
+
+	for n := 0; n <= b.N; n++ {
+		heap.Put(heap.Get(256))
+	}
+}
+
+func BenchmarkBytesHeap(b *testing.B) {
+	heap := NewBytesPool([]Bucket{
+		Bucket{Capacity: 128, Count: 4},
+		Bucket{Capacity: 256, Count: 4},
+	}, nil)
+
+	heap.Init()
+
+	for n := 0; n <= b.N; n++ {
+		heap.Put(heap.Get(256))
+	}
+}

--- a/pool/heap_test.go
+++ b/pool/heap_test.go
@@ -31,7 +31,7 @@ func TestNativeHeapBasics(t *testing.T) {
 	heap := NewNativeHeap([]Bucket{
 		Bucket{Capacity: 128, Count: 4},
 		Bucket{Capacity: 256, Count: 4},
-	})
+	}, nil)
 
 	heap.Init()
 
@@ -49,7 +49,7 @@ func TestNativeHeapDirect(t *testing.T) {
 	heap := NewNativeHeap([]Bucket{
 		Bucket{Capacity: 128, Count: 4},
 		Bucket{Capacity: 256, Count: 4},
-	})
+	}, nil)
 
 	heap.Init()
 
@@ -62,7 +62,7 @@ func TestNativeHeapOverflow(t *testing.T) {
 	heap := NewNativeHeap([]Bucket{
 		Bucket{Capacity: 128, Count: 2},
 		Bucket{Capacity: 256, Count: 2},
-	})
+	}, nil)
 
 	heap.Init()
 
@@ -75,7 +75,7 @@ func BenchmarkNativeHeap(b *testing.B) {
 	heap := NewNativeHeap([]Bucket{
 		Bucket{Capacity: 128, Count: 4},
 		Bucket{Capacity: 256, Count: 4},
-	})
+	}, nil)
 
 	heap.Init()
 

--- a/pool/mmap.go
+++ b/pool/mmap.go
@@ -30,8 +30,11 @@ const (
 	mmapMemory          = syscall.MAP_ANON | syscall.MAP_PRIVATE
 )
 
-func munmap(head []byte) {
+func munmap(head []byte) error {
 	if err := syscall.Munmap(head); err != nil {
 		fmt.Printf("munmap(%p, %d) error: %v\n", &head[0], cap(head), err)
+		return err
 	}
+
+	return nil
 }

--- a/pool/mmap.go
+++ b/pool/mmap.go
@@ -26,12 +26,12 @@ import (
 )
 
 const (
-	mmapRegionProtections = syscall.PROT_READ | syscall.PROT_WRITE
-	mmapFlags             = syscall.MAP_ANON | syscall.MAP_PRIVATE
+	mmapReadWriteAccess = syscall.PROT_READ | syscall.PROT_WRITE
+	mmapMemory          = syscall.MAP_ANON | syscall.MAP_PRIVATE
 )
 
 func munmap(head []byte) {
 	if err := syscall.Munmap(head); err != nil {
-		panic(fmt.Errorf("off-heap arena release error: %v", err))
+		fmt.Printf("munmap(%p, %d) error: %v\n", &head[0], cap(head), err)
 	}
 }

--- a/pool/mmap.go
+++ b/pool/mmap.go
@@ -32,7 +32,7 @@ const (
 
 func mmap(n int) []byte {
 	if r, err := syscall.Mmap(
-		0, 0, n, mmapRegionProtections, mmapFlags,
+		-1, 0, n, mmapRegionProtections, mmapFlags,
 	); err != nil {
 		panic(fmt.Errorf("off-heap arena acquire error: %v", err))
 	} else {

--- a/pool/mmap.go
+++ b/pool/mmap.go
@@ -20,10 +20,7 @@
 
 package pool
 
-import (
-	"fmt"
-	"syscall"
-)
+import "syscall"
 
 const (
 	mmapReadWriteAccess = syscall.PROT_READ | syscall.PROT_WRITE
@@ -31,10 +28,5 @@ const (
 )
 
 func munmap(head []byte) error {
-	if err := syscall.Munmap(head); err != nil {
-		fmt.Printf("munmap(%p, %d) error: %v\n", &head[0], cap(head), err)
-		return err
-	}
-
-	return nil
+	return syscall.Munmap(head)
 }

--- a/pool/mmap_darwin.go
+++ b/pool/mmap_darwin.go
@@ -28,9 +28,9 @@ import (
 )
 
 func mmap(n int) []byte {
-	r, err := syscall.Mmap(-1, 0, n, mmapRegionProtections, mmapFlags)
+	r, err := syscall.Mmap(-1, 0, n, mmapReadWriteAccess, mmapMemory)
 	if err != nil {
-		panic(fmt.Errorf("error while mapping arena: %v", err))
+		panic(fmt.Errorf("mmap(%d) error: %v", n, err))
 	}
 
 	return r

--- a/pool/mmap_darwin.go
+++ b/pool/mmap_darwin.go
@@ -22,16 +22,8 @@
 
 package pool
 
-import (
-	"fmt"
-	"syscall"
-)
+import "syscall"
 
-func mmap(n int) []byte {
-	r, err := syscall.Mmap(-1, 0, n, mmapReadWriteAccess, mmapMemory)
-	if err != nil {
-		panic(fmt.Errorf("mmap(%d) error: %v", n, err))
-	}
-
-	return r
+func mmap(n int) ([]byte, error) {
+	return syscall.Mmap(-1, 0, n, mmapReadWriteAccess, mmapMemory)
 }

--- a/pool/mmap_darwin.go
+++ b/pool/mmap_darwin.go
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// +build darwin
+
 package pool
 
 import (
@@ -25,13 +27,11 @@ import (
 	"syscall"
 )
 
-const (
-	mmapRegionProtections = syscall.PROT_READ | syscall.PROT_WRITE
-	mmapFlags             = syscall.MAP_ANON | syscall.MAP_PRIVATE
-)
-
-func munmap(head []byte) {
-	if err := syscall.Munmap(head); err != nil {
-		panic(fmt.Errorf("off-heap arena release error: %v", err))
+func mmap(n int) []byte {
+	r, err := syscall.Mmap(-1, 0, n, mmapRegionProtections, mmapFlags)
+	if err != nil {
+		panic(fmt.Errorf("error while mapping arena: %v", err))
 	}
+
+	return r
 }

--- a/pool/mmap_linux.go
+++ b/pool/mmap_linux.go
@@ -32,9 +32,9 @@ const (
 )
 
 func mmap(n int) []byte {
-	r, err := syscall.Mmap(-1, 0, n, mmapRegionProtections, mmapFlags)
+	r, err := syscall.Mmap(-1, 0, n, mmapReadWriteAccess, mmapMemory)
 	if err != nil {
-		panic(fmt.Errorf("error while mapping arena: %v", err))
+		panic(fmt.Errorf("mmap(%d) error: %v", n, err))
 	}
 
 	if n < mmapHugePageSize {
@@ -42,7 +42,7 @@ func mmap(n int) []byte {
 	}
 
 	if err := syscall.Madvise(r, syscall.MADV_HUGEPAGE); err != nil {
-		fmt.Printf("error while marking hugepages for arena: %v", err)
+		fmt.Printf("madvise(%p, HUGEPAGE) error: %v\n", &r[0], err)
 	}
 
 	return r

--- a/pool/mmap_linux.go
+++ b/pool/mmap_linux.go
@@ -27,10 +27,18 @@ import (
 	"syscall"
 )
 
+const (
+	mmapHugePageSize = 2 << 20
+)
+
 func mmap(n int) []byte {
 	r, err := syscall.Mmap(-1, 0, n, mmapRegionProtections, mmapFlags)
 	if err != nil {
 		panic(fmt.Errorf("error while mapping arena: %v", err))
+	}
+
+	if n < mmapHugePageSize {
+		return r
 	}
 
 	if err := syscall.Madvise(r, syscall.MADV_HUGEPAGE); err != nil {

--- a/pool/mmap_linux.go
+++ b/pool/mmap_linux.go
@@ -31,7 +31,7 @@ const (
 	mmapHugePageSize = 2 << 20
 )
 
-func mmap(n int) []byte {
+func mmap(n int) ([]byte, error) {
 	r, err := syscall.Mmap(-1, 0, n, mmapReadWriteAccess, mmapMemory)
 	if err != nil {
 		return nil, err

--- a/pool/mmap_linux.go
+++ b/pool/mmap_linux.go
@@ -22,10 +22,7 @@
 
 package pool
 
-import (
-	"fmt"
-	"syscall"
-)
+import "syscall"
 
 const (
 	mmapHugePageSize = 2 << 20
@@ -39,8 +36,10 @@ func mmap(n int) ([]byte, error) {
 
 	if n < mmapHugePageSize {
 		return r, nil
-	} else if err := syscall.Madvise(r, syscall.MADV_HUGEPAGE); err != nil {
-		fmt.Printf("unable to turn THP on for %p: %v\n", &r[0], err)
+	}
+
+	if err := syscall.Madvise(r, syscall.MADV_HUGEPAGE); err != nil {
+		panic("madvise() error: " + err.Error())
 	}
 
 	return r, nil

--- a/pool/native.go
+++ b/pool/native.go
@@ -75,6 +75,11 @@ func NewNativePool(opts NativePoolOptions) NativePool {
 	return p
 }
 
+type hdr struct {
+	// Offset from the beginning of the arena to the object.
+	idx uint64
+}
+
 // Header size with padding, as determined by the compiler.
 const hsz = unsafe.Sizeof(*(*hdr)(nil))
 
@@ -83,11 +88,6 @@ type nativePool struct {
 	free       chan uint64
 	opts       NativePoolOptions
 	step, size uint64
-}
-
-type hdr struct {
-	// Offset from the beginning of the arena to the object.
-	idx uint64
 }
 
 func (p *nativePool) init() {

--- a/pool/native.go
+++ b/pool/native.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// NativePoolOptions specify options for NativePool.
+type NativePoolOptions struct {
+	Construct func(ptr interface{})
+	Size      uint
+	Type      reflect.Type
+}
+
+// NativePool represents an object pool which is opaque to the Go GC.
+type NativePool interface {
+	Get() interface{}
+	GetOr(OverflowFn) interface{}
+	Put(interface{})
+
+	// Determines if the object belongs to the pool.
+	Owns(interface{}) bool
+}
+
+// OverflowFn produces non-pooled objects.
+type OverflowFn func() interface{}
+
+// NewNativePool constructs a new NativePool.
+func NewNativePool(opts NativePoolOptions) NativePool {
+	if opts.Size == 0 {
+		panic("native-pool: pool size is zero")
+	}
+
+	p := &nativePool{
+		free: make(chan uintptr, opts.Size),
+		opts: opts,
+		// TODO(@kobolog): alignment & padding.
+		step: hsz + opts.Type.Size()}
+
+	p.size = uintptr(p.opts.Size * uint(p.step))
+
+	if p.opts.Construct == nil {
+		p.opts.Construct = func(interface{}) {}
+	}
+
+	p.init()
+
+	return p
+}
+
+type nativePool struct {
+	pool       []uint8
+	free       chan uintptr
+	opts       NativePoolOptions
+	step, size uintptr
+}
+
+func (p *nativePool) String() string {
+	return fmt.Sprintf(
+		"NativePool[%d/%d: %s, %p-%p, %d]", len(p.free), cap(p.free),
+		p.opts.Type, &p.pool[0], &p.pool[p.size-1], p.size)
+}
+
+type hdr struct {
+	// Offset from the beginning of the arena to the object.
+	idx uintptr
+}
+
+const (
+	hsz = unsafe.Sizeof(*(*hdr)(nil))
+)
+
+func (p *nativePool) init() {
+	// Heap is a slice of uint8 large enough to fit opts.Size objects
+	// of type struct { hdr; T }.
+	p.pool = mmap(int(p.size))
+
+	for i := uintptr(0); i < p.size; i += p.step {
+		hdr := (*hdr)(unsafe.Pointer(&p.pool[i]))
+		hdr.idx = i + hsz
+		ptr := unsafe.Pointer(&p.pool[hdr.idx])
+
+		p.opts.Construct(reflect.NewAt(p.opts.Type, ptr).Interface())
+
+		// Alternatively, we can use a channel of interfaces, but it
+		// would keep opts.Size objects rooted in the channel.
+		// We aim to avoid allocating unnecessary GC-visible objects.
+		p.free <- hdr.idx
+	}
+}
+
+// Get provides an object from the pool.
+func (p *nativePool) Get() interface{} {
+	return reflect.NewAt(
+		p.opts.Type, unsafe.Pointer(&p.pool[<-p.free])).Interface()
+}
+
+func (p *nativePool) GetOr(fn OverflowFn) interface{} {
+	select {
+	case next := <-p.free:
+		return reflect.NewAt(
+			p.opts.Type, unsafe.Pointer(&p.pool[next])).Interface()
+	default:
+		return fn()
+	}
+}
+
+// Put returns an object to the pool.
+func (p *nativePool) Put(object interface{}) {
+	ptr := unsafe.Pointer(reflect.ValueOf(object).Pointer())
+
+	if (uintptr(ptr) < uintptr(unsafe.Pointer(&p.pool[0]))) ||
+		uintptr(ptr) > uintptr(unsafe.Pointer(&p.pool[p.size-1])) {
+		return
+	}
+
+	// We know that this object is in our arena, so it's okay
+	// to read memory directly in front of it.
+	p.free <- (*hdr)(unsafe.Pointer(uintptr(ptr) - hsz)).idx
+}
+
+func (p *nativePool) Owns(object interface{}) bool {
+	ptr := unsafe.Pointer(reflect.ValueOf(object).Pointer())
+
+	if (uintptr(ptr) < uintptr(unsafe.Pointer(&p.pool[0]))) ||
+		uintptr(ptr) > uintptr(unsafe.Pointer(&p.pool[p.size-1])) {
+		return false
+	}
+
+	return true
+}

--- a/pool/native.go
+++ b/pool/native.go
@@ -41,7 +41,7 @@ type NativePool interface {
 	// Owns determines if the object belongs to the pool.
 	Owns(interface{}) bool
 
-	// Size returns the used and the total capacity of the pool.
+	// Size returns the available and the total capacity of the pool.
 	Size() (uint64, uint64)
 }
 
@@ -116,10 +116,7 @@ func (p *nativePool) init() {
 }
 
 func (p *nativePool) Size() (uint64, uint64) {
-	free := uint64(cap(p.free)) * p.step
-	used := p.size - uint64(len(p.free))*p.step
-
-	return used, free
+	return uint64(len(p.free)) * p.step, p.size
 }
 
 // Get provides an object from the pool.

--- a/pool/native.go
+++ b/pool/native.go
@@ -95,7 +95,11 @@ type nativePool struct {
 func (p *nativePool) init() {
 	// Heap is a slice of bytes large enough to fit opts.Size objects
 	// of type struct { hdr; T }.
-	p.pool = mmap(int(p.size))
+	if r, err := mmap(int(p.size)); err != nil {
+		panic("mmap() error: " + err.Error())
+	} else {
+		p.pool = r
+	}
 
 	for i := uint64(0); i < p.size; i += p.step {
 		hdr := (*hdr)(unsafe.Pointer(&p.pool[i]))

--- a/pool/native.go
+++ b/pool/native.go
@@ -76,7 +76,9 @@ func NewNativePool(opts NativePoolOptions) NativePool {
 }
 
 type hdr struct {
-	// Offset from the beginning of the arena to the object.
+	// Offset from the beginning of the arena to the object, we chose
+	// to use uint64 to address > 4GB and for the hdr structure to be
+	// aligned at the largest possible value.
 	idx uint64
 }
 

--- a/pool/native.go
+++ b/pool/native.go
@@ -21,7 +21,6 @@
 package pool
 
 import (
-	"fmt"
 	"reflect"
 	"unsafe"
 )
@@ -39,8 +38,11 @@ type NativePool interface {
 	GetOr(OverflowFn) interface{}
 	Put(interface{})
 
-	// Determines if the object belongs to the pool.
+	// Owns determines if the object belongs to the pool.
 	Owns(interface{}) bool
+
+	// Size returns the used and the total capacity of the pool.
+	Size() (uint, uint)
 }
 
 // OverflowFn produces non-pooled objects.
@@ -80,10 +82,8 @@ type nativePool struct {
 	step, size uint
 }
 
-func (p *nativePool) String() string {
-	return fmt.Sprintf(
-		"NativePool[%d/%d: %s, %p-%p, %d]", len(p.free), cap(p.free),
-		p.opts.Type, &p.pool[0], &p.pool[p.size-1], p.size)
+func (p *nativePool) Size() (uint, uint) {
+	return p.size - uint(len(p.free))*p.step, uint(cap(p.free)) * p.step
 }
 
 type hdr struct {

--- a/pool/native_test.go
+++ b/pool/native_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+
+	"sync"
+
+	"github.com/stretchr/testify/require"
+)
+
+type I interface {
+	Set(int)
+	Get() int
+}
+
+type T struct {
+	x I
+	y [4096]uint8
+	z int
+}
+
+func TestNativePoolBasics(t *testing.T) {
+	ts := NewNativePool(NativePoolOptions{
+		Size: 1,
+		Type: reflect.TypeOf(T{})})
+
+	var (
+		v  = ts.Get().(*T)
+		wg sync.WaitGroup
+	)
+
+	wg.Add(1)
+
+	go func() {
+		require.True(t, ts.Owns(ts.Get()))
+		wg.Done()
+	}()
+
+	ts.Put(v)
+	wg.Wait()
+}
+
+func TestNativePoolOverflow(t *testing.T) {
+	ts := NewNativePool(NativePoolOptions{
+		Size: 1,
+		Type: reflect.TypeOf(T{})})
+
+	fn := func() interface{} {
+		return &T{}
+	}
+
+	require.True(t, ts.Owns(ts.GetOr(fn)))
+	require.False(t, ts.Owns(ts.GetOr(fn)))
+}
+
+type U struct {
+	v int
+}
+
+func (u *U) Set(v int) {
+	u.v = v
+}
+
+func (u *U) Get() int {
+	return u.v
+}
+
+func TestNativePoolNesting(t *testing.T) {
+	us := NewNativePool(NativePoolOptions{
+		Size: 50000,
+		Type: reflect.TypeOf(U{})})
+
+	ts := NewNativePool(NativePoolOptions{
+		Construct: func(ptr interface{}) {
+			ptr.(*T).x = us.Get().(I)
+		},
+		Size: 50000,
+		Type: reflect.TypeOf(T{})})
+
+	vs := make([]*T, 100000)
+
+	for i := range vs {
+		vs[i] = ts.GetOr(func() interface{} {
+			return &T{x: &U{}} // Direct allocation.
+		}).(*T)
+
+		vs[i].x.Set(i)
+	}
+
+	runtime.GC()
+
+	for i := range vs {
+		require.Equal(t, i, vs[i].x.Get())
+	}
+}
+
+func TestNativePoolErrors(t *testing.T) {
+	require.Panics(t, func() {
+		NewNativePool(NativePoolOptions{Size: 0})
+	})
+}
+
+func BenchmarkNativePool(b *testing.B) {
+	ts := NewNativePool(NativePoolOptions{
+		Size: 5,
+		Type: reflect.TypeOf(T{})})
+
+	for n := 0; n <= b.N; n++ {
+		ts.Put(ts.Get())
+	}
+}

--- a/pool/native_test.go
+++ b/pool/native_test.go
@@ -23,9 +23,8 @@ package pool
 import (
 	"reflect"
 	"runtime"
-	"testing"
-
 	"sync"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pool/native_test.go
+++ b/pool/native_test.go
@@ -37,7 +37,7 @@ type I interface {
 
 type T struct {
 	x I
-	y [4096]uint8
+	y [4096]byte
 	z int
 }
 

--- a/pool/object.go
+++ b/pool/object.go
@@ -57,6 +57,8 @@ func NewObjectPool(opts ObjectPoolOptions) ObjectPool {
 		opts = NewObjectPoolOptions()
 	}
 
+	m := opts.InstrumentOptions().MetricsScope()
+
 	p := &objectPool{
 		opts:   opts,
 		values: make(chan interface{}, opts.Size()),
@@ -66,10 +68,10 @@ func NewObjectPool(opts ObjectPoolOptions) ObjectPool {
 		refillHighWatermark: int(math.Ceil(
 			float64(opts.RefillHighWatermark()) * float64(opts.Size()))),
 		metrics: objectPoolMetrics{
-			free:       opts.MetricsScope().Gauge("free"),
-			total:      opts.MetricsScope().Gauge("total"),
-			getOnEmpty: opts.MetricsScope().Counter("get-on-empty"),
-			putOnFull:  opts.MetricsScope().Counter("put-on-full"),
+			free:       m.Gauge("free"),
+			total:      m.Gauge("total"),
+			getOnEmpty: m.Counter("get-on-empty"),
+			putOnFull:  m.Counter("put-on-full"),
 		},
 	}
 

--- a/pool/options.go
+++ b/pool/options.go
@@ -20,7 +20,7 @@
 
 package pool
 
-import "github.com/uber-go/tally"
+import "github.com/m3db/m3db/instrument"
 
 const (
 	defaultSize               = 4096
@@ -31,7 +31,7 @@ type objectPoolOptions struct {
 	size                int
 	refillLowWatermark  float64
 	refillHighWatermark float64
-	scope               tally.Scope
+	instrumentOpts      instrument.Options
 }
 
 // NewObjectPoolOptions creates a new set of object pool options
@@ -39,7 +39,7 @@ func NewObjectPoolOptions() ObjectPoolOptions {
 	return &objectPoolOptions{
 		size:               defaultSize,
 		refillLowWatermark: defaultRefillLowWatermark,
-		scope:              tally.NoopScope,
+		instrumentOpts:     instrument.NewOptions(),
 	}
 }
 
@@ -73,12 +73,12 @@ func (o *objectPoolOptions) RefillHighWatermark() float64 {
 	return o.refillHighWatermark
 }
 
-func (o *objectPoolOptions) SetMetricsScope(value tally.Scope) ObjectPoolOptions {
+func (o *objectPoolOptions) SetInstrumentOptions(value instrument.Options) ObjectPoolOptions {
 	opts := *o
-	opts.scope = value
+	opts.instrumentOpts = value
 	return &opts
 }
 
-func (o *objectPoolOptions) MetricsScope() tally.Scope {
-	return o.scope
+func (o *objectPoolOptions) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
 }

--- a/pool/types.go
+++ b/pool/types.go
@@ -20,7 +20,7 @@
 
 package pool
 
-import "github.com/uber-go/tally"
+import "github.com/m3db/m3db/instrument"
 
 // Allocator allocates an object for a pool.
 type Allocator func() interface{}
@@ -64,11 +64,11 @@ type ObjectPoolOptions interface {
 	// if less or equal to low watermark then no refills occur
 	RefillHighWatermark() float64
 
-	// SetMetricsScope sets the metrics scope
-	SetMetricsScope(value tally.Scope) ObjectPoolOptions
+	// SetInstrumentOptions sets the instrument options
+	SetInstrumentOptions(value instrument.Options) ObjectPoolOptions
 
-	// MetricsScope returns the metrics scope
-	MetricsScope() tally.Scope
+	// InstrumentOptions returns the instrument options
+	InstrumentOptions() instrument.Options
 }
 
 // Bucket specifies a pool bucket

--- a/storage/options.go
+++ b/storage/options.go
@@ -220,7 +220,7 @@ func (o *options) SetEncodingM3TSZPooled() Options {
 		Capacity: defaultBytesPoolBucketCapacity,
 		Count:    defaultBytesPoolBucketCount,
 	}}
-	bytesPool := pool.NewNativeHeap(buckets)
+	bytesPool := pool.NewNativeHeap(buckets, nil)
 	bytesPool.Init()
 	opts.bytesPool = bytesPool
 

--- a/storage/options.go
+++ b/storage/options.go
@@ -129,7 +129,7 @@ func NewOptions() Options {
 		segmentReaderPool:              xio.NewSegmentReaderPool(nil),
 		readerIteratorPool:             encoding.NewReaderIteratorPool(nil),
 		multiReaderIteratorPool:        encoding.NewMultiReaderIteratorPool(nil),
-		identifierPool:                 ts.NewIdentifierPool(nil),
+		identifierPool:                 ts.NewIdentifierPool(nil, nil),
 		fetchBlockMetadataResultsPool:  block.NewFetchBlockMetadataResultsPool(nil, 0),
 		fetchBlocksMetadataResultsPool: block.NewFetchBlocksMetadataResultsPool(nil, 0),
 	}
@@ -220,7 +220,7 @@ func (o *options) SetEncodingM3TSZPooled() Options {
 		Capacity: defaultBytesPoolBucketCapacity,
 		Count:    defaultBytesPoolBucketCount,
 	}}
-	bytesPool := pool.NewBytesPool(buckets, nil)
+	bytesPool := pool.NewNativeHeap(buckets)
 	bytesPool.Init()
 	opts.bytesPool = bytesPool
 

--- a/ts/identifier_pool.go
+++ b/ts/identifier_pool.go
@@ -21,26 +21,50 @@
 package ts
 
 import (
+	"reflect"
+
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/pool"
 )
 
 type identifierPool struct {
-	pool pool.ObjectPool
+	pool pool.NativePool
+	heap pool.BytesPool
 }
 
 // NewIdentifierPool constructs a new IdentifierPool
-func NewIdentifierPool(options pool.ObjectPoolOptions) IdentifierPool {
-	p := pool.NewObjectPool(options)
-	p.Init(func() interface{} { return &id{pool: p} })
+func NewIdentifierPool(
+	heap pool.BytesPool, options pool.ObjectPoolOptions) IdentifierPool {
 
-	return &identifierPool{pool: p}
+	if options == nil {
+		options = pool.NewObjectPoolOptions()
+	}
+
+	return &identifierPool{
+		pool: pool.NewNativePool(pool.NativePoolOptions{
+			Type: reflect.TypeOf(id{}),
+			Size: uint(options.Size()),
+		}), heap: configureHeap(heap)}
+}
+
+func configureHeap(heap pool.BytesPool) pool.BytesPool {
+	if heap != nil {
+		return heap
+	}
+
+	return pool.NewNativeHeap([]pool.Bucket{
+		{Capacity: 128, Count: 4096},
+		{Capacity: 256, Count: 2048}})
+}
+
+func create() interface{} {
+	return &id{}
 }
 
 // GetBinaryID returns a new ID based on a binary value
 func (p *identifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
-	id := p.pool.Get().(*id)
-	id.data = v
+	id := p.pool.GetOr(create).(*id)
+	id.pool, id.data = p, append(p.heap.Get(len(v)), v...)
 	ctx.RegisterCloser(id)
 
 	return id
@@ -52,9 +76,9 @@ func (p *identifierPool) GetStringID(ctx context.Context, v string) ID {
 }
 
 // Clone replicates given ID into a new ID from the pool
-func (p *identifierPool) Clone(other ID) ID {
-	id := p.pool.Get().(*id)
-	id.data = other.Data()
+func (p *identifierPool) Clone(v ID) ID {
+	id := p.pool.GetOr(create).(*id)
+	id.pool, id.data = p, append(p.heap.Get(len(v.Data())), v.Data()...)
 
 	return id
 }

--- a/ts/identifier_pool.go
+++ b/ts/identifier_pool.go
@@ -54,7 +54,7 @@ func configureHeap(heap pool.BytesPool) pool.BytesPool {
 
 	return pool.NewNativeHeap([]pool.Bucket{
 		{Capacity: 128, Count: 4096},
-		{Capacity: 256, Count: 2048}})
+		{Capacity: 256, Count: 2048}}, nil)
 }
 
 func create() interface{} {

--- a/ts/identifier_test.go
+++ b/ts/identifier_test.go
@@ -43,7 +43,7 @@ func TestConstructorEquality(t *testing.T) {
 }
 
 func TestPooling(t *testing.T) {
-	p := NewIdentifierPool(pool.NewObjectPoolOptions())
+	p := NewIdentifierPool(nil, pool.NewObjectPoolOptions())
 	ctx := context.NewContext()
 
 	a := p.GetStringID(ctx, "abc")
@@ -56,8 +56,7 @@ func TestPooling(t *testing.T) {
 
 func TestCloning(t *testing.T) {
 	a := StringID("abc")
-
-	p := NewIdentifierPool(pool.NewObjectPoolOptions())
+	p := NewIdentifierPool(nil, pool.NewObjectPoolOptions())
 	b := p.Clone(a)
 
 	require.True(t, a.Equal(b))
@@ -83,7 +82,7 @@ func BenchmarkHashCaching(b *testing.B) {
 }
 
 func BenchmarkPooling(b *testing.B) {
-	p := NewIdentifierPool(pool.NewObjectPoolOptions())
+	p := NewIdentifierPool(nil, pool.NewObjectPoolOptions())
 	ctx := context.NewContext()
 
 	v := []byte{}


### PR DESCRIPTION
This PR introduces a new object pool type which is opaque to the GC. The rationale behind it is that we accumulate an enourmous number of active objects on the GC heap and eventually GC starts to struggle when scanning all of them to determine if any of these objects should be deallocated. In reality, none of these objects would ever be deallocated since they are all pooled, so GC is essentially wasting CPU. The general observation is that background GC pause time is linear with the size of the heap, so reducing its size also reduces the width of CPU consumption peaks when background GC kicks in.

The `NativePool` works around this issue by hiding pooled objects from the GC – from GC's PoV there's only one giant slice of `uint8`s. Each time a new object is requested, a new `interface{}` is allocated on the heap which points to some area inside that slice. When an object is returned, the only thing that is remembered about it is its offset into that slice.

Unfortunately, objects which involve indirection – slices, maps, interfaces, pointer fields and so on – won't work with this pool **in general case** since GC will see these pointers as unreachable because their owners are hidden from it.

- Slices and maps won't work since we don't have control over their internal pointers. For example, even though it's possible to manually construct a slice with `reflect.SliceHeader` and point its storage to an area from `NativePool`, it will work only as long as no internal storage reallocation happens.
- It is only possible to use pointer and interface members if the pointee is also allocated from an `NativePool`.

This PR also introduces a `NativeHeap` which is an elastic GC-opaque []byte allocator. The `NativeHeap` is based on `NativePool` to provide underlying storage primitives.