### PR TITLE
Protect ID hash from data races

### DIFF
--- a/ts/identifier_test.go
+++ b/ts/identifier_test.go
@@ -21,6 +21,8 @@
 package ts
 
 import (
+	"crypto/md5"
+	"sync"
 	"testing"
 
 	"github.com/m3db/m3db/context"
@@ -52,6 +54,25 @@ func TestPooling(t *testing.T) {
 	ctx.BlockingClose()
 
 	require.Empty(t, a.Data())
+}
+
+func TestHashing(t *testing.T) {
+	var (
+		wg         sync.WaitGroup
+		id         = StringID("abc")
+		expected   = Hash(md5.Sum(id.Data()))
+		numWorkers = 100
+	)
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			require.Equal(t, expected, id.Hash())
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestCloning(t *testing.T) {


### PR DESCRIPTION
cc @robskillington @kobolog @martin-mao @cw9 @prateek @ben-lerner 

This PR adds logic to protect ID hashes from data races.

Previously there is a race condition where two goroutines have reference to the same ID object, now if the first goroutine calls `id.Hash()`, it'll realize that the hash hasn't been initialized and starts computing. It'll then proceed to set the hash. However if halfway through setting the hash, the second goroutine also calls `id.Hash()`, it'll see a half-filled hash array and think the hash has been initialized, and return that hash even though it's incomplete. This in turn will trigger a crash in the client code.

The reason why we don't use a RWLock is to save space (4 bytes compared to 24 bytes needed for a RWLock object). This overhead adds up given we have a large number of IDs.