### PR TITLE
Send the checksum of the block when returning it for streaming

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -1925,7 +1925,7 @@ func (s *session) streamBlocksBatchFromPeer(
 			}
 
 			// Verify and if verify succeeds add the block from the peer
-			err := s.verifyFetchedBlock(block, batch[i].blocks[j])
+			err := s.verifyFetchedBlock(block)
 			if err == nil {
 				err = blocksResult.addBlockFromPeer(id, peer.Host(), block)
 			}
@@ -1950,7 +1950,7 @@ func (s *session) streamBlocksBatchFromPeer(
 	}
 }
 
-func (s *session) verifyFetchedBlock(block *rpc.Block, metadata blockMetadata) error {
+func (s *session) verifyFetchedBlock(block *rpc.Block) error {
 	if block.Err != nil {
 		return fmt.Errorf("block error from peer: %s %s", block.Err.Type.String(), block.Err.Message)
 	}
@@ -1961,8 +1961,8 @@ func (s *session) verifyFetchedBlock(block *rpc.Block, metadata blockMetadata) e
 		return fmt.Errorf("block segments is bad: merged and unmerged not set")
 	}
 
-	if metadata.checksum != nil {
-		expected := *metadata.checksum
+	if block.Checksum != nil {
+		expected := uint32(*block.Checksum)
 		digest := s.digestPool.Get().(hash.Hash32)
 		digest.Reset()
 		if block.Segments.Merged != nil {

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -1240,7 +1240,137 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 
 // TODO: add test TestVerifyFetchedBlockSegmentsNoMergedOrUnmerged
 
-// TODO: add test TestVerifyFetchedBlockChecksum
+func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestAdminOptions()
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+	session := s.(*session)
+
+	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
+	session.newHostQueueFn = mockHostQueues.newHostQueueFn()
+	// Ensure work enqueued immediately so can test result of the reenqueue
+	session.streamBlocksReattemptWorkers = newSynchronousWorkerPool()
+
+	assert.NoError(t, session.Open())
+
+	blockSize := 2 * time.Hour
+	start := time.Now().Truncate(blockSize).Add(blockSize * -(24 - 1))
+
+	enc := m3tsz.NewEncoder(start, nil, true, encoding.NewOptions())
+	require.NoError(t, enc.Encode(ts.Datapoint{
+		Timestamp: start.Add(10 * time.Second),
+		Value:     42,
+	}, xtime.Second, nil))
+	reader := enc.Stream()
+	require.NotNil(t, reader)
+	segment := reader.Segment()
+	rawBlockData := make([]byte, segment.Len())
+	n, err := reader.Read(rawBlockData)
+	require.NoError(t, err)
+	require.Equal(t, len(rawBlockData), n)
+	rawBlockLen := int64(len(rawBlockData))
+
+	var (
+		retrier = xretry.NewRetrier(xretry.NewOptions().
+			SetMaxRetries(1).
+			SetInitialBackoff(time.Millisecond))
+		peerIdx       = len(mockHostQueues) - 1
+		peer          = mockHostQueues[peerIdx]
+		client        = mockClients[peerIdx]
+		enqueueCh     = newEnqueueChannel(session.streamFromPeersMetricsForShard(0, resultTypeTest))
+		blockChecksum = digest.Checksum(rawBlockData)
+		batch         = []*blocksMetadata{
+			&blocksMetadata{id: fooID, blocks: []blockMetadata{
+				{start: start, size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: fooID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start, size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+			}},
+			&blocksMetadata{id: barID, blocks: []blockMetadata{
+				{start: start, size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: barID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start, size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+				{start: start.Add(blockSize), size: rawBlockLen, reattempt: blockMetadataReattempt{
+					id: barID,
+					peersMetadata: []blockMetadataReattemptPeerMetadata{
+						{start: start.Add(blockSize), size: rawBlockLen, checksum: &blockChecksum},
+					},
+				}},
+			}},
+		}
+	)
+
+	head := rawBlockData[:len(rawBlockData)-1]
+	tail := []byte{rawBlockData[len(rawBlockData)-1]}
+	di := digest.NewDigest()
+	_, err = di.Write(head)
+	require.NoError(t, err)
+	_, err = di.Write(tail)
+	require.NoError(t, err)
+	validChecksum := int64(di.Sum32())
+	invalidChecksum := 1 + validChecksum
+
+	client.EXPECT().
+		FetchBlocksRaw(gomock.Any(), gomock.Any()).
+		Return(&rpc.FetchBlocksRawResult_{
+			Elements: []*rpc.Blocks{
+				// valid foo block
+				&rpc.Blocks{ID: []byte("foo"), Blocks: []*rpc.Block{
+					&rpc.Block{Start: start.UnixNano(), Checksum: &validChecksum, Segments: &rpc.Segments{
+						Merged: &rpc.Segment{
+							Head: head,
+							Tail: tail,
+						},
+					}},
+				}},
+				&rpc.Blocks{ID: []byte("bar"), Blocks: []*rpc.Block{
+					// invalid bar block
+					&rpc.Block{Start: start.UnixNano(), Checksum: &invalidChecksum, Segments: &rpc.Segments{
+						Merged: &rpc.Segment{
+							Head: head,
+							Tail: tail,
+						},
+					}},
+					// valid bar block, no checksum
+					&rpc.Block{Start: start.Add(blockSize).UnixNano(), Segments: &rpc.Segments{
+						Merged: &rpc.Segment{
+							Head: head,
+							Tail: tail,
+						},
+					}},
+				}},
+			},
+		}, nil)
+
+	// Attempt stream blocks
+	ropts := retention.NewOptions().SetBlockSize(blockSize).SetRetentionPeriod(48 * blockSize)
+	bopts := result.NewOptions().SetRetentionOptions(ropts)
+	m := session.streamFromPeersMetricsForShard(0, resultTypeTest)
+	r := newBulkBlocksResult(opts, bopts)
+	session.streamBlocksBatchFromPeer(nsID, 0, peer, batch, bopts, r, enqueueCh, retrier, m)
+
+	// Assert enqueueChannel contents (bad bar block)
+	assertEnqueueChannel(t, batch[1].blocks[:1], enqueueCh)
+
+	// Assert length of blocks result
+	assert.Equal(t, 2, len(r.result.AllSeries()))
+	assert.Equal(t, 1, r.result.AllSeries()[fooID.Hash()].Blocks.Len())
+	_, ok := r.result.AllSeries()[fooID.Hash()].Blocks.BlockAt(start)
+	assert.True(t, ok)
+	assert.Equal(t, 1, r.result.AllSeries()[barID.Hash()].Blocks.Len())
+	_, ok = r.result.AllSeries()[barID.Hash()].Blocks.BlockAt(start.Add(blockSize))
+	assert.True(t, ok)
+
+	assert.NoError(t, session.Close())
+}
 
 // TODO: add test TestVerifyFetchedBlockSize
 
@@ -1947,15 +2077,12 @@ func assertEnqueueChannel(
 		}
 	}
 
-	matchesLen := len(expected) == len(distinct)
-	assert.True(t, matchesLen)
-	if matchesLen {
-		for i, expected := range expected {
-			actual := distinct[i]
-			assert.Equal(t, expected.start, actual.start)
-			assert.Equal(t, expected.size, actual.size)
-			assert.Equal(t, expected.reattempt.id, actual.reattempt.id)
-		}
+	require.Equal(t, len(expected), len(distinct))
+	for i, expected := range expected {
+		actual := distinct[i]
+		require.Equal(t, expected.start, actual.start)
+		require.Equal(t, expected.size, actual.size)
+		require.Equal(t, expected.reattempt.id, actual.reattempt.id)
 	}
 
 	close(enqueueCh.peersMetadataCh)

--- a/generated/thrift/rpc.thrift
+++ b/generated/thrift/rpc.thrift
@@ -132,6 +132,7 @@ struct Block {
 	1: required i64 start
 	2: optional Segments segments
 	3: optional Error err
+	4: optional i64 checksum
 }
 
 struct FetchBlocksMetadataRawRequest {

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -2789,10 +2789,12 @@ func (p *Blocks) String() string {
 //  - Start
 //  - Segments
 //  - Err
+//  - Checksum
 type Block struct {
 	Start    int64     `thrift:"start,1,required" db:"start" json:"start"`
 	Segments *Segments `thrift:"segments,2" db:"segments" json:"segments,omitempty"`
 	Err      *Error    `thrift:"err,3" db:"err" json:"err,omitempty"`
+	Checksum *int64    `thrift:"checksum,4" db:"checksum" json:"checksum,omitempty"`
 }
 
 func NewBlock() *Block {
@@ -2820,12 +2822,25 @@ func (p *Block) GetErr() *Error {
 	}
 	return p.Err
 }
+
+var Block_Checksum_DEFAULT int64
+
+func (p *Block) GetChecksum() int64 {
+	if !p.IsSetChecksum() {
+		return Block_Checksum_DEFAULT
+	}
+	return *p.Checksum
+}
 func (p *Block) IsSetSegments() bool {
 	return p.Segments != nil
 }
 
 func (p *Block) IsSetErr() bool {
 	return p.Err != nil
+}
+
+func (p *Block) IsSetChecksum() bool {
+	return p.Checksum != nil
 }
 
 func (p *Block) Read(iprot thrift.TProtocol) error {
@@ -2855,6 +2870,10 @@ func (p *Block) Read(iprot thrift.TProtocol) error {
 			}
 		case 3:
 			if err := p.ReadField3(iprot); err != nil {
+				return err
+			}
+		case 4:
+			if err := p.ReadField4(iprot); err != nil {
 				return err
 			}
 		default:
@@ -2902,6 +2921,15 @@ func (p *Block) ReadField3(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *Block) ReadField4(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(); err != nil {
+		return thrift.PrependError("error reading field 4: ", err)
+	} else {
+		p.Checksum = &v
+	}
+	return nil
+}
+
 func (p *Block) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Block"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -2914,6 +2942,9 @@ func (p *Block) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField3(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField4(oprot); err != nil {
 			return err
 		}
 	}
@@ -2964,6 +2995,21 @@ func (p *Block) writeField3(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 3:err: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *Block) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetChecksum() {
+		if err := oprot.WriteFieldBegin("checksum", thrift.I64, 4); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:checksum: ", p), err)
+		}
+		if err := oprot.WriteI64(int64(*p.Checksum)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.checksum (4) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:checksum: ", p), err)
 		}
 	}
 	return err

--- a/generated/thrift/rpc/tchan-rpc.go
+++ b/generated/thrift/rpc/tchan-rpc.go
@@ -79,8 +79,11 @@ func (c *tchanClusterClient) Fetch(ctx thrift.Context, req *FetchRequest) (*Fetc
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetch", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetch")
 		}
 	}
 
@@ -92,8 +95,11 @@ func (c *tchanClusterClient) Health(ctx thrift.Context) (*HealthResult_, error) 
 	args := ClusterHealthArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "health", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for health")
 		}
 	}
 
@@ -107,8 +113,11 @@ func (c *tchanClusterClient) Truncate(ctx thrift.Context, req *TruncateRequest) 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "truncate", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for truncate")
 		}
 	}
 
@@ -122,8 +131,11 @@ func (c *tchanClusterClient) Write(ctx thrift.Context, req *WriteRequest) error 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "write", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for write")
 		}
 	}
 
@@ -306,8 +318,11 @@ func (c *tchanNodeClient) Fetch(ctx thrift.Context, req *FetchRequest) (*FetchRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetch", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetch")
 		}
 	}
 
@@ -321,8 +336,11 @@ func (c *tchanNodeClient) FetchBatchRaw(ctx thrift.Context, req *FetchBatchRawRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBatchRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBatchRaw")
 		}
 	}
 
@@ -336,8 +354,11 @@ func (c *tchanNodeClient) FetchBlocksMetadataRaw(ctx thrift.Context, req *FetchB
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBlocksMetadataRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBlocksMetadataRaw")
 		}
 	}
 
@@ -351,8 +372,11 @@ func (c *tchanNodeClient) FetchBlocksRaw(ctx thrift.Context, req *FetchBlocksRaw
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBlocksRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBlocksRaw")
 		}
 	}
 
@@ -364,8 +388,11 @@ func (c *tchanNodeClient) Health(ctx thrift.Context) (*NodeHealthResult_, error)
 	args := NodeHealthArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "health", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for health")
 		}
 	}
 
@@ -377,8 +404,11 @@ func (c *tchanNodeClient) Repair(ctx thrift.Context) error {
 	args := NodeRepairArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "repair", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for repair")
 		}
 	}
 
@@ -392,8 +422,11 @@ func (c *tchanNodeClient) Truncate(ctx thrift.Context, req *TruncateRequest) (*T
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "truncate", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for truncate")
 		}
 	}
 
@@ -407,8 +440,11 @@ func (c *tchanNodeClient) Write(ctx thrift.Context, req *WriteRequest) error {
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "write", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for write")
 		}
 	}
 
@@ -422,8 +458,11 @@ func (c *tchanNodeClient) WriteBatchRaw(ctx thrift.Context, req *WriteBatchRawRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "writeBatchRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for writeBatchRaw")
 		}
 	}
 

--- a/network/server/tchannelthrift/node/service.go
+++ b/network/server/tchannelthrift/node/service.go
@@ -306,7 +306,10 @@ func (s *service) FetchBlocksRaw(tctx thrift.Context, req *rpc.FetchBlocksRawReq
 		for j, fetchedBlock := range fetched {
 			block := rpc.NewBlock()
 			block.Start = xtime.ToNanoseconds(fetchedBlock.Start())
-
+			if ck := fetchedBlock.Checksum(); ck != nil {
+				cki := int64(*ck)
+				block.Checksum = &cki
+			}
 			if err := fetchedBlock.Err(); err != nil {
 				block.Err = convert.ToRPCError(err)
 			} else {

--- a/storage/block/result.go
+++ b/storage/block/result.go
@@ -29,19 +29,21 @@ import (
 )
 
 type fetchBlockResult struct {
-	start   time.Time
-	readers []xio.SegmentReader
-	err     error
+	start    time.Time
+	readers  []xio.SegmentReader
+	err      error
+	checksum *uint32
 }
 
 // NewFetchBlockResult creates a new fetch block result
-func NewFetchBlockResult(start time.Time, readers []xio.SegmentReader, err error) FetchBlockResult {
-	return fetchBlockResult{start: start, readers: readers, err: err}
+func NewFetchBlockResult(start time.Time, readers []xio.SegmentReader, err error, checksum *uint32) FetchBlockResult {
+	return fetchBlockResult{start: start, readers: readers, err: err, checksum: checksum}
 }
 
 func (b fetchBlockResult) Start() time.Time             { return b.start }
 func (b fetchBlockResult) Readers() []xio.SegmentReader { return b.readers }
 func (b fetchBlockResult) Err() error                   { return b.err }
+func (b fetchBlockResult) Checksum() *uint32            { return b.checksum }
 
 type fetchBlockResultByTimeAscending []FetchBlockResult
 

--- a/storage/block/result_test.go
+++ b/storage/block/result_test.go
@@ -33,9 +33,9 @@ import (
 func TestSortFetchBlockResultByTimeAscending(t *testing.T) {
 	now := time.Now()
 	input := []FetchBlockResult{
-		NewFetchBlockResult(now, nil, nil),
-		NewFetchBlockResult(now.Add(time.Second), nil, nil),
-		NewFetchBlockResult(now.Add(-time.Second), nil, nil),
+		NewFetchBlockResult(now, nil, nil, nil),
+		NewFetchBlockResult(now.Add(time.Second), nil, nil, nil),
+		NewFetchBlockResult(now.Add(-time.Second), nil, nil, nil),
 	}
 	expected := []FetchBlockResult{input[2], input[0], input[1]}
 	sort.Sort(fetchBlockResultByTimeAscending(input))

--- a/storage/block/types.go
+++ b/storage/block/types.go
@@ -62,7 +62,8 @@ type FilteredBlocksMetadataIter interface {
 	Current() (ts.ID, Metadata)
 }
 
-// FetchBlockResult captures the block start time, the readers for the underlying streams, and any errors encountered.
+// FetchBlockResult captures the block start time, the readers for the underlying streams, the
+// corresponding checksum and any errors encountered.
 type FetchBlockResult interface {
 	// Start returns the start time of an encoded block
 	Start() time.Time
@@ -72,6 +73,9 @@ type FetchBlockResult interface {
 
 	// Err returns the error encountered when fetching the block.
 	Err() error
+
+	// Checksum returns the checksum of the underlying block.
+	Checksum() *uint32
 }
 
 // FetchBlockMetadataResult captures the block start time, the block size, and any errors encountered

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -206,7 +206,7 @@ func TestDatabaseFetchBlocksNamespaceOwned(t *testing.T) {
 	shardID := uint32(0)
 	now := time.Now()
 	starts := []time.Time{now, now.Add(time.Second), now.Add(-time.Second)}
-	expected := []block.FetchBlockResult{block.NewFetchBlockResult(starts[0], nil, nil)}
+	expected := []block.FetchBlockResult{block.NewFetchBlockResult(starts[0], nil, nil, nil)}
 	mockNamespace := NewMockdatabaseNamespace(ctrl)
 	mockNamespace.EXPECT().FetchBlocks(ctx, shardID, id, starts).Return(expected, nil)
 	d.namespaces[ns.Hash()] = mockNamespace

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -267,7 +267,9 @@ func (b *dbBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.
 		bucket.readStreams(ctx, func(stream xio.SegmentReader) {
 			readers = append(readers, stream)
 		})
-		res = append(res, block.NewFetchBlockResult(bucket.start, readers, nil))
+		// Following convention from FetchBlocksMetadata, returning nil checksums for buckets
+		// because they haven't been flushed yet
+		res = append(res, block.NewFetchBlockResult(bucket.start, readers, nil, nil))
 	})
 
 	return res

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -274,10 +274,10 @@ func (s *dbSeries) FetchBlocks(ctx context.Context, starts []time.Time) []block.
 			if err != nil {
 				r := block.NewFetchBlockResult(start, nil,
 					fmt.Errorf("unable to retrieve block stream for series %s time %v: %v",
-						s.id.String(), start, err))
+						s.id.String(), start, err), nil)
 				res = append(res, r)
 			} else if stream != nil {
-				r := block.NewFetchBlockResult(start, []xio.SegmentReader{stream}, nil)
+				r := block.NewFetchBlockResult(start, []xio.SegmentReader{stream}, nil, b.Checksum())
 				res = append(res, r)
 			}
 		}

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -478,7 +478,7 @@ func TestShardFetchBlocksIDExists(t *testing.T) {
 	series := addMockSeries(ctrl, shard, id, 0)
 	now := time.Now()
 	starts := []time.Time{now}
-	expected := []block.FetchBlockResult{block.NewFetchBlockResult(now, nil, nil)}
+	expected := []block.FetchBlockResult{block.NewFetchBlockResult(now, nil, nil, nil)}
 	series.EXPECT().FetchBlocks(ctx, starts).Return(expected)
 	res, err := shard.FetchBlocks(ctx, id, starts)
 	require.NoError(t, err)


### PR DESCRIPTION
Right now we verify the checksum of the streamed block from the checksum we retrieve when fetching metadata for all the blocks.  This could change, say perhaps due to a repair in progress that's happening.

Instead we should send the checksum of the block when returning it during the FetchBlocks calls.  Then the client can check that checksum value and compare against the received bytes.