### PR TITLE
Fix ID data not being properly copied on creation

### DIFF
--- a/ts/identifier.go
+++ b/ts/identifier.go
@@ -27,12 +27,12 @@ import (
 
 // BinaryID constructs a new ID based on a binary value
 func BinaryID(v []byte) ID {
-	return &id{data: v}
+	return &id{data: append(make([]byte, 0, len(v)), v...)}
 }
 
 // StringID constructs a new ID based on a string value
 func StringID(v string) ID {
-	return BinaryID([]byte(v))
+	return &id{data: append(make([]byte, 0, len(v)), v...)}
 }
 
 type id struct {


### PR DESCRIPTION
This PR fixes `ID` data slice being a reference instead of a copy of the argument in non-pooled `ID` constructor. The result of this is that `Series` constructor would end up having a reference to an incoming `ID` from the client, which in turn comes from a pool, so that when it is returned when request is completed, `Series` would have a dangling reference to a memory that might (and in fact ends up) being reused for other data, e.g. the actual `Block` contents.