### PR TITLE
Cleanup persist/fs.ReadInfoFile usage

### DIFF
--- a/persist/fs/files.go
+++ b/persist/fs/files.go
@@ -161,8 +161,7 @@ func TimeAndIndexFromFileName(fname string) (time.Time, int, error) {
 
 type infoFileFn func(fname string, infoData []byte)
 
-// ForEachInfoFile iterates over each valid info file and applies the function passed in.
-func ForEachInfoFile(filePathPrefix string, namespace ts.ID, shard uint32, readerBufferSize int, fn infoFileFn) {
+func forEachInfoFile(filePathPrefix string, namespace ts.ID, shard uint32, readerBufferSize int, fn infoFileFn) {
 	matched, err := filesetFiles(filePathPrefix, namespace, shard, infoFilePattern)
 	if err != nil {
 		return
@@ -207,7 +206,7 @@ func ForEachInfoFile(filePathPrefix string, namespace ts.ID, shard uint32, reade
 // ReadInfoFiles reads all the valid info entries.
 func ReadInfoFiles(filePathPrefix string, namespace ts.ID, shard uint32, readerBufferSize int) []*schema.IndexInfo {
 	var indexEntries []*schema.IndexInfo
-	ForEachInfoFile(filePathPrefix, namespace, shard, readerBufferSize, func(_ string, data []byte) {
+	forEachInfoFile(filePathPrefix, namespace, shard, readerBufferSize, func(_ string, data []byte) {
 		info, err := readInfo(data)
 		if err != nil {
 			return

--- a/persist/fs/files_test.go
+++ b/persist/fs/files_test.go
@@ -208,7 +208,7 @@ func TestForEachInfoFile(t *testing.T) {
 
 	var fnames []string
 	var res []byte
-	ForEachInfoFile(dir, testNamespaceID, shard, testReaderBufferSize, func(fname string, data []byte) {
+	forEachInfoFile(dir, testNamespaceID, shard, testReaderBufferSize, func(fname string, data []byte) {
 		fnames = append(fnames, fname)
 		res = append(res, data...)
 	})

--- a/persist/fs/read_write_test.go
+++ b/persist/fs/read_write_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/checked"
+	"github.com/m3db/m3x/time"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,6 +99,31 @@ func TestSimpleReadWrite(t *testing.T) {
 
 	r := newTestReader(filePathPrefix)
 	readTestData(t, r, 0, testWriterStart, entries)
+}
+
+func TestInfoReadWrite(t *testing.T) {
+	dir := createTempDir(t)
+	filePathPrefix := filepath.Join(dir, "")
+	defer os.RemoveAll(dir)
+
+	entries := []testEntry{
+		{"foo", []byte{1, 2, 3}},
+		{"bar", []byte{4, 5, 6}},
+		{"baz", make([]byte, 65536)},
+		{"cat", make([]byte, 100000)},
+		{"echo", []byte{7, 8, 9}},
+	}
+
+	w := newTestWriter(filePathPrefix)
+	writeTestData(t, w, 0, testWriterStart, entries)
+
+	infoFiles := ReadInfoFiles(filePathPrefix, testNamespaceID, 0, 16)
+	require.Equal(t, 1, len(infoFiles))
+
+	infoFile := infoFiles[0]
+	require.True(t, testWriterStart.Equal(xtime.FromNanoseconds(infoFile.Start)))
+	require.Equal(t, testBlockSize, time.Duration(infoFile.BlockSize))
+	require.Equal(t, int64(len(entries)), infoFile.Entries)
 }
 
 func TestReusingReaderWriter(t *testing.T) {

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -116,11 +116,7 @@ func (s *fileSystemSource) enqueueReaders(
 	readersCh chan<- shardReaders,
 ) {
 	for shard, tr := range shardsTimeRanges {
-		var files []string
-		fs.ForEachInfoFile(s.filePathPrefix, namespace, shard, s.readerBufferSize, func(fname string, _ []byte) {
-			files = append(files, fname)
-		})
-
+		files := fs.ReadInfoFiles(s.filePathPrefix, namespace, shard, s.readerBufferSize)
 		if len(files) == 0 {
 			// Use default readers value to indicate no readers for this shard
 			readersCh <- shardReaders{shard: shard, tr: tr}
@@ -129,16 +125,8 @@ func (s *fileSystemSource) enqueueReaders(
 
 		readers := make([]fs.FileSetReader, 0, len(files))
 		for i := 0; i < len(files); i++ {
-			t, err := fs.TimeFromFileName(files[i])
-			if err != nil {
-				s.log.WithFields(
-					xlog.NewLogField("shard", shard),
-					xlog.NewLogField("file", files[i]),
-					xlog.NewLogField("error", err.Error()),
-				).Error("unable to get time from info file")
-				continue
-			}
 			r := readerPool.get()
+			t := xtime.FromNanoseconds(files[i].Start)
 			if err := r.Open(namespace, shard, t); err != nil {
 				s.log.WithFields(
 					xlog.NewLogField("shard", shard),


### PR DESCRIPTION
tiny changes: 
- Make fs bootstrapper read start from protobuf records within Info file rather than the filename. 
- Add a unit test for Info file read/write coverage


/cc @robskillington @xichen2020 