### PR TITLE
Write quorum logic during bootstrapping

### DIFF
--- a/client/connection_pool_test.go
+++ b/client/connection_pool_test.go
@@ -35,9 +35,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testHost     = "testhost"
+	testHostAddr = testHost + ":9000"
+)
+
 var (
-	testHost    = "testhost"
-	h           = topology.NewHost(testHost, testHost+":9000")
+	h           = topology.NewHost(testHost, testHostAddr)
 	channelNone = &nullChannel{}
 )
 

--- a/client/connection_pool_test.go
+++ b/client/connection_pool_test.go
@@ -29,14 +29,15 @@ import (
 
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
-	"github.com/m3db/m3x/close"
+	xclose "github.com/m3db/m3x/close"
 	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	h           = topology.NewHost("testhost", "testhost:9000")
+	testHost    = "testhost"
+	h           = topology.NewHost(testHost, testHost+":9000")
 	channelNone = &nullChannel{}
 )
 

--- a/client/host_queue_test.go
+++ b/client/host_queue_test.go
@@ -143,7 +143,7 @@ func TestHostQueueWriteBatches(t *testing.T) {
 	wg.Wait()
 
 	// Assert writes successful
-	success := []hostQueueResult{{nil, nil}, {nil, nil}, {nil, nil}, {nil, nil}}
+	success := []hostQueueResult{{testHost, nil}, {testHost, nil}, {testHost, nil}, {testHost, nil}}
 	assert.Equal(t, success, results)
 
 	// Close
@@ -221,7 +221,7 @@ func TestHostQueueWriteBatchesDifferentNamespaces(t *testing.T) {
 	wg.Wait()
 
 	// Assert writes successful
-	success := []hostQueueResult{{nil, nil}, {nil, nil}, {nil, nil}, {nil, nil}}
+	success := []hostQueueResult{{testHost, nil}, {testHost, nil}, {testHost, nil}, {testHost, nil}}
 	assert.Equal(t, success, results)
 
 	// Close

--- a/client/host_queue_test.go
+++ b/client/host_queue_test.go
@@ -143,8 +143,10 @@ func TestHostQueueWriteBatches(t *testing.T) {
 	wg.Wait()
 
 	// Assert writes successful
-	success := []hostQueueResult{{testHost, nil}, {testHost, nil}, {testHost, nil}, {testHost, nil}}
-	assert.Equal(t, success, results)
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
 
 	// Close
 	var closeWg sync.WaitGroup
@@ -221,8 +223,10 @@ func TestHostQueueWriteBatchesDifferentNamespaces(t *testing.T) {
 	wg.Wait()
 
 	// Assert writes successful
-	success := []hostQueueResult{{testHost, nil}, {testHost, nil}, {testHost, nil}, {testHost, nil}}
-	assert.Equal(t, success, results)
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
 
 	// Close
 	var closeWg sync.WaitGroup

--- a/client/session.go
+++ b/client/session.go
@@ -42,9 +42,9 @@ import (
 	"github.com/m3db/m3db/ts"
 	xio "github.com/m3db/m3db/x/io"
 	xerrors "github.com/m3db/m3x/errors"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/pool"
-	"github.com/m3db/m3x/retry"
+	xretry "github.com/m3db/m3x/retry"
 	"github.com/m3db/m3x/sync"
 	xtime "github.com/m3db/m3x/time"
 
@@ -631,6 +631,7 @@ func (s *session) Write(namespace, id string, t time.Time, value float64, unit x
 	}
 
 	state := s.writeStatePool.Get().(*writeState)
+	state.topoMap = s.topoMap
 	state.incRef()
 
 	state.op, state.majority = s.writeOpPool.Get(), majority

--- a/client/session.go
+++ b/client/session.go
@@ -294,17 +294,6 @@ func (s *session) nodesRespondingErrorsMetricIndex(respErrs int32) int32 {
 	return idx
 }
 
-// todo@bl - pull out other pool inits
-func (s *session) initWriteOpPool() {
-	writeOpPoolOpts := pool.NewObjectPoolOptions().
-		SetSize(s.opts.WriteOpPoolSize()).
-		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
-			s.scope.SubScope("write-op-pool"),
-		))
-	s.writeOpPool = newWriteOpPool(writeOpPoolOpts)
-	s.writeOpPool.Init()
-}
-
 func (s *session) Open() error {
 	s.Lock()
 	if s.state != stateNotOpen {
@@ -333,7 +322,13 @@ func (s *session) Open() error {
 
 	// NB(r): Alloc pools that can take some time in Open, expectation
 	// is already that Open will take some time
-	s.initWriteOpPool()
+	writeOpPoolOpts := pool.NewObjectPoolOptions().
+		SetSize(s.opts.WriteOpPoolSize()).
+		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(
+			s.scope.SubScope("write-op-pool"),
+		))
+	s.writeOpPool = newWriteOpPool(writeOpPoolOpts)
+	s.writeOpPool.Init()
 	fetchBatchOpPoolOpts := pool.NewObjectPoolOptions().
 		SetSize(s.opts.FetchBatchOpPoolSize()).
 		SetInstrumentOptions(s.opts.InstrumentOptions().SetMetricsScope(

--- a/client/session.go
+++ b/client/session.go
@@ -390,9 +390,10 @@ func (s *session) BorrowConnection(hostID string, fn withConnectionFn) error {
 
 func (s *session) newHostQueues(topoMap topology.Map) ([]hostQueue, int, int, error) {
 	// NB(r): we leave existing writes in the host queues to finish
-	// as they are already enroute to their destination, this is ok
-	// as part of adding a host is to add another replica for the
-	// shard set and only once bootstrapped decomission the old node
+	// as they are already enroute to their destination. This is an edge case
+	// that might result in leaving nodes counting towards quorum, but fixing it
+	// would result in additional chatter.
+
 	start := s.nowFn()
 
 	hosts := topoMap.Hosts()

--- a/client/session.go
+++ b/client/session.go
@@ -682,8 +682,7 @@ func (s *session) Write(namespace, id string, t time.Time, value float64, unit x
 	s.RUnlock()
 	state.Wait()
 
-	err := s.writeConsistencyResult(majority, enqueued,
-		enqueued-atomic.LoadInt32(&state.pending), int32(len(state.errors)), state.errors)
+	err := s.writeConsistencyResult(majority, enqueued, enqueued-state.pending, int32(len(state.errors)), state.errors)
 	s.incWriteMetrics(err, int32(len(state.errors)))
 
 	state.Unlock()

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -67,8 +67,7 @@ func sessionTestShardSet() sharding.ShardSet {
 	return shardSet
 }
 
-func defaultTestHostName() string { return testHostName(0) }
-func testHostName(i int) string   { return fmt.Sprintf("testhost%d", i) }
+func testHostName(i int) string { return fmt.Sprintf("testhost%d", i) }
 
 func sessionTestHostAndShards(
 	shardSet sharding.ShardSet,

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -67,12 +67,15 @@ func sessionTestShardSet() sharding.ShardSet {
 	return shardSet
 }
 
+func defaultTestHostName() string { return testHostName(0) }
+func testHostName(i int) string   { return fmt.Sprintf("testhost%d", i) }
+
 func sessionTestHostAndShards(
 	shardSet sharding.ShardSet,
 ) []topology.HostShardSet {
 	var hosts []topology.Host
 	for i := 0; i < sessionTestReplicas; i++ {
-		id := fmt.Sprintf("testhost%d", i)
+		id := testHostName(i)
 		host := topology.NewHost(id, fmt.Sprintf("%s:9000", id))
 		hosts = append(hosts, host)
 	}

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -87,7 +87,7 @@ func TestSessionWrite(t *testing.T) {
 	// Callback
 	enqueueWg.Wait()
 	for i := 0; i < session.topoMap.Replicas(); i++ {
-		completionFn(defaultTestHostName(), nil)
+		completionFn(session.topoMap.Hosts()[0], nil)
 	}
 
 	// Wait for write to complete
@@ -216,12 +216,13 @@ func testWriteConsistencyLevel(
 
 	// Callback
 	enqueueWg.Wait()
+	host := session.topoMap.Hosts()[0] // any host
 	writeErr := "a specific write error"
 	for i := 0; i < session.topoMap.Replicas()-failures; i++ {
-		completionFn(defaultTestHostName(), nil)
+		completionFn(host, nil)
 	}
 	for i := 0; i < failures; i++ {
-		completionFn(defaultTestHostName(), fmt.Errorf(writeErr))
+		completionFn(host, fmt.Errorf(writeErr))
 	}
 
 	// Wait for write to complete

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -55,14 +55,7 @@ func TestSessionWrite(t *testing.T) {
 
 	session := newDefaultTestSession(t).(*session)
 
-	w := struct {
-		ns         string
-		id         string
-		value      float64
-		t          time.Time
-		unit       xtime.Unit
-		annotation []byte
-	}{
+	w := writeStub{
 		ns:         "testNs",
 		id:         "foo",
 		value:      1.0,
@@ -278,6 +271,15 @@ func testWriteConsistencyLevel(
 			}
 		}
 	}
+}
+
+type writeStub struct {
+	ns         string
+	id         string
+	value      float64
+	t          time.Time
+	unit       xtime.Unit
+	annotation []byte
 }
 
 func newTestSession(t *testing.T, opts Options) clientSession {

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -55,15 +55,7 @@ func TestSessionWrite(t *testing.T) {
 
 	session := newDefaultTestSession(t).(*session)
 
-	w := writeStub{
-		ns:         "testNs",
-		id:         "foo",
-		value:      1.0,
-		t:          time.Now(),
-		unit:       xtime.Second,
-		annotation: nil,
-	}
-
+	w := newWriteStub()
 	var completionFn completionFn
 	enqueueWg := mockHostQueues(ctrl, session, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
 		completionFn = op.CompletionFn()
@@ -290,4 +282,15 @@ func newTestSession(t *testing.T, opts Options) clientSession {
 
 func newDefaultTestSession(t *testing.T) clientSession {
 	return newTestSession(t, newSessionTestOptions())
+}
+
+func newWriteStub() writeStub {
+	return writeStub{
+		ns:         "testNs",
+		id:         "foo",
+		value:      1.0,
+		t:          time.Now(),
+		unit:       xtime.Second,
+		annotation: nil,
+	}
 }

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
 	xmetrics "github.com/m3db/m3db/x/metrics"
-	"github.com/m3db/m3x/time"
+	xtime "github.com/m3db/m3x/time"
 	"github.com/uber-go/tally"
 
 	"github.com/golang/mock/gomock"

--- a/client/write.go
+++ b/client/write.go
@@ -136,7 +136,7 @@ func (w *writeState) close() {
 }
 
 func (w *writeState) completionFn(result interface{}, err error) {
-	hostID := result.(string)
+	hostID := result.(topology.Host).ID()
 	// NB(bl) panic on invalid result, it indicates a bug in the code
 
 	w.Lock()

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -56,6 +56,8 @@ func TestWriteToInitializingAndLeavingShards(t *testing.T) {
 
 func initWriteState(t *testing.T) (*session, *writeState) {
 	s := newDefaultTestSession(t).(*session)
+	s.initWriteOpPool()
+
 	wState := s.writeStatePool.Get().(*writeState)
 	wState.topoMap = s.topoMap
 	wState.op = s.writeOpPool.Get()

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -23,10 +23,8 @@ package client
 import (
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/m3db/m3cluster/shard"
-	xtime "github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -34,31 +32,61 @@ import (
 )
 
 func TestWriteToAvailableShards(t *testing.T) {
-	success, halfSuccess := shardStateWriteTest(t, shard.Available)
+	success, halfSuccess := shardStateWriteTest(t,
+		[]shard.State{
+			shard.Available,
+			shard.Available,
+			shard.Available,
+		})
 
 	assert.Equal(t, int32(sessionTestReplicas), success)
 	assert.Equal(t, int32(2*sessionTestReplicas), halfSuccess)
 }
 
 func TestWriteToInitializingShards(t *testing.T) {
-	success, halfSuccess := shardStateWriteTest(t, shard.Initializing)
+	success, halfSuccess := shardStateWriteTest(t,
+		[]shard.State{
+			shard.Initializing,
+			shard.Initializing,
+			shard.Initializing,
+		})
 
 	assert.Equal(t, int32(sessionTestReplicas/2), success)
 	assert.Equal(t, int32(sessionTestReplicas), halfSuccess)
 }
 
 func TestWriteToLeavingShards(t *testing.T) {
-	success, halfSuccess := shardStateWriteTest(t, shard.Leaving)
+	success, halfSuccess := shardStateWriteTest(t,
+		[]shard.State{
+			shard.Leaving,
+			shard.Leaving,
+			shard.Leaving,
+		})
 
 	assert.Equal(t, int32(sessionTestReplicas/2), success)
 	assert.Equal(t, int32(sessionTestReplicas), halfSuccess)
 }
 
 func TestWriteToInitializingAndLeavingShards(t *testing.T) {
+	success, halfSuccess := shardStateWriteTest(t,
+		[]shard.State{
+			shard.Initializing,
+			shard.Available,
+			shard.Leaving,
+		})
+
+	assert.Equal(t, int32(2), success)
+	assert.Equal(t, int32(4), halfSuccess)
+}
+
+func shardStateWriteTest(t *testing.T, states []shard.State) (success, halfSuccess int32) {
+	require.True(t, len(states) == sessionTestReplicas)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	s := newDefaultTestSession(t).(*session)
+	w := newWriteStub()
 
 	var completionFn completionFn
 	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
@@ -68,7 +96,6 @@ func TestWriteToInitializingAndLeavingShards(t *testing.T) {
 	s.Open()
 	defer s.Close()
 
-	// set up write state
 	wState := getWriteState(s)
 	for i := 0; i < sessionTestReplicas+1; i++ {
 		wState.incRef()
@@ -78,68 +105,22 @@ func TestWriteToInitializingAndLeavingShards(t *testing.T) {
 	// Begin write
 	var writeWg sync.WaitGroup
 	writeWg.Add(1)
-	w := newWriteStub()
 	go func() {
 		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
 		writeWg.Done()
 	}()
 
 	// Callbacks
-	callback := func(state shard.State) {
-		setShardStates(t, s, state)
+	callback := func(idx int) {
+		setShardStates(t, s, states[idx])
 		completionFn(defaultTestHostName(), nil)        // maintain session state
 		wState.completionFn(defaultTestHostName(), nil) // for the test
 	}
-	enqueueWg.Wait()
-
-	callback(shard.Available)
-	callback(shard.Initializing)
-	callback(shard.Leaving)
-
-	// Wait for writes to complete
-	writeWg.Wait()
-
-	assert.Equal(t, int32(2), wState.successful())
-	assert.Equal(t, int32(4), wState.halfSuccess)
-
-}
-
-func shardStateWriteTest(t *testing.T, state shard.State) (success, halfSuccess int32) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	s := newDefaultTestSession(t).(*session)
-	w := newWriteStub()
-
-	var completionFn completionFn
-	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
-		completionFn = op.CompletionFn()
-	}})
-
-	s.Open()
-	defer s.Close()
-
-	wState := getWriteState(s)
-	for i := 0; i < sessionTestReplicas+1; i++ {
-		wState.incRef()
-	}
-	defer wState.decRef() // add an extra incRef so we can inspect wState
-
-	// Begin write
-	var writeWg sync.WaitGroup
-	writeWg.Add(1)
-	go func() {
-		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
-		writeWg.Done()
-	}()
-
-	// Callback
-	setShardStates(t, s, state)
 
 	enqueueWg.Wait()
+	require.True(t, s.topoMap.Replicas() == sessionTestReplicas)
 	for i := 0; i < s.topoMap.Replicas(); i++ {
-		completionFn(defaultTestHostName(), nil)
-		wState.completionFn(defaultTestHostName(), nil)
+		callback(i)
 	}
 
 	// Wait for write to complete
@@ -162,38 +143,4 @@ func setShardStates(t *testing.T, s *session, state shard.State) {
 	for _, hostShard := range hostShardSet.ShardSet().All() {
 		hostShard.SetState(state)
 	}
-}
-
-func writeToSession(t *testing.T, s *session) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var completionFn completionFn
-	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
-		completionFn = op.CompletionFn()
-	}})
-
-	w := writeStub{
-		ns:         "testNs",
-		id:         "foo",
-		value:      1.0,
-		t:          time.Now(),
-		unit:       xtime.Second,
-		annotation: nil,
-	}
-
-	var writeWg sync.WaitGroup
-	writeWg.Add(1)
-	go func() {
-		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
-		writeWg.Done()
-	}()
-
-	// Callback
-	enqueueWg.Wait()
-	require.Equal(t, 1, s.topoMap.Replicas())
-	completionFn(defaultTestHostName(), nil)
-
-	// Wait for write to complete
-	writeWg.Wait()
 }

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -21,13 +21,25 @@
 package client
 
 import (
+	"sync"
 	"testing"
+	"time"
 
-	_ "github.com/golang/mock/gomock"
+	"github.com/m3db/m3cluster/shard"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteToAvailableShard(t *testing.T) {
+	s, wState := initWriteState(t)
+	setShardStates(t, s, shard.Available)
+	writeToSession(t, s)
 
+	assert.Equal(t, 2, wState.halfSuccess)
+	assert.Equal(t, 1, wState.successful())
 }
 
 func TestWriteToInitializingShard(t *testing.T) {
@@ -42,15 +54,55 @@ func TestWriteToInitializingAndLeavingShards(t *testing.T) {
 
 }
 
-func initShardTest(t *testing.T) {
-	// ctrl := gomock.NewController(t)
-	// defer ctrl.Finish()
+func initWriteState(t *testing.T) (*session, *writeState) {
+	s := newDefaultTestSession(t).(*session)
+	wState := s.writeStatePool.Get().(*writeState)
+	wState.topoMap = s.topoMap
+	wState.op = s.writeOpPool.Get()
+	wState.op.completionFn = wState.completionFn
 
-	// session := newDefaultTestSession(t).(*session)
+	return s, wState
+}
 
-	// var completionFn completionFn
-	// enqueueWg := mockHostQueues(ctrl, session, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
-	// 	completionFn = op.CompletionFn()
-	// 	write, ok := op.(*writeOp)
-	// }})
+func setShardStates(t *testing.T, s *session, state shard.State) {
+	hostShardSet, ok := s.topoMap.LookupHostShardSet(defaultTestHostName())
+	require.True(t, ok)
+
+	for _, hostShard := range hostShardSet.ShardSet().All() {
+		hostShard.SetState(state)
+	}
+}
+
+func writeToSession(t *testing.T, s *session) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var completionFn completionFn
+	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
+		completionFn = op.CompletionFn()
+	}})
+
+	w := writeStub{
+		ns:         "testNs",
+		id:         "foo",
+		value:      1.0,
+		t:          time.Now(),
+		unit:       xtime.Second,
+		annotation: nil,
+	}
+
+	var writeWg sync.WaitGroup
+	writeWg.Add(1)
+	go func() {
+		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
+		writeWg.Done()
+	}()
+
+	// Callback
+	enqueueWg.Wait()
+	require.Equal(t, 1, s.topoMap.Replicas())
+	completionFn(defaultTestHostName(), nil)
+
+	// Wait for write to complete
+	writeWg.Wait()
 }

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"testing"
+
+	_ "github.com/golang/mock/gomock"
+)
+
+func TestWriteToAvailableShard(t *testing.T) {
+
+}
+
+func TestWriteToInitializingShard(t *testing.T) {
+
+}
+
+func TestWriteToLeavingShard(t *testing.T) {
+
+}
+
+func TestWriteToInitializingAndLeavingShards(t *testing.T) {
+
+}
+
+func initShardTest(t *testing.T) {
+	// ctrl := gomock.NewController(t)
+	// defer ctrl.Finish()
+
+	// session := newDefaultTestSession(t).(*session)
+
+	// var completionFn completionFn
+	// enqueueWg := mockHostQueues(ctrl, session, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
+	// 	completionFn = op.CompletionFn()
+	// 	write, ok := op.(*writeOp)
+	// }})
+}

--- a/sharding/shardset.go
+++ b/sharding/shardset.go
@@ -80,8 +80,7 @@ func (s *shardSet) Lookup(identifier ts.ID) uint32 {
 func (s *shardSet) LookupStateByID(shardID uint32) (shard.State, error) {
 	hostShard, ok := s.shardMap[shardID]
 	if !ok {
-		var noState shard.State
-		return noState, ErrInvalidShardID
+		return shard.State(0), ErrInvalidShardID
 	}
 	return hostShard.State(), nil
 }

--- a/sharding/shardset.go
+++ b/sharding/shardset.go
@@ -78,12 +78,12 @@ func (s *shardSet) Lookup(identifier ts.ID) uint32 {
 }
 
 func (s *shardSet) LookupStateByID(shardID uint32) (shard.State, error) {
-	hostShard, ok := s.shardMap[shardID]
-	if !ok {
-		var state shard.State
-		return state, ErrInvalidShardID
+	if hostShard, ok := s.shardMap[shardID]; !ok {
+		var noState shard.State
+		return noState, ErrInvalidShardID
+	} else {
+		return hostShard.State(), nil
 	}
-	return hostShard.State(), nil
 }
 
 func (s *shardSet) All() []shard.Shard {

--- a/sharding/shardset.go
+++ b/sharding/shardset.go
@@ -78,12 +78,12 @@ func (s *shardSet) Lookup(identifier ts.ID) uint32 {
 }
 
 func (s *shardSet) LookupStateByID(shardID uint32) (shard.State, error) {
-	if hostShard, ok := s.shardMap[shardID]; !ok {
+	hostShard, ok := s.shardMap[shardID]
+	if !ok {
 		var noState shard.State
 		return noState, ErrInvalidShardID
-	} else {
-		return hostShard.State(), nil
 	}
+	return hostShard.State(), nil
 }
 
 func (s *shardSet) All() []shard.Shard {

--- a/sharding/shardset_test.go
+++ b/sharding/shardset_test.go
@@ -56,3 +56,23 @@ func TestShardSet(t *testing.T) {
 	fn := ss.HashFn()
 	require.Equal(t, staticShard, fn(id))
 }
+
+func TestLookupShardState(t *testing.T) {
+	staticShard := uint32(1)
+	ss, err := NewShardSet(
+		NewShards([]uint32{1, 5, 3}, shard.Available),
+		func(id ts.ID) uint32 {
+			return staticShard
+		})
+	require.NoError(t, err)
+
+	shardOneState, err := ss.LookupStateByID(1)
+	require.NoError(t, err)
+	require.Equal(t, shard.Available, shardOneState)
+
+	var noState shard.State
+
+	shardTwoState, err := ss.LookupStateByID(2)
+	require.Equal(t, ErrInvalidShardID, err)
+	require.Equal(t, noState, shardTwoState)
+}

--- a/sharding/shardset_test.go
+++ b/sharding/shardset_test.go
@@ -71,7 +71,6 @@ func TestLookupShardState(t *testing.T) {
 	require.Equal(t, shard.Available, shardOneState)
 
 	var noState shard.State
-
 	shardTwoState, err := ss.LookupStateByID(2)
 	require.Equal(t, ErrInvalidShardID, err)
 	require.Equal(t, noState, shardTwoState)

--- a/sharding/types.go
+++ b/sharding/types.go
@@ -43,6 +43,9 @@ type ShardSet interface {
 	// Lookup will return a shard for a given identifier
 	Lookup(id ts.ID) uint32
 
+	// LookupStateByID returns the state of the shard with a given ID
+	LookupStateByID(shardID uint32) (shard.State, error)
+
 	// Min returns the smallest shard owned by this shard set
 	Min() uint32
 


### PR DESCRIPTION
Add support for bootstrapping to the write client. While bootstrapping the initializing and leaving shards count as a single shard towards a quorum, and only if the client successfully writes to both of them.