### PR TITLE
Add retries and checksum & size verification for peer block streaming

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -116,7 +116,8 @@ const (
 	defaultSeriesIteratorPoolSize = 100000
 
 	// defaultFetchSeriesBlocksMaxBlockRetries is the default max retries for fetch series blocks
-	defaultFetchSeriesBlocksMaxBlockRetries = 3
+	// from a single peer
+	defaultFetchSeriesBlocksMaxBlockRetries = 2
 
 	// defaultFetchSeriesBlocksBatchSize is the default fetch series blocks batch size
 	defaultFetchSeriesBlocksBatchSize = 4096

--- a/client/options.go
+++ b/client/options.go
@@ -31,9 +31,9 @@ import (
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/encoding"
 	"github.com/m3db/m3db/encoding/m3tsz"
+	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
-	"github.com/m3db/m3db/topology"
 
 	"github.com/uber/tchannel-go"
 )
@@ -115,6 +115,9 @@ const (
 	// defaultSeriesIteratorPoolSize is the default size of the series iterator pools
 	defaultSeriesIteratorPoolSize = 100000
 
+	// defaultFetchSeriesBlocksMaxBlockRetries is the default max retries for fetch series blocks
+	defaultFetchSeriesBlocksMaxBlockRetries = 3
+
 	// defaultFetchSeriesBlocksBatchSize is the default fetch series blocks batch size
 	defaultFetchSeriesBlocksBatchSize = 4096
 
@@ -172,6 +175,7 @@ type options struct {
 	seriesIteratorArrayPoolBuckets          []pool.Bucket
 	contextPool                             context.Pool
 	origin                                  topology.Host
+	fetchSeriesBlocksMaxBlockRetries        int
 	fetchSeriesBlocksBatchSize              int
 	fetchSeriesBlocksMetadataBatchTimeout   time.Duration
 	fetchSeriesBlocksBatchTimeout           time.Duration
@@ -219,6 +223,7 @@ func newOptions() *options {
 		seriesIteratorPoolSize:                  defaultSeriesIteratorPoolSize,
 		seriesIteratorArrayPoolBuckets:          defaultSeriesIteratorArrayPoolBuckets,
 		contextPool:                             context.NewPool(nil, nil),
+		fetchSeriesBlocksMaxBlockRetries:        defaultFetchSeriesBlocksMaxBlockRetries,
 		fetchSeriesBlocksBatchSize:              defaultFetchSeriesBlocksBatchSize,
 		fetchSeriesBlocksMetadataBatchTimeout:   defaultFetchSeriesBlocksMetadataBatchTimeout,
 		fetchSeriesBlocksBatchTimeout:           defaultFetchSeriesBlocksBatchTimeout,
@@ -564,6 +569,16 @@ func (o *options) SetOrigin(value topology.Host) AdminOptions {
 
 func (o *options) Origin() topology.Host {
 	return o.origin
+}
+
+func (o *options) SetFetchSeriesBlocksMaxBlockRetries(value int) AdminOptions {
+	opts := *o
+	opts.fetchSeriesBlocksMaxBlockRetries = value
+	return &opts
+}
+
+func (o *options) FetchSeriesBlocksMaxBlockRetries() int {
+	return o.fetchSeriesBlocksMaxBlockRetries
 }
 
 func (o *options) SetFetchSeriesBlocksBatchSize(value int) AdminOptions {

--- a/client/session.go
+++ b/client/session.go
@@ -1749,7 +1749,7 @@ func (s *session) streamBlocksBatchFromPeer(
 	}); err != nil {
 		m.fetchBlockError.Inc(reqBlocksLen)
 		s.log.WithFields(
-			xlog.NewLogField("error", err),
+			xlog.NewLogField("error", err.Error()),
 			xlog.NewLogField("peer", peer.Host().String()),
 		).Errorf("stream blocks request error")
 		for i := range batch {
@@ -1835,7 +1835,7 @@ func (s *session) streamBlocksBatchFromPeer(
 				s.log.WithFields(
 					xlog.NewLogField("id", id.String()),
 					xlog.NewLogField("start", block.Start),
-					xlog.NewLogField("error", err),
+					xlog.NewLogField("error", err.Error()),
 					xlog.NewLogField("indexID", i),
 					xlog.NewLogField("indexBlock", j),
 					xlog.NewLogField("peer", peer.Host().String()),

--- a/client/session.go
+++ b/client/session.go
@@ -1867,20 +1867,12 @@ func (s *session) verifyFetchedBlock(block *rpc.Block, metadata blockMetadata) e
 		digest := s.digestPool.Get().(hash.Hash32)
 		digest.Reset()
 		if block.Segments.Merged != nil {
-			if block.Segments.Merged.Head != nil {
-				digest.Write(block.Segments.Merged.Head)
-			}
-			if block.Segments.Merged.Tail != nil {
-				digest.Write(block.Segments.Merged.Tail)
-			}
+			digest.Write(block.Segments.Merged.Head)
+			digest.Write(block.Segments.Merged.Tail)
 		} else {
 			for _, segment := range block.Segments.Unmerged {
-				if segment.Head != nil {
-					digest.Write(segment.Head)
-				}
-				if segment.Tail != nil {
-					digest.Write(segment.Tail)
-				}
+				digest.Write(segment.Head)
+				digest.Write(segment.Tail)
 			}
 		}
 		actual := digest.Sum32()

--- a/client/session_bootstrap_blocks_test.go
+++ b/client/session_bootstrap_blocks_test.go
@@ -520,7 +520,8 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	opts := newSessionTestAdminOptions()
+	opts := newSessionTestAdminOptions().
+		SetFetchSeriesBlocksMaxBlockRetries(0)
 	s, err := newSession(opts)
 	assert.NoError(t, err)
 	session := s.(*session)
@@ -594,6 +595,8 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	assert.Equal(t, 0, len(perPeer[2].blocks))
 }
 
+// TODO: add test TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries
+
 func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -613,7 +616,9 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 	var (
 		blockSize = 2 * time.Hour
 		start     = time.Now().Truncate(blockSize).Add(blockSize * -(24 - 1))
-		retrier   = xretry.NewRetrier(xretry.NewOptions().SetMax(1).SetInitialBackoff(time.Millisecond))
+		retrier   = xretry.NewRetrier(xretry.NewOptions().
+				SetMaxRetries(1).
+				SetInitialBackoff(time.Millisecond))
 		peerIdx   = len(mockHostQueues) - 1
 		peer      = mockHostQueues[peerIdx]
 		client    = mockClients[peerIdx]
@@ -664,6 +669,16 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 
 	assert.NoError(t, session.Close())
 }
+
+// TODO: add test TestStreamBlocksBatchFromPeerVerifiesBlockErr
+
+// TODO: add test TestVerifyFetchedBlockSegmentsNil
+
+// TODO: add test TestVerifyFetchedBlockSegmentsNoMergedOrUnmerged
+
+// TODO: add test TestVerifyFetchedBlockChecksum
+
+// TODO: add test TestVerifyFetchedBlockSize
 
 func TestBlocksResultAddBlockFromPeerReadMerged(t *testing.T) {
 	opts := newSessionTestAdminOptions()
@@ -795,6 +810,8 @@ func TestBlocksResultAddBlockFromPeerReadUnmerged(t *testing.T) {
 	assert.Equal(t, len(all), asserted)
 	assert.NoError(t, iter.Err())
 }
+
+// TODO: add test TestBlocksResultAddBlockFromPeerMergeExistingResult
 
 func TestBlocksResultAddBlockFromPeerErrorOnNoSegments(t *testing.T) {
 	opts := newSessionTestAdminOptions()

--- a/client/session_bootstrap_blocks_test.go
+++ b/client/session_bootstrap_blocks_test.go
@@ -40,12 +40,14 @@ import (
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3db/x/io"
+	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/retry"
 	"github.com/m3db/m3x/sync"
 	"github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -540,7 +542,10 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 		blocksMetadataQueues    []blocksMetadataQueue
 		start                   = timeZero
 		checksum                = uint32(2)
-		reattempt               = blockMetadataReattempt{
+		// First block should be fetched from the first peer and the second
+		// block should be avoided being fetched at all as all peers already
+		// attempted
+		reattempt = blockMetadataReattempt{
 			attempt:   3,
 			id:        fooID,
 			attempted: []peer{peerA, peerB, peerC},
@@ -579,7 +584,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 		currStart, currEligible, blocksMetadataQueues)
 
 	// Assert selection first peer
-	assert.Equal(t, 1, len(perPeer[0].blocks))
+	require.Equal(t, 1, len(perPeer[0].blocks))
 
 	assert.Equal(t, start, perPeer[0].blocks[0].start)
 	assert.Equal(t, int64(2), perPeer[0].blocks[0].size)
@@ -595,7 +600,87 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	assert.Equal(t, 0, len(perPeer[2].blocks))
 }
 
-// TODO: add test TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries
+func TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestAdminOptions().
+		SetFetchSeriesBlocksMaxBlockRetries(2)
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+	session := s.(*session)
+
+	var (
+		peerA            = NewMockpeer(ctrl)
+		peerB            = NewMockpeer(ctrl)
+		peers            = preparedMockPeers(peerA, peerB)
+		peerBlocksQueues = mockPeerBlocksQueues(peers, opts)
+	)
+	atomic.StoreUint64(&peerBlocksQueues[0].assigned, 16)
+	atomic.StoreUint64(&peerBlocksQueues[1].assigned, 0)
+	defer peerBlocksQueues.closeAll()
+
+	var (
+		currStart, currEligible []*blocksMetadata
+		blocksMetadataQueues    []blocksMetadataQueue
+		start                   = timeZero
+		checksum                = uint32(2)
+		// Peer A has 2 attempts, peer B has 1 attempt, peer B should be selected
+		// for the second block as it has one retry remaining.  The first block
+		// should select peer B to retrieve as we synthetically set the assigned
+		// blocks count for peer A much higher than peer B.
+		reattempt = blockMetadataReattempt{
+			attempt:   3,
+			id:        fooID,
+			attempted: []peer{peerA, peerB, peerA},
+		}
+		perPeer = []*blocksMetadata{
+			&blocksMetadata{
+				peer: peerA,
+				id:   fooID,
+				blocks: []blockMetadata{
+					{start: start, size: 2, checksum: &checksum},
+					{start: start.Add(time.Hour * 2), size: 2, checksum: &checksum, reattempt: reattempt},
+				},
+			},
+			&blocksMetadata{
+				peer: peerB,
+				id:   fooID,
+				blocks: []blockMetadata{
+					{start: start, size: 2, checksum: &checksum},
+					{start: start.Add(time.Hour * 2), size: 2, checksum: &checksum, reattempt: reattempt},
+				},
+			},
+		}
+	)
+
+	// Perform selection
+	session.selectBlocksForSeriesFromPeerBlocksMetadata(
+		perPeer, peerBlocksQueues,
+		currStart, currEligible, blocksMetadataQueues)
+
+	// Assert selection first peer
+	assert.Equal(t, 0, len(perPeer[0].blocks))
+
+	// Assert selection second peer
+	require.Equal(t, 2, len(perPeer[1].blocks))
+
+	// Assert first block second peer
+	assert.Equal(t, start, perPeer[1].blocks[0].start)
+	assert.Equal(t, int64(2), perPeer[1].blocks[0].size)
+	assert.Equal(t, &checksum, perPeer[1].blocks[0].checksum)
+
+	assert.Equal(t, 1, perPeer[1].blocks[0].reattempt.attempt)
+	assert.Equal(t, []peer{peerB}, perPeer[1].blocks[0].reattempt.attempted)
+
+	// Assert first block second peer
+	assert.Equal(t, start.Add(time.Hour*2), perPeer[1].blocks[1].start)
+	assert.Equal(t, int64(2), perPeer[1].blocks[1].size)
+	assert.Equal(t, &checksum, perPeer[1].blocks[1].checksum)
+
+	assert.Equal(t, 4, perPeer[1].blocks[1].reattempt.attempt)
+	assert.Equal(t, []peer{peerA, peerB, peerA, peerB}, perPeer[1].blocks[1].reattempt.attempted)
+}
 
 func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -640,13 +725,13 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 			}},
 			&blocksMetadata{id: barID, blocks: []blockMetadata{
 				{start: start, size: 2, reattempt: blockMetadataReattempt{
-					id: fooID,
+					id: barID,
 					peersMetadata: []blockMetadataReattemptPeerMetadata{
 						{start: start, size: 2},
 					},
 				}},
 				{start: start.Add(blockSize), size: 2, reattempt: blockMetadataReattempt{
-					id: fooID,
+					id: barID,
 					peersMetadata: []blockMetadataReattemptPeerMetadata{
 						{start: start.Add(blockSize), size: 2},
 					},
@@ -670,7 +755,128 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 	assert.NoError(t, session.Close())
 }
 
-// TODO: add test TestStreamBlocksBatchFromPeerVerifiesBlockErr
+func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestAdminOptions()
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+	session := s.(*session)
+
+	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
+	session.newHostQueueFn = mockHostQueues.newHostQueueFn()
+	// Ensure work enqueued immediately so can test result of the reenqueue
+	session.streamBlocksReattemptWorkers = newSynchronousWorkerPool()
+
+	assert.NoError(t, session.Open())
+
+	blockSize := 2 * time.Hour
+	start := time.Now().Truncate(blockSize).Add(blockSize * -(24 - 1))
+
+	enc := m3tsz.NewEncoder(start, nil, true, encoding.NewOptions())
+	require.NoError(t, enc.Encode(ts.Datapoint{
+		Timestamp: start.Add(10 * time.Second),
+		Value:     42,
+	}, xtime.Second, nil))
+	reader := enc.Stream()
+	require.NotNil(t, reader)
+	segment := reader.Segment()
+	rawBlockData := make([]byte, segment.Len())
+	n, err := reader.Read(rawBlockData)
+	require.NoError(t, err)
+	require.Equal(t, len(rawBlockData), n)
+	rawBlockLen := int64(len(rawBlockData))
+
+	var (
+		retrier = xretry.NewRetrier(xretry.NewOptions().
+			SetMaxRetries(1).
+			SetInitialBackoff(time.Millisecond))
+		peerIdx       = len(mockHostQueues) - 1
+		peer          = mockHostQueues[peerIdx]
+		client        = mockClients[peerIdx]
+		enqueueCh     = newEnqueueChannel(session.streamFromPeersMetricsForShard(0))
+		blockChecksum = digest.Checksum(rawBlockData)
+		batch         = []*blocksMetadata{
+			&blocksMetadata{id: fooID, blocks: []blockMetadata{
+				{start: start, size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: fooID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start, size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+			}},
+			&blocksMetadata{id: barID, blocks: []blockMetadata{
+				{start: start, size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: barID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start, size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+				{start: start.Add(blockSize), size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: barID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start.Add(blockSize), size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+			}},
+		}
+	)
+
+	// Fail the call twice due to retry
+	client.EXPECT().
+		FetchBlocksRaw(gomock.Any(), gomock.Any()).
+		Return(&rpc.FetchBlocksRawResult_{
+			Elements: []*rpc.Blocks{
+				// First foo block intact
+				&rpc.Blocks{ID: []byte("foo"), Blocks: []*rpc.Block{
+					&rpc.Block{Start: start.UnixNano(), Segments: &rpc.Segments{
+						Merged: &rpc.Segment{
+							Head: rawBlockData[:len(rawBlockData)-1],
+							Tail: []byte{rawBlockData[len(rawBlockData)-1]},
+						},
+					}},
+				}},
+				// First bar block with error, second intact
+				&rpc.Blocks{ID: []byte("bar"), Blocks: []*rpc.Block{
+					&rpc.Block{Start: start.UnixNano(), Segments: &rpc.Segments{
+						Merged: &rpc.Segment{
+							Head: rawBlockData[:len(rawBlockData)-1],
+							Tail: []byte{rawBlockData[len(rawBlockData)-1]},
+						},
+					}},
+					&rpc.Block{Start: start.Add(blockSize).UnixNano(), Err: &rpc.Error{
+						Type:    rpc.ErrorType_INTERNAL_ERROR,
+						Message: "an error",
+					}},
+				}},
+			},
+		}, nil)
+
+	// Attempt stream blocks
+	ropts := retention.NewOptions().SetBlockSize(blockSize).SetRetentionPeriod(48 * blockSize)
+	bopts := bootstrap.NewOptions().SetRetentionOptions(ropts)
+	m := session.streamFromPeersMetricsForShard(0)
+	poolOpts := pool.NewObjectPoolOptions().SetSize(0)
+	multiReaderIteratorPool := encoding.NewMultiReaderIteratorPool(poolOpts)
+	multiReaderIteratorPool.Init(func(r io.Reader) encoding.ReaderIterator {
+		return m3tsz.NewReaderIterator(r, true, encoding.NewOptions())
+	})
+	r := newBlocksResult(opts, bopts, multiReaderIteratorPool)
+	session.streamBlocksBatchFromPeer(nsID, 0, peer, batch, bopts, r, enqueueCh, retrier, m)
+
+	// Assert result
+	assertEnqueueChannel(t, batch[1].blocks[1:], enqueueCh)
+
+	// Assert length of blocks result
+	assert.Equal(t, 2, len(r.result.AllSeries()))
+	assert.Equal(t, 1, r.result.AllSeries()[fooID.Hash()].Blocks.Len())
+	assert.Equal(t, 1, r.result.AllSeries()[barID.Hash()].Blocks.Len())
+
+	assert.NoError(t, session.Close())
+}
+
+// TODO: add test TestStreamBlocksBatchFromPeerDoesNotRetryOnUnreachable
 
 // TODO: add test TestVerifyFetchedBlockSegmentsNil
 

--- a/client/session_truncate_test.go
+++ b/client/session_truncate_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+// TODO: add truncate tests

--- a/client/types.go
+++ b/client/types.go
@@ -492,6 +492,12 @@ type AdminOptions interface {
 	// Origin gets the current host originating requests from
 	Origin() topology.Host
 
+	// SetFetchSeriesBlocksMaxBlockRetries sets the max retries for fetching series blocks
+	SetFetchSeriesBlocksMaxBlockRetries(value int) AdminOptions
+
+	// FetchSeriesBlocksMaxBlockRetries gets the max retries for fetching series blocks
+	FetchSeriesBlocksMaxBlockRetries() int
+
 	// SetFetchSeriesBlocksBatchSize sets the batch size for fetching series blocks in batch
 	SetFetchSeriesBlocksBatchSize(value int) AdminOptions
 


### PR DESCRIPTION
This change adds checking and verification to the checksums and sizes when peer bootstrapping.  This means if there is any interference either inside the process itself or during network transfer for the block itself the error is identified and also retried on top of to ensure it does not corrupt nor fatally stall the bootstrapping.

cc @kobolog @xichen2020 @martin-mao @prateek 