### PR TITLE
Remove double frees in series.mergeBlock()

### DIFF
--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -394,8 +394,6 @@ func (s *dbSeries) mergeBlock(
 		return nil
 	}
 
-	defer newBlockReader.Close()
-
 	existingBlockReader, err := existingBlock.Stream(ctx)
 	if err != nil {
 		return err
@@ -405,8 +403,6 @@ func (s *dbSeries) mergeBlock(
 		blocks.AddBlock(newBlock)
 		return nil
 	}
-
-	defer existingBlockReader.Close()
 
 	var readers [2]io.Reader
 	readers[0] = newBlockReader


### PR DESCRIPTION
The ctx registers the reader, so it's Close() call also closes the reader. This makes the explicit deferred Close() calls double frees.

/cc @robskillington @xichen2020 @cw9 