### PR TITLE
Avoid false reference sharing

### DIFF
--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -82,9 +82,6 @@ func NewPooledDatabaseSeries(pool DatabaseSeriesPool, opts Options) DatabaseSeri
 }
 
 func newDatabaseSeries(id ts.ID, opts Options) *dbSeries {
-	if id != nil {
-		id = opts.IdentifierPool().Clone(id)
-	}
 	series := &dbSeries{
 		id:     id,
 		opts:   opts,

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -75,8 +75,8 @@ func NewDatabaseSeries(id ts.ID, opts Options) DatabaseSeries {
 }
 
 // NewPooledDatabaseSeries creates a new pooled database series
-func NewPooledDatabaseSeries(id ts.ID, pool DatabaseSeriesPool, opts Options) DatabaseSeries {
-	series := newDatabaseSeries(id, opts)
+func NewPooledDatabaseSeries(pool DatabaseSeriesPool, opts Options) DatabaseSeries {
+	series := newDatabaseSeries(nil, opts)
 	series.pool = pool
 	return series
 }
@@ -555,7 +555,7 @@ func (s *dbSeries) Close() {
 
 func (s *dbSeries) Reset(id ts.ID) {
 	s.Lock()
-	s.id = s.opts.IdentifierPool().Clone(id)
+	s.id = id
 	s.buffer.Reset()
 	s.blocks.RemoveAll()
 	s.bs = bootstrapNotStarted

--- a/storage/series/series_pool.go
+++ b/storage/series/series_pool.go
@@ -30,7 +30,7 @@ type databaseSeriesPool struct {
 func NewDatabaseSeriesPool(seriesOpts Options, opts pool.ObjectPoolOptions) DatabaseSeriesPool {
 	p := &databaseSeriesPool{pool: pool.NewObjectPool(opts)}
 	p.pool.Init(func() interface{} {
-		return NewPooledDatabaseSeries(nil, p, seriesOpts)
+		return NewPooledDatabaseSeries(p, seriesOpts)
 	})
 	return p
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -462,7 +462,7 @@ func (s *dbShard) writableSeries(id ts.ID) (*dbShardEntry, error) {
 	// Retrieve the entry out of any locks to avoid any possible expensive
 	// allocations during any unpooled gets blocking other writers
 	series := s.seriesPool.Get()
-	series.Reset(id)
+	series.Reset(s.identifierPool.Clone(id))
 
 	entry := &dbShardEntry{
 		series:     series,


### PR DESCRIPTION
Avoid passing references to objects across function boundaries which are not meant to be shared.