### PR TITLE
Investigate deadlock in session.go FetchBlocksFromPeers 

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -122,6 +122,7 @@ type session struct {
 	digestPool                       sync.Pool
 	fetchBatchSize                   int
 	newPeerBlocksQueueFn             newPeerBlocksQueueFn
+	reattemptStreamBlocksFromPeersFn reattemptStreamBlocksFromPeersFn
 	origin                           topology.Host
 	streamBlocksMaxBlockRetries      int
 	streamBlocksWorkers              xsync.WorkerPool
@@ -200,6 +201,7 @@ func newSession(opts Options) (clientSession, error) {
 		newPeerBlocksQueueFn: newPeerBlocksQueue,
 		metrics:              newSessionMetrics(scope),
 	}
+	s.reattemptStreamBlocksFromPeersFn = s.streamBlocksReattemptFromPeers
 	s.writeStatePool = sync.Pool{New: func() interface{} {
 		w := &writeState{session: s}
 		w.reset()
@@ -1861,7 +1863,7 @@ func (s *session) streamBlocksBatchFromPeer(
 		).Errorf("stream blocks request error")
 		for i := range batch {
 			b := batch[i].blocks
-			s.streamBlocksReattemptFromPeers(b, enqueueCh, reqErrReason, m)
+			s.reattemptStreamBlocksFromPeersFn(b, enqueueCh, reqErrReason, m)
 		}
 		return
 	}
@@ -1883,7 +1885,7 @@ func (s *session) streamBlocksBatchFromPeer(
 		id := batch[i].id
 		if !bytes.Equal(id.Data().Get(), result.Elements[i].ID) {
 			b := batch[i].blocks
-			s.streamBlocksReattemptFromPeers(b, enqueueCh, respErrReason, m)
+			s.reattemptStreamBlocksFromPeersFn(b, enqueueCh, respErrReason, m)
 			m.fetchBlockError.Inc(int64(len(req.Elements[i].Starts)))
 			s.log.WithFields(
 				xlog.NewLogField("expectedID", batch[i].id),
@@ -1929,7 +1931,7 @@ func (s *session) streamBlocksBatchFromPeer(
 
 			if err != nil {
 				failed := []blockMetadata{batch[i].blocks[j]}
-				s.streamBlocksReattemptFromPeers(failed, enqueueCh, respErrReason, m)
+				s.reattemptStreamBlocksFromPeersFn(failed, enqueueCh, respErrReason, m)
 				m.fetchBlockError.Inc(1)
 				s.log.WithFields(
 					xlog.NewLogField("id", id.String()),
@@ -1987,6 +1989,8 @@ const (
 	respErrReason
 )
 
+type reattemptStreamBlocksFromPeersFn func([]blockMetadata, *enqueueChannel, reason, *streamFromPeersMetrics)
+
 func (s *session) streamBlocksReattemptFromPeers(
 	blocks []blockMetadata,
 	enqueueCh *enqueueChannel,
@@ -2005,27 +2009,32 @@ func (s *session) streamBlocksReattemptFromPeers(
 	// getting done because new attempts are blocked on existing attempts completing
 	// and existing attempts are trying to enqueue into a full reattempt channel
 	enqueue := enqueueCh.enqueueDelayed()
-	go func() {
-		for i := range blocks {
-			// Reconstruct peers metadata for reattempt
-			reattemptBlocksMetadata :=
-				make([]*blocksMetadata, len(blocks[i].reattempt.peersMetadata))
-			for j := range reattemptBlocksMetadata {
-				reattemptBlocksMetadata[j] = &blocksMetadata{
-					peer: blocks[i].reattempt.peersMetadata[j].peer,
-					id:   blocks[i].reattempt.id,
-					blocks: []blockMetadata{blockMetadata{
-						start:     blocks[i].reattempt.peersMetadata[j].start,
-						size:      blocks[i].reattempt.peersMetadata[j].size,
-						checksum:  blocks[i].reattempt.peersMetadata[j].checksum,
-						reattempt: blocks[i].reattempt,
-					}},
-				}
+	go s.streamBlocksReattemptFromPeersEnqueue(blocks, enqueue)
+}
+
+func (s *session) streamBlocksReattemptFromPeersEnqueue(
+	blocks []blockMetadata,
+	enqueueFn func([]*blocksMetadata),
+) {
+	for i := range blocks {
+		// Reconstruct peers metadata for reattempt
+		reattemptBlocksMetadata :=
+			make([]*blocksMetadata, len(blocks[i].reattempt.peersMetadata))
+		for j := range reattemptBlocksMetadata {
+			reattemptBlocksMetadata[j] = &blocksMetadata{
+				peer: blocks[i].reattempt.peersMetadata[j].peer,
+				id:   blocks[i].reattempt.id,
+				blocks: []blockMetadata{blockMetadata{
+					start:     blocks[i].reattempt.peersMetadata[j].start,
+					size:      blocks[i].reattempt.peersMetadata[j].size,
+					checksum:  blocks[i].reattempt.peersMetadata[j].checksum,
+					reattempt: blocks[i].reattempt,
+				}},
 			}
-			// Re-enqueue the block to be fetched
-			enqueue(reattemptBlocksMetadata)
 		}
-	}()
+		// Re-enqueue the block to be fetched
+		enqueueFn(reattemptBlocksMetadata)
+	}
 }
 
 type blocksResult interface {

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -1220,6 +1220,9 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 	r := newBulkBlocksResult(opts, bopts)
 	session.streamBlocksBatchFromPeer(nsID, 0, peer, batch, bopts, r, enqueueCh, retrier, m)
 
+	// need the sleep to yield the current go routine to any pending reattempt routines
+	time.Sleep(time.Millisecond)
+
 	// Assert result
 	assertEnqueueChannel(t, batch[1].blocks[1:], enqueueCh)
 

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -1250,6 +1250,10 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 	s, err := newSession(opts)
 	assert.NoError(t, err)
 	session := s.(*session)
+	session.reattemptStreamBlocksFromPeersFn = func(blocks []blockMetadata, enqueueCh *enqueueChannel, _ reason, _ *streamFromPeersMetrics) {
+		enqueue := enqueueCh.enqueueDelayed()
+		session.streamBlocksReattemptFromPeersEnqueue(blocks, enqueue)
+	}
 
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
 	session.newHostQueueFn = mockHostQueues.newHostQueueFn()


### PR DESCRIPTION
Observed that some m3db nodes get stuck in "repairing" state, only recovering after a restart. 

Stack trace shows the repairer is stuck waiting on data to come through. 
```
chan receive [1171 minutes] [Created by sync.(*workerPool).Go @ .:0]
    client  session.go:2219     (*peerBlocksIter).Next(0xcd0df2a6c0, 0xcace5e1450)
    storage repair.go:333       shardRepairer.repairDifferences(0xf8f6e0, #3, 0xf8c800, #6, 0xf8c680, #4, #11, #5, #8, 0, ...)
    storage repair.go:91        repairDifferences)-fm(0xf88c80, #7, 0xf8c740, #9, 0x26f85, 0x26f85, 0xf882c0, 0xc8ddb58480, 0xf882c0, 0xc8ddb584e0, ...)
    storage repair.go:140       shardRepairer.Repair(0xf8f6e0, #3, 0xf8c800, #6, 0xf8c680, #4, #11, #5, #8, 0xc8675d8b40, ...)
    storage <autogenerated>:194 (*shardRepairer).Repair(0xc86733ec00, 0xf888c0, #10, 0xf88c80, #7, #1, 0, 0xfbc960, #2, 0, ...)
    storage shard.go:763        (*dbShard).Repair(#9, 0xf888c0, #10, 0xf88c80, #7, #1, 0, 0xfbc960, #2, 0, ...)
    storage namespace.go:574    (*dbNamespace).Repair.func1()
    sync    worker_pool.go:64   (*workerPool).Go.func1(0xcb80638b60, 0xc9bcf920c8)
```

Another thing to point out: only nodes that exhibited a lot of checksum errors (caused due to lack of #217) got into this state. Nodes that didn't run into checksum errors were fine. 

Full stack trace - [stack.1485109327.gz](https://github.com/m3db/m3db/files/722182/stack.1485109327.gz)

