### PR TITLE
Fix use-after-free in repair logic.

### DIFF
--- a/storage/repair.go
+++ b/storage/repair.go
@@ -116,9 +116,10 @@ func (r shardRepairer) Repair(
 
 	// Add local metadata
 	localMetadata, _ := shard.FetchBlocksMetadata(ctx, start, end, math.MaxInt64, 0, true, true)
+	ctx.RegisterFinalizer(context.FinalizerFn(localMetadata.Close))
+
 	localIter := block.NewFilteredBlocksMetadataIter(localMetadata)
 	metadata.AddLocalMetadata(origin, localIter)
-	localMetadata.Close()
 
 	// Add peer metadata
 	peerIter, err := session.FetchBlocksMetadataFromPeers(namespace, shard.ID(), start, end)


### PR DESCRIPTION
This PR fixes an issue where pooled resources in metadata results are being used after the enclosing object was destroyed.