### PR TITLE
Fix a resource leak in FetchBlocksMetadata().

### DIFF
--- a/storage/block/result.go
+++ b/storage/block/result.go
@@ -160,8 +160,8 @@ func (s *fetchBlocksMetadataResults) Reset() {
 
 func (s *fetchBlocksMetadataResults) Close() {
 	for i := range s.results {
-		s.results[i].Blocks.Close()
 		s.results[i].ID.Finalize()
+		s.results[i].Blocks.Close()
 	}
 	if s.pool != nil {
 		s.pool.Put(s)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -549,6 +549,7 @@ func (s *dbShard) FetchBlocksMetadata(
 		// If the blocksMetadata is empty, the series have no data within the specified
 		// time range so we don't return it to the client
 		if len(blocksMetadata.Blocks.Results()) == 0 {
+			blocksMetadata.ID.Finalize()
 			blocksMetadata.Blocks.Close()
 			return true
 		}


### PR DESCRIPTION
This PR fixes a small resource leak in `FetchBlocksMetadata()`: if one of the resulting series metadata objects has no blocks, it is ignored, but its ID is not being returned back to the pool.