### PR TITLE
Remove block size verification for streamed blocks, latest block size changes

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -1996,18 +1996,6 @@ func (s *session) verifyFetchedBlock(block *rpc.Block, metadata blockMetadata) e
 		}
 	}
 
-	var size int
-	if block.Segments.Merged != nil {
-		size = len(block.Segments.Merged.Head) + len(block.Segments.Merged.Tail)
-	} else {
-		for _, segment := range block.Segments.Unmerged {
-			size += len(segment.Head) + len(segment.Tail)
-		}
-	}
-	if size != int(metadata.size) {
-		return fmt.Errorf("block size is bad: expected=%d, actual=%d", metadata.size, size)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The latest block changes its size constantly as it's being written so this doesn't always match the size sent when streaming metadata.

The checksum verification will catch any size mismatch anyhow, so this check is superfluous.  The latest block always has a nil checksum so this issue doesn't affect it.

cc @xichen2020 @kobolog 