### PR TITLE
Refactor context.Context

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -20,140 +20,141 @@
 
 package context
 
-import (
-	"sync"
-)
+import "sync"
 
-type dependency struct {
-	closers      []Closer
-	dependencies sync.WaitGroup
-}
-
-// NB(r): using golang.org/x/net/context is too GC expensive
+// NB(r): using golang.org/x/net/context is too GC expensive.
 type ctx struct {
+	sync.WaitGroup
 	sync.RWMutex
-	pool   contextPool
-	closed bool
-	dep    *dependency
+
+	pool       contextPool
+	done       bool
+	finalizers []Finalizer
 }
 
-// NewContext creates a new context
+// NewContext creates a new context.
 func NewContext() Context {
 	return newPooledContext(nil)
 }
 
-// NewPooledContext returns a new context that is returned to a pool when closed
+// NewPooledContext returns a new context that is returned to a pool when closed.
 func newPooledContext(pool contextPool) Context {
 	return &ctx{pool: pool}
 }
 
-func (c *ctx) ensureDependencies(initClosers bool) {
-	if c.dep == nil {
-		c.dep = &dependency{}
-	}
-	if !initClosers || c.dep.closers != nil {
-		return
-	}
-	if c.pool != nil {
-		c.dep.closers = c.pool.GetClosers()
-	} else {
-		c.dep.closers = allocateClosers()
-	}
+func (c *ctx) IsClosed() bool {
+	c.RLock()
+	done := c.done
+	c.RUnlock()
+
+	return done
 }
 
-func (c *ctx) RegisterCloser(closer Closer) {
-	c.Lock()
-	if c.closed {
+func (c *ctx) RegisterFinalizer(f Finalizer) {
+	if c.Lock(); c.done {
 		c.Unlock()
 		return
 	}
-	c.ensureDependencies(true)
-	c.dep.closers = append(c.dep.closers, closer)
+
+	if c.finalizers != nil {
+		c.finalizers = append(c.finalizers, f)
+		c.Unlock()
+		return
+	}
+
+	if c.pool != nil {
+		c.finalizers = append(c.pool.GetFinalizers(), f)
+	} else {
+		c.finalizers = append(allocateFinalizers(), f)
+	}
+
 	c.Unlock()
 }
 
 func (c *ctx) DependsOn(blocker Context) {
 	c.Lock()
-	if !c.closed {
-		c.ensureDependencies(false)
-		c.dep.dependencies.Add(1)
-		blocker.RegisterCloser(c)
+
+	if !c.done {
+		c.Add(1)
+		blocker.RegisterFinalizer(c)
 	}
+
 	c.Unlock()
 }
 
-// OnClose handles a call from another context that was depended upon closing
-func (c *ctx) OnClose() {
-	c.dep.dependencies.Done()
+// Finalize handles a call from another context that was depended upon closing.
+func (c *ctx) Finalize() {
+	c.Done()
 }
 
+type closeMode int
+
+const (
+	closeAsync closeMode = iota
+	closeBlock
+)
+
 func (c *ctx) Close() {
-	c.close(false)
+	c.close(closeAsync)
 }
 
 func (c *ctx) BlockingClose() {
-	c.close(true)
+	c.close(closeBlock)
 }
 
-func (c *ctx) close(blocking bool) {
-	var closers []Closer
-
-	c.Lock()
-	if c.closed {
+func (c *ctx) close(mode closeMode) {
+	if c.Lock(); c.done {
 		c.Unlock()
 		return
 	}
-	c.closed = true
-	if c.dep != nil {
-		closers = c.dep.closers[:]
-	}
+
+	c.done = true
+	finalizers := c.finalizers[:]
 	c.Unlock()
 
-	if len(closers) == 0 {
+	if len(finalizers) == 0 {
 		c.returnToPool()
 		return
 	}
 
-	if blocking {
-		c.finalize(closers)
-	} else {
-		go c.finalize(closers)
+	switch mode {
+	case closeAsync:
+		go c.finalize(finalizers)
+	case closeBlock:
+		c.finalize(finalizers)
 	}
 }
 
-func (c *ctx) finalize(closers []Closer) {
-	// Wait for dependencies
-	c.dep.dependencies.Wait()
-	// Now call closers
-	for i := range closers {
-		closers[i].OnClose()
+func (c *ctx) finalize(finalizers []Finalizer) {
+	// Wait for dependencies.
+	c.Wait()
+
+	// Now call finalizers.
+	for i := range finalizers {
+		finalizers[i].Finalize()
 	}
+
 	c.returnToPool()
-}
-
-func (c *ctx) IsClosed() bool {
-	c.RLock()
-	closed := c.closed
-	c.RUnlock()
-	return closed
 }
 
 func (c *ctx) Reset() {
 	c.Lock()
-	c.closed = false
-	if c.dep != nil {
-		if c.pool != nil {
-			c.pool.PutClosers(c.dep.closers)
-		}
-		c.dep.closers = nil
-		c.dep.dependencies = sync.WaitGroup{}
+
+	if c.pool != nil {
+		c.pool.PutFinalizers(c.finalizers)
 	}
+
+	c.WaitGroup = sync.WaitGroup{}
+	c.done, c.finalizers = false, nil
+
 	c.Unlock()
 }
 
 func (c *ctx) returnToPool() {
-	if c.pool != nil {
-		c.Reset()
-		c.pool.Put(c)
+	if c.pool == nil {
+		return
 	}
+
+	c.Reset()
+	c.pool.Put(c)
 }

--- a/context/types.go
+++ b/context/types.go
@@ -20,61 +20,60 @@
 
 package context
 
-// Closer closes a resource
-type Closer interface {
-	// OnClose is called on close
-	OnClose()
+// Finalizer finalizes a resource.
+type Finalizer interface {
+	Finalize()
 }
 
-// CloserFn is a function literal that is a closer
-type CloserFn func()
+// FinalizerFn is a function literal that is a finalizer.
+type FinalizerFn func()
 
-// OnClose will call the function literal as a closer
-func (fn CloserFn) OnClose() {
+// Finalize will call the function literal as a finalizer.
+func (fn FinalizerFn) Finalize() {
 	fn()
 }
 
-// Context provides context to an operation
+// Context provides context to an operation.
 type Context interface {
-	// RegisterCloser will register a resource closer
-	RegisterCloser(closer Closer)
+	// IsClosed returns whether the context is closed.
+	IsClosed() bool
+
+	// RegisterFinalizer will register a resource finalizer.
+	RegisterFinalizer(Finalizer)
 
 	// DependsOn will register a blocking context that
-	// must complete first before closers can be called
-	DependsOn(blocker Context)
+	// must complete first before finalizers can be called.
+	DependsOn(Context)
 
-	// Close will close the context
+	// Close will close the context.
 	Close()
 
 	// BlockingClose will close the context and call the
-	// registered closers in a blocking manner after waiting
+	// registered finalizers in a blocking manner after waiting
 	// for any dependent contexts to close. After calling
 	// the context becomes safe to reset and reuse again.
 	BlockingClose()
 
-	// IsClosed returns whether the context is closed
-	IsClosed() bool
-
-	// Reset will reset the context for reuse
+	// Reset will reset the context for reuse.
 	Reset()
 }
 
-// Pool provides a pool for contexts
+// Pool provides a pool for contexts.
 type Pool interface {
-	// Get provides a context from the pool
+	// Get provides a context from the pool.
 	Get() Context
 
-	// Put returns a context to the pool
-	Put(ctx Context)
+	// Put returns a context to the pool.
+	Put(Context)
 }
 
-// contextPool is the internal pool interface for contexts
+// contextPool is the internal pool interface for contexts.
 type contextPool interface {
 	Pool
 
-	// GetClosers provides a closer slice from the pool
-	GetClosers() []Closer
+	// GetFinalizers provides a finalizer slice from the pool.
+	GetFinalizers() []Finalizer
 
-	// PutClosers returns the closers to pool
-	PutClosers(closers []Closer)
+	// PutFinalizers returns the finalizers to pool.
+	PutFinalizers([]Finalizer)
 }

--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -226,7 +226,7 @@ func (l *commitLog) write() {
 
 		err := l.writer.Write(write.series,
 			write.datapoint, write.unit, write.annotation)
-		write.series.ID.Close()
+		write.series.ID.Finalize()
 
 		if err != nil {
 			l.metrics.errors.Inc(1)

--- a/storage/block/block.go
+++ b/storage/block/block.go
@@ -83,7 +83,7 @@ func (b *dbBlock) Stream(blocker context.Context) (xio.SegmentReader, error) {
 	}
 	s := b.opts.SegmentReaderPool().Get()
 	s.Reset(b.segment)
-	blocker.RegisterCloser(context.CloserFn(s.Close))
+	blocker.RegisterFinalizer(context.FinalizerFn(s.Close))
 	return s, nil
 }
 
@@ -107,7 +107,7 @@ func (b *dbBlock) resetSegment(segment ts.Segment) {
 		return
 	}
 
-	b.ctx.RegisterCloser(context.CloserFn(func() {
+	b.ctx.RegisterFinalizer(context.FinalizerFn(func() {
 		if segment.Head != nil && !segment.HeadShared {
 			bytesPool.Put(segment.Head)
 		}

--- a/storage/block/block_test.go
+++ b/storage/block/block_test.go
@@ -69,7 +69,7 @@ func validateBlocks(t *testing.T, blocks *databaseSeriesBlocks, minTime, maxTime
 func closeTestDatabaseBlock(t *testing.T, block *dbBlock) {
 	var finished uint32
 	block.ctx = block.opts.ContextPool().Get()
-	block.ctx.RegisterCloser(context.CloserFn(func() { atomic.StoreUint32(&finished, 1) }))
+	block.ctx.RegisterFinalizer(context.FinalizerFn(func() { atomic.StoreUint32(&finished, 1) }))
 	block.Close()
 	// waiting for the goroutine that closes context to finish
 	for atomic.LoadUint32(&finished) == 0 {
@@ -122,7 +122,7 @@ func testDatabaseBlockWithDependentContext(
 	require.NoError(t, err)
 
 	var finished uint32
-	block.ctx.RegisterCloser(context.CloserFn(func() {
+	block.ctx.RegisterFinalizer(context.FinalizerFn(func() {
 		atomic.StoreUint32(&finished, 1)
 	}))
 	f(block)

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -112,7 +112,7 @@ func (r shardRepairer) Repair(
 	)
 
 	metadata := repair.NewReplicaMetadataComparer(replicas, r.rpopts)
-	ctx.RegisterCloser(metadata)
+	ctx.RegisterFinalizer(metadata)
 
 	// Add local metadata
 	localMetadata, _ := shard.FetchBlocksMetadata(ctx, start, end, math.MaxInt64, 0, true, true)

--- a/storage/repair/metadata.go
+++ b/storage/repair/metadata.go
@@ -259,6 +259,6 @@ func (m replicaMetadataComparer) Compare() MetadataComparisonResult {
 	}
 }
 
-func (m replicaMetadataComparer) OnClose() {
+func (m replicaMetadataComparer) Finalize() {
 	m.metadata.Close()
 }

--- a/storage/repair/types.go
+++ b/storage/repair/types.go
@@ -128,8 +128,8 @@ type ReplicaMetadataComparer interface {
 	// Compare returns the metadata differences between local host and peers
 	Compare() MetadataComparisonResult
 
-	// OnClose performs cleanup during close
-	OnClose()
+	// Finalize performs cleanup during close
+	Finalize()
 }
 
 // MetadataComparisonResult captures metadata comparison results

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -339,7 +339,7 @@ func (b *dbBufferBucket) resetTo(
 	encoder.Reset(start, bopts.DatabaseBlockAllocSize())
 
 	// Register when this bucket resets we close the encoder
-	ctx.RegisterCloser(context.CloserFn(encoder.Close))
+	ctx.RegisterFinalizer(context.FinalizerFn(encoder.Close))
 
 	if b.ctx != nil {
 		// Close the old context if we're resetting for use
@@ -386,7 +386,7 @@ func (b *dbBufferBucket) bootstrap(
 	bl block.DatabaseBlock,
 ) {
 	// Register when this bucket resets we close the bootstrapped block
-	b.ctx.RegisterCloser(context.CloserFn(bl.Close))
+	b.ctx.RegisterFinalizer(context.FinalizerFn(bl.Close))
 	b.empty = false
 	b.bootstrapped = append(b.bootstrapped, bl)
 }
@@ -420,7 +420,7 @@ func (b *dbBufferBucket) write(
 		target = &b.encoders[len(b.encoders)-1]
 
 		// Register when this bucket resets we close the encoder we just created
-		b.ctx.RegisterCloser(context.CloserFn(encoder.Close))
+		b.ctx.RegisterFinalizer(context.FinalizerFn(encoder.Close))
 	}
 
 	datapoint := ts.Datapoint{
@@ -451,7 +451,7 @@ func (b *dbBufferBucket) readStreams(
 	}
 	for i := range b.encoders {
 		if s := b.encoders[i].encoder.Stream(); s != nil {
-			ctx.RegisterCloser(context.CloserFn(s.Close))
+			ctx.RegisterFinalizer(context.FinalizerFn(s.Close))
 			streamFn(s)
 		}
 	}
@@ -472,7 +472,7 @@ func (b *dbBufferBucket) merge() {
 	encoder.Reset(b.start, bopts.DatabaseBlockAllocSize())
 
 	// Register when this bucket resets we close the encoder we just created
-	b.ctx.RegisterCloser(context.CloserFn(encoder.Close))
+	b.ctx.RegisterFinalizer(context.FinalizerFn(encoder.Close))
 
 	readers := make([]io.Reader, 0, len(b.encoders)+len(b.bootstrapped))
 	for i := range b.encoders {

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -542,7 +542,7 @@ func (s *dbSeries) Flush(
 
 func (s *dbSeries) Close() {
 	s.Lock()
-	s.id.Close()
+	s.id.Finalize()
 	s.buffer.Reset()
 	s.blocks.Close()
 	s.Unlock()

--- a/ts/identifier_pool.go
+++ b/ts/identifier_pool.go
@@ -42,7 +42,7 @@ type simpleIdentifierPool struct {
 func (p *simpleIdentifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
 	id := p.pool.Get().(*id)
 	id.data = v
-	ctx.RegisterCloser(context.CloserFn(id.Close))
+	ctx.RegisterFinalizer(id)
 
 	return id
 }
@@ -104,7 +104,7 @@ func create() interface{} {
 func (p *nativeIdentifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
 	id := p.pool.GetOr(create).(*id)
 	id.pool, id.data = p, append(p.heap.Get(len(v)), v...)
-	ctx.RegisterCloser(context.CloserFn(id.Close))
+	ctx.RegisterFinalizer(id)
 
 	return id
 }
@@ -113,7 +113,7 @@ func (p *nativeIdentifierPool) GetBinaryID(ctx context.Context, v []byte) ID {
 func (p *nativeIdentifierPool) GetStringID(ctx context.Context, v string) ID {
 	id := p.pool.GetOr(create).(*id)
 	id.pool, id.data = p, append(p.heap.Get(len(v)), v...)
-	ctx.RegisterCloser(context.CloserFn(id.Close))
+	ctx.RegisterFinalizer(id)
 
 	return id
 }

--- a/ts/identifier_test.go
+++ b/ts/identifier_test.go
@@ -113,6 +113,6 @@ func BenchmarkPooling(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		id := p.GetBinaryID(ctx, v)
 		id.Hash()
-		id.Close()
+		id.Finalize()
 	}
 }

--- a/ts/types.go
+++ b/ts/types.go
@@ -36,7 +36,7 @@ type ID interface {
 	Hash() Hash
 	Equal(value ID) bool
 
-	Close()
+	Finalize()
 	Reset(v []byte)
 }
 


### PR DESCRIPTION
This PR refactors `context.Context` to avoid having a pointer to the `dependecies` object. In practice, all Contexts always have it initialized eventually – after a few minutes of runtime – and we have tens of millions of Contexts active. This effectively **reduces the number of active pointers in the GC heap by almost 20%**.

This PR also refactors Closers concept and renames it to Finalizers to avoid a naming ambiguity with regards to `Close()`/`OnClose()` calls. The proposed naming is still not perfect but in my head is less confusing. Up for a discussion. An outstanding issue with this mechanics is the `context.CloserFn` conversion that takes up a considerable portion of total allocations but in essence is a no-op, i.e. an object with `Close()` is effectively is a Closer already, but a conversion has to be made because of the `Close()`/`OnClose()` disparity.