### PR TITLE
Avoid ID creation where only hash is needed.

### DIFF
--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -184,7 +184,7 @@ func (s *seeker) readIndex(size int) error {
 		}
 
 		indexUnread = indexUnread[size:]
-		s.indexMap[ts.BinaryID(entry.Id).Hash()] = entry
+		s.indexMap[ts.HashFn(entry.Id)] = entry
 	}
 
 	return nil

--- a/ts/identifier.go
+++ b/ts/identifier.go
@@ -39,7 +39,8 @@ func StringID(v string) ID {
 	return &id{data: []byte(v)}
 }
 
-func hash(data []byte) Hash {
+// HashFn is the default hashing implementation for IDs.
+func HashFn(data []byte) Hash {
 	return md5.Sum(data)
 }
 
@@ -77,7 +78,7 @@ func (v *id) Hash() Hash {
 		// If the hash is not computed, and this goroutine gains exclusive
 		// access to the hash field, compute and cache it.
 		if atomic.CompareAndSwapInt32(&v.flag, int32(invalid), int32(pending)) {
-			v.hash = hash(v.data)
+			v.hash = HashFn(v.data)
 			atomic.StoreInt32(&v.flag, int32(computed))
 			return v.hash
 		}
@@ -87,7 +88,7 @@ func (v *id) Hash() Hash {
 
 	// If the hash is being computed, compute the hash in place and don't
 	// wait.
-	return hash(v.data)
+	return HashFn(v.data)
 }
 
 func (v *id) Equal(value ID) bool {


### PR DESCRIPTION
This PR introduces a mechanic where ID creation can be avoided in case only an ID hash is required and hash caching would not bring any benefit.