### PR TITLE
Pool DatabaseSeries IDs

### DIFF
--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -226,7 +226,7 @@ func (l *commitLog) write() {
 
 		err := l.writer.Write(write.series,
 			write.datapoint, write.unit, write.annotation)
-		write.series.ID.OnClose()
+		write.series.ID.Close()
 
 		if err != nil {
 			l.metrics.errors.Inc(1)

--- a/storage/namespace/metadata.go
+++ b/storage/namespace/metadata.go
@@ -29,7 +29,7 @@ type metadata struct {
 
 // NewMetadata creates a new namespace metadata
 func NewMetadata(id ts.ID, opts Options) Metadata {
-	return metadata{id: ts.BinaryID(id.Data()), opts: opts}
+	return metadata{id: ts.BinaryID(append([]byte{}, id.Data()...)), opts: opts}
 }
 
 func (m metadata) ID() ts.ID {

--- a/storage/series/options.go
+++ b/storage/series/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m3db/m3db/encoding"
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/instrument"
 )
 
@@ -38,6 +39,7 @@ type options struct {
 	encoderPool                   encoding.EncoderPool
 	multiReaderIteratorPool       encoding.MultiReaderIteratorPool
 	fetchBlockMetadataResultsPool block.FetchBlockMetadataResultsPool
+	identifierPool                ts.IdentifierPool
 }
 
 // NewOptions creates new database series options
@@ -51,6 +53,7 @@ func NewOptions() Options {
 		encoderPool:                   encoding.NewEncoderPool(nil),
 		multiReaderIteratorPool:       encoding.NewMultiReaderIteratorPool(nil),
 		fetchBlockMetadataResultsPool: block.NewFetchBlockMetadataResultsPool(nil, 0),
+		identifierPool:                ts.NewIdentifierPool(nil, nil),
 	}
 }
 
@@ -132,4 +135,14 @@ func (o *options) SetFetchBlockMetadataResultsPool(value block.FetchBlockMetadat
 
 func (o *options) FetchBlockMetadataResultsPool() block.FetchBlockMetadataResultsPool {
 	return o.fetchBlockMetadataResultsPool
+}
+
+func (o *options) SetIdentifierPool(value ts.IdentifierPool) Options {
+	opts := *o
+	opts.identifierPool = value
+	return &opts
+}
+
+func (o *options) IdentifierPool() ts.IdentifierPool {
+	return o.identifierPool
 }

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -92,7 +92,7 @@ func newDatabaseSeries(id ts.ID, opts Options) *dbSeries {
 	ropts := opts.RetentionOptions()
 	blocksLen := int(ropts.RetentionPeriod() / ropts.BlockSize())
 	series := &dbSeries{
-		id:     ts.BinaryID(id.Data()),
+		id:     opts.IdentifierPool().Clone(id),
 		opts:   opts,
 		blocks: block.NewDatabaseSeriesBlocks(blocksLen, opts.DatabaseBlockOptions()),
 		bs:     bootstrapNotStarted,
@@ -559,6 +559,7 @@ func (s *dbSeries) Flush(ctx context.Context, blockStart time.Time, persistFn pe
 
 func (s *dbSeries) Close() {
 	s.Lock()
+	s.id.Close()
 	s.buffer.Reset()
 	s.blocks.Close()
 	s.pendingBootstrap = nil
@@ -570,7 +571,7 @@ func (s *dbSeries) Close() {
 
 func (s *dbSeries) Reset(id ts.ID) {
 	s.Lock()
-	s.id = ts.BinaryID(id.Data())
+	s.id = s.opts.IdentifierPool().Clone(id)
 	s.buffer.Reset()
 	s.blocks.RemoveAll()
 	s.pendingBootstrap = nil

--- a/storage/series/types.go
+++ b/storage/series/types.go
@@ -192,4 +192,10 @@ type Options interface {
 
 	// FetchBlockMetadataResultsPool returns the fetchBlockMetadataResultsPool
 	FetchBlockMetadataResultsPool() block.FetchBlockMetadataResultsPool
+
+	// SetIdentifierPool sets the identifierPool
+	SetIdentifierPool(value ts.IdentifierPool) Options
+
+	// IdentifierPool returns the identifierPool
+	IdentifierPool() ts.IdentifierPool
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -339,8 +339,8 @@ func (s *dbShard) purgeExpiredSeries(expired []series.DatabaseSeries) {
 	// Remove all expired series from lookup and list.
 	s.Lock()
 	for _, series := range expired {
-		id := series.ID()
-		elem, exists := s.lookup[id.Hash()]
+		hash := series.ID().Hash()
+		elem, exists := s.lookup[hash]
 		if !exists {
 			continue
 		}
@@ -360,7 +360,7 @@ func (s *dbShard) purgeExpiredSeries(expired []series.DatabaseSeries) {
 		// safe to remove it.
 		series.Close()
 		s.list.Remove(elem)
-		delete(s.lookup, id.Hash())
+		delete(s.lookup, hash)
 	}
 	s.Unlock()
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -21,6 +21,7 @@
 package storage
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/m3db/m3db/clock"
@@ -132,7 +133,7 @@ type NamespacesByID []Namespace
 func (n NamespacesByID) Len() int      { return len(n) }
 func (n NamespacesByID) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
 func (n NamespacesByID) Less(i, j int) bool {
-	return n[i].ID().String() < n[j].ID().String()
+	return bytes.Compare(n[i].ID().Data(), n[j].ID().Data()) < 0
 }
 
 type databaseNamespace interface {

--- a/ts/identifier_pool.go
+++ b/ts/identifier_pool.go
@@ -32,7 +32,7 @@ type identifierPool struct {
 	heap pool.BytesPool
 }
 
-// NewIdentifierPool constructs a new IdentifierPool
+// NewIdentifierPool constructs a new IdentifierPool.
 func NewIdentifierPool(
 	heap pool.BytesPool, options pool.ObjectPoolOptions) IdentifierPool {
 
@@ -64,21 +64,25 @@ func create() interface{} {
 	return &id{}
 }
 
-// GetBinaryID returns a new ID based on a binary value
+// GetBinaryID returns a new ID based on a binary value.
 func (p *identifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
 	id := p.pool.GetOr(create).(*id)
 	id.pool, id.data = p, append(p.heap.Get(len(v)), v...)
-	ctx.RegisterCloser(id)
+	ctx.RegisterCloser(context.CloserFn(id.Close))
 
 	return id
 }
 
-// GetStringID returns a new ID based on a string value
+// GetStringID returns a new ID based on a string value.
 func (p *identifierPool) GetStringID(ctx context.Context, v string) ID {
-	return p.GetBinaryID(ctx, []byte(v))
+	id := p.pool.GetOr(create).(*id)
+	id.pool, id.data = p, append(p.heap.Get(len(v)), v...)
+	ctx.RegisterCloser(context.CloserFn(id.Close))
+
+	return id
 }
 
-// Clone replicates given ID into a new ID from the pool
+// Clone replicates given ID into a new ID from the pool.
 func (p *identifierPool) Clone(v ID) ID {
 	id := p.pool.GetOr(create).(*id)
 	id.pool, id.data = p, append(p.heap.Get(len(v.Data())), v.Data()...)

--- a/ts/identifier_test.go
+++ b/ts/identifier_test.go
@@ -111,6 +111,6 @@ func BenchmarkPooling(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		id := p.GetBinaryID(ctx, v)
 		id.Hash()
-		id.OnClose()
+		id.Close()
 	}
 }

--- a/ts/segment.go
+++ b/ts/segment.go
@@ -20,17 +20,17 @@
 
 package ts
 
-// Segment represents a binary blob consisting of two byte slices
+// Segment represents a binary blob consisting of two byte slices.
 type Segment struct {
-	// Head is the head of the segment
+	// Head is the head of the segment.
 	Head []byte
 
-	// Tail is the tail of the segment
+	// Tail is the tail of the segment.
 	Tail []byte
 
-	// HeadShared determines whether the head bytes are shared
+	// HeadShared determines whether the head bytes are shared.
 	HeadShared bool
 
-	// TailShared determines whether the tail bytes are shared
+	// TailShared determines whether the tail bytes are shared.
 	TailShared bool
 }

--- a/ts/types.go
+++ b/ts/types.go
@@ -22,39 +22,41 @@ package ts
 
 import (
 	"crypto/md5"
+	"fmt"
 	"time"
 
 	"github.com/m3db/m3db/context"
 )
 
-// ID represents an immutable identifier for a timeseries
+// ID represents an immutable identifier for a timeseries.
 type ID interface {
-	context.Closer
+	fmt.Stringer
 
 	Data() []byte
-	Equal(value ID) bool
 	Hash() Hash
-	String() string
+	Equal(value ID) bool
+
+	Close()
 	Reset(v []byte)
 }
 
-// IdentifierPool represents an automatic pool of IDs
+// IdentifierPool represents an automatic pool of IDs.
 type IdentifierPool interface {
 	GetBinaryID(context.Context, []byte) ID
 	GetStringID(context.Context, string) ID
 
-	// Clone replicates a given ID into a pooled ID
+	// Clone replicates a given ID into a pooled ID.
 	Clone(other ID) ID
 }
 
-// Hash represents a form of ID suitable to be used as map keys
+// Hash represents a form of ID suitable to be used as map keys.
 type Hash [md5.Size]byte
 
-// A Datapoint is a single data value reported at a given time
+// A Datapoint is a single data value reported at a given time.
 type Datapoint struct {
 	Timestamp time.Time
 	Value     float64
 }
 
-// Annotation represents information used to annotate datapoints
+// Annotation represents information used to annotate datapoints.
 type Annotation []byte


### PR DESCRIPTION
This PR changes the `DatabaseSeries` construction to use the ID pool instead of allocating IDs in place out of the GC heap.