### PR TITLE
Fix fs writer not being nil aware of the checked bytes array

### DIFF
--- a/persist/fs/write.go
+++ b/persist/fs/write.go
@@ -148,6 +148,9 @@ func (w *writer) WriteAll(id ts.ID, data []checked.Bytes) error {
 func (w *writer) writeAll(id ts.ID, data []checked.Bytes) error {
 	var size int64
 	for _, d := range data {
+		if d == nil {
+			continue
+		}
 		size += int64(d.Len())
 	}
 	if size == 0 {
@@ -180,6 +183,9 @@ func (w *writer) writeAll(id ts.ID, data []checked.Bytes) error {
 		return err
 	}
 	for _, d := range data {
+		if d == nil {
+			continue
+		}
 		if err := w.writeData(d.Get()); err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes an issue when head and tail of a `ts.Segment` is passed directly into the second argument of the fs Writer `WriteAll(id ts.ID, data []checked.Bytes)` call.

cc @prateek @xichen2020 @kobolog @ben-lerner 