### PR TITLE
MultiReaderIterator EOF check + test

### DIFF
--- a/encoding/multi_reader_iterator.go
+++ b/encoding/multi_reader_iterator.go
@@ -169,7 +169,7 @@ func (it *multiReaderIterator) moveIteratorToValidNext(iter Iterator) bool {
 	}
 
 	err := iter.Err()
-	if it.err == nil && err != nil {
+	if it.err == nil && err != nil && err != io.EOF {
 		it.err = err
 	}
 	return false

--- a/integration/multi_reader_iterator_test.go
+++ b/integration/multi_reader_iterator_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/context"
+	"github.com/m3db/m3db/encoding"
+	"github.com/m3db/m3db/encoding/m3tsz"
+	"github.com/m3db/m3db/storage/block"
+	pseries "github.com/m3db/m3db/storage/series"
+	"github.com/m3db/m3db/ts"
+	xlog "github.com/m3db/m3x/log"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func newSeriesTestOptions() pseries.Options {
+	var timeZero time.Time
+	encoderPool := encoding.NewEncoderPool(nil)
+	multiReaderIteratorPool := encoding.NewMultiReaderIteratorPool(nil)
+
+	encodingOpts := encoding.NewOptions().SetEncoderPool(encoderPool)
+
+	encoderPool.Init(func() encoding.Encoder {
+		return m3tsz.NewEncoder(timeZero, nil, m3tsz.DefaultIntOptimizationEnabled, encodingOpts)
+	})
+	multiReaderIteratorPool.Init(func(r io.Reader) encoding.ReaderIterator {
+		return m3tsz.NewReaderIterator(r, m3tsz.DefaultIntOptimizationEnabled, encodingOpts)
+	})
+
+	opts := pseries.NewOptions().
+		SetEncoderPool(encoderPool).
+		SetMultiReaderIteratorPool(multiReaderIteratorPool)
+	opts = opts.
+		SetRetentionOptions(opts.
+			RetentionOptions().
+			SetBlockSize(2 * time.Minute).
+			SetBufferFuture(10 * time.Second).
+			SetBufferPast(10 * time.Second).
+			SetBufferDrain(30 * time.Second).
+			SetRetentionPeriod(time.Hour)).
+		SetDatabaseBlockOptions(opts.
+			DatabaseBlockOptions().
+			SetContextPool(opts.ContextPool()).
+			SetEncoderPool(opts.EncoderPool()))
+	return opts
+}
+
+func mins(x float64) time.Duration {
+	return time.Duration(x * float64(time.Minute))
+}
+
+func TestSeriesIter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSeriesTestOptions()
+	blockSize := opts.RetentionOptions().BlockSize()
+	curr := time.Now().Truncate(blockSize)
+	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+		return curr
+	}))
+
+	type value struct {
+		timestamp  time.Time
+		value      float64
+		unit       xtime.Unit
+		annotation []byte
+	}
+
+	data := []value{
+		{curr.Add(mins(1)), 2, xtime.Second, nil},
+		{curr.Add(mins(3)), 3, xtime.Second, nil},
+		{curr.Add(mins(5)), 4, xtime.Second, nil},
+		{curr.Add(mins(7)), 4, xtime.Second, nil},
+		{curr.Add(mins(9)), 4, xtime.Second, nil},
+	}
+
+	e1 := m3tsz.NewEncoder(curr, nil, false, nil)
+	for _, val := range data {
+		e1.Encode(ts.Datapoint{Timestamp: val.timestamp, Value: val.value}, val.unit, val.annotation)
+	}
+
+	ctx := context.NewContext()
+	defer ctx.Close()
+
+	b1 := block.NewDatabaseBlock(curr, e1.Discard(), opts.DatabaseBlockOptions())
+	r1, err := b1.Stream(ctx)
+	require.NoError(t, err)
+
+	logger := opts.InstrumentOptions().Logger()
+	iters := opts.MultiReaderIteratorPool().Get()
+	iters.Reset([]io.Reader{r1})
+	for iters.Next() {
+		datapoint, unit, annotation := iters.Current()
+		logger.WithFields(
+			xlog.NewLogField("datapoint", datapoint),
+			xlog.NewLogField("unit", unit),
+			xlog.NewLogField("annotation", annotation),
+		).Info("received iter value")
+	}
+	require.NoError(t, iters.Err())
+}


### PR DESCRIPTION
Addressing a weird edge case I ran into while working on some unrelated code. Looks like the MultiReaderIterator propagates EOF errs from ReaderIterator(s) below it. IMO, that shouldn't be exposed as an error on the ReaderIterator interface but one of the tests for that object had an explicit check for it. So I moved the err check to the level above it (MulitReaderIterator)

Created a new test to capture the behaviour. It's placed in integration because it depended on both storage and encoding packages. Happy to move to a better place if there is one. 

/cc @ben-lerner @robskillington @xichen2020 