### PR TITLE
Explicitly control when reallocation happens in bitset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/.ci/common.mk
+
 SHELL=/bin/bash -o pipefail
 
 html_report := coverage.html
@@ -73,10 +76,6 @@ tools-linux-amd64:
 $(foreach SERVICE,$(SERVICES),$(eval $(SERVICE_RULES)))
 $(foreach TOOL,$(TOOLS),$(eval $(TOOL_RULES)))
 
-install-vendor: install-glide
-	@echo Installing glide deps
-	glide install
-
 install-license-bin: install-vendor
 	@echo Installing node modules
 	git submodule update --init --recursive
@@ -93,9 +92,6 @@ install-proto-bin: install-vendor
 	@echo Note: the protobuf compiler v3.0.0 can be downloaded from https://github.com/google/protobuf/releases or built from source at https://github.com/google/protobuf.
 	go install $(m3db_package)/$(vendor_prefix)/$(protoc_go_package)
 
-install-glide:
-	@which glide > /dev/null || go get -u github.com/Masterminds/glide && cd $(GOPATH)/src/github.com/Masterminds/glide && git checkout v0.12.3 && go install
-
 install-thrift-bin: install-vendor install-glide
 	@echo Installing thrift binaries
 	@echo Note: the thrift binary should be installed from https://github.com/apache/thrift at commit 9b954e6a469fef18682314458e6fc4af2dd84add.
@@ -104,15 +100,15 @@ install-thrift-bin: install-vendor install-glide
 
 mock-gen: install-mockgen install-license-bin
 	@echo Generating mocks
-	$(auto_gen) $(mocks_output_dir) $(mocks_rules_dir)
+	PACKAGE=$(m3db_package) $(auto_gen) $(mocks_output_dir) $(mocks_rules_dir)
 
 proto-gen: install-proto-bin install-license-bin
 	@echo Generating protobuf files
-	$(auto_gen) $(proto_output_dir) $(proto_rules_dir)
+	PACKAGE=$(m3db_package) $(auto_gen) $(proto_output_dir) $(proto_rules_dir)
 
 thrift-gen: install-thrift-bin install-license-bin
 	@echo Generating thrift files
-	$(auto_gen) $(thrift_output_dir) $(thrift_rules_dir)
+	PACKAGE=$(m3db_package) $(auto_gen) $(thrift_output_dir) $(thrift_rules_dir)
 
 all-gen: mock-gen proto-gen thrift-gen
 
@@ -140,9 +136,6 @@ test: test-internal
 testhtml: test-internal
 	gocov convert $(coverfile) | gocov-html > $(html_report) && open $(html_report)
 	@rm -f $(test_log) &> /dev/null
-
-install-ci:
-	make install-vendor
 
 test-ci-unit: test-internal
 	@which goveralls > /dev/null || go get -u -f github.com/mattn/goveralls

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL=/bin/bash -o pipefail
 
 html_report := coverage.html
 test := .ci/test-cover.sh
+test_one_integration := .ci/test-one-integration.sh
 test_ci_integration := .ci/test-integration.sh
 convert-test-data := .ci/convert-test-data.sh
 coverfile := cover.out
@@ -150,6 +151,10 @@ test-ci-unit: test-internal
 test-ci-integration:
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false $(test_ci_integration)
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=true $(test_ci_integration)
+
+# run as: make test-one-integration test=<test_name>
+test-one-integration:
+	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false $(test_one_integration) $(test)
 
 clean:
 	@rm -f *.html *.xml *.out *.test

--- a/client/connection_pool_test.go
+++ b/client/connection_pool_test.go
@@ -29,14 +29,19 @@ import (
 
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
-	"github.com/m3db/m3x/close"
+	xclose "github.com/m3db/m3x/close"
 	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testHostStr  = "testhost"
+	testHostAddr = testHostStr + ":9000"
+)
+
 var (
-	h           = topology.NewHost("testhost", "testhost:9000")
+	h           = topology.NewHost(testHostStr, testHostAddr)
 	channelNone = &nullChannel{}
 )
 

--- a/client/host_queue.go
+++ b/client/host_queue.go
@@ -21,7 +21,7 @@
 package client
 
 import (
-	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -33,12 +33,6 @@ import (
 	"github.com/m3db/m3x/pool"
 
 	"github.com/uber/tchannel-go/thrift"
-)
-
-var (
-	errQueueNotOpen          = errors.New("host operation queue not open")
-	errQueueUnknownOperation = errors.New("host operation queue received unknown operation")
-	errQueueFetchNoResponse  = errors.New("host operation queue did not receive response for given fetch")
 )
 
 type queue struct {
@@ -72,8 +66,7 @@ func newHostQueue(
 			"hostID": host.ID(),
 		})
 
-	opts = opts.SetInstrumentOptions(
-		opts.InstrumentOptions().SetMetricsScope(scope))
+	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().SetMetricsScope(scope))
 
 	size := opts.HostQueueOpsFlushSize()
 
@@ -230,7 +223,7 @@ func (q *queue) drain() {
 				q.asyncTruncate(v)
 			default:
 				completionFn := ops[i].CompletionFn()
-				completionFn(nil, errQueueUnknownOperation)
+				completionFn(nil, errQueueUnknownOperation(q.host.ID()))
 			}
 		}
 
@@ -275,10 +268,13 @@ func (q *queue) asyncWrite(
 			q.Done()
 		}
 
+		// NB(bl): host is passed to writeState to determine the state of the
+		// shard on the node we're writing to
+
 		client, err := q.connPool.NextClient()
 		if err != nil {
 			// No client available
-			callAllCompletionFns(ops, nil, err)
+			callAllCompletionFns(ops, q.host, err)
 			cleanup()
 			return
 		}
@@ -287,7 +283,7 @@ func (q *queue) asyncWrite(
 		err = client.WriteBatchRaw(ctx, req)
 		if err == nil {
 			// All succeeded
-			callAllCompletionFns(ops, nil, nil)
+			callAllCompletionFns(ops, q.host, nil)
 			cleanup()
 			return
 		}
@@ -297,14 +293,14 @@ func (q *queue) asyncWrite(
 			hasErr := make(map[int]struct{})
 			for _, batchErr := range batchErrs.Errors {
 				op := ops[batchErr.Index]
-				op.CompletionFn()(nil, batchErr.Err)
+				op.CompletionFn()(q.host, batchErr.Err)
 				hasErr[int(batchErr.Index)] = struct{}{}
 			}
 			// Callback all writes with no errors
 			for i := range ops {
 				if _, ok := hasErr[i]; !ok {
 					// No error
-					ops[i].CompletionFn()(nil, nil)
+					ops[i].CompletionFn()(q.host, nil)
 				}
 			}
 			cleanup()
@@ -312,7 +308,7 @@ func (q *queue) asyncWrite(
 		}
 
 		// Entire batch failed
-		callAllCompletionFns(ops, nil, err)
+		callAllCompletionFns(ops, q.host, err)
 		cleanup()
 	}()
 }
@@ -344,7 +340,7 @@ func (q *queue) asyncFetch(op *fetchBatchOp) {
 		for i := 0; i < op.Size(); i++ {
 			if !(i < resultLen) {
 				// No results for this entry, in practice should never occur
-				op.complete(i, nil, errQueueFetchNoResponse)
+				op.complete(i, nil, errQueueFetchNoResponse(q.host.ID()))
 				continue
 			}
 			if result.Elements[i].Err != nil {
@@ -394,7 +390,7 @@ func (q *queue) Enqueue(o op) error {
 	q.Lock()
 	if q.state != stateOpen {
 		q.Unlock()
-		return errQueueNotOpen
+		return errQueueNotOpen(q.host.ID())
 	}
 	q.ops = append(q.ops, o)
 	q.opsSumSize += o.Size()
@@ -427,7 +423,7 @@ func (q *queue) BorrowConnection(fn withConnectionFn) error {
 	q.RLock()
 	if q.state != stateOpen {
 		q.RUnlock()
-		return errQueueNotOpen
+		return errQueueNotOpen(q.host.ID())
 	}
 	// Add an outstanding operation to avoid connection pool being closed
 	q.Add(1)
@@ -455,4 +451,18 @@ func (q *queue) Close() {
 	// consistently if channel is open or not by checking state
 	close(q.drainIn)
 	q.Unlock()
+}
+
+// errors
+
+func errQueueNotOpen(hostID string) error {
+	return fmt.Errorf("host operation queue not open for host: %s", hostID)
+}
+
+func errQueueUnknownOperation(hostID string) error {
+	return fmt.Errorf("host operation queue received unknown operation for host: %s", hostID)
+}
+
+func errQueueFetchNoResponse(hostID string) error {
+	return fmt.Errorf("host operation queue did not receive response for given fetch for host: %s", hostID)
 }

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -67,12 +67,14 @@ func sessionTestShardSet() sharding.ShardSet {
 	return shardSet
 }
 
+func testHostName(i int) string { return fmt.Sprintf("testhost%d", i) }
+
 func sessionTestHostAndShards(
 	shardSet sharding.ShardSet,
 ) []topology.HostShardSet {
 	var hosts []topology.Host
 	for i := 0; i < sessionTestReplicas; i++ {
-		id := fmt.Sprintf("testhost%d", i)
+		id := testHostName(i)
 		host := topology.NewHost(id, fmt.Sprintf("%s:9000", id))
 		hosts = append(hosts, host)
 	}

--- a/client/write.go
+++ b/client/write.go
@@ -21,9 +21,11 @@
 package client
 
 import (
+	"fmt"
+	"math"
 	"sync"
-	"sync/atomic"
 
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
@@ -31,11 +33,13 @@ import (
 )
 
 var (
-	writeOpZeroed writeOp
+	writeOpZeroed = writeOp{shardID: math.MaxUint32}
+	// NB(bl): use an invalid shardID for the zerod op
 )
 
 type writeOp struct {
 	namespace    ts.ID
+	shardID      uint32
 	request      rpc.WriteBatchRawRequestElement
 	datapoint    rpc.Datapoint
 	completionFn completionFn
@@ -98,11 +102,12 @@ type writeState struct {
 	sync.Mutex
 	refCounter
 
-	session             *session
-	op                  *writeOp
-	majority            int32
-	successful, pending int32
-	errors              []error
+	session           *session
+	topoMap           topology.Map
+	op                *writeOp
+	majority, pending int32
+	success           int32
+	errors            []error
 
 	queues []hostQueue
 }
@@ -117,10 +122,12 @@ func (w *writeState) reset() {
 func (w *writeState) close() {
 	w.session.writeOpPool.Put(w.op)
 
-	w.op, w.majority, w.successful, w.pending = nil, 0, 0, 0
+	w.op, w.majority, w.pending, w.success = nil, 0, 0, 0
+
 	for i := range w.errors {
 		w.errors[i] = nil
 	}
+
 	w.errors = w.errors[:0]
 	for i := range w.queues {
 		w.queues[i] = nil
@@ -131,29 +138,49 @@ func (w *writeState) close() {
 }
 
 func (w *writeState) completionFn(result interface{}, err error) {
-	remaining := atomic.AddInt32(&w.pending, -1)
-	successful := int32(0)
-	if err == nil {
-		successful = atomic.AddInt32(&w.successful, 1)
-	}
+	hostID := result.(topology.Host).ID()
+	// NB(bl) panic on invalid result, it indicates a bug in the code
 
 	w.Lock()
+	w.pending--
+
+	var wErr error
 
 	if err != nil {
-		w.errors = append(w.errors, err)
+		wErr = fmt.Errorf("error writing to host %s: %v", hostID, err)
+	} else if hostShardSet, ok := w.topoMap.LookupHostShardSet(hostID); !ok {
+		wErr = fmt.Errorf("missing host shard in writeState completionFn: %s", hostID)
+	} else if shardState, err := hostShardSet.ShardSet().LookupStateByID(w.op.shardID); err != nil {
+		wErr = fmt.Errorf("missing shard %d in host %s", w.op.shardID, hostID)
+	} else if shardState != shard.Available {
+		// NB(bl): only count writes to available shards towards success
+		switch shardState {
+		case shard.Initializing:
+			wErr = fmt.Errorf("shard %d in host %s is not available (initializing)", w.op.shardID, hostID)
+		case shard.Leaving:
+			wErr = fmt.Errorf("shard %d in host %s not available (leaving)", w.op.shardID, hostID)
+		default:
+			wErr = fmt.Errorf("shard %d in host %s not available (unknown state)", w.op.shardID, hostID)
+		}
+	} else {
+		w.success++
+	}
+
+	if wErr != nil {
+		w.errors = append(w.errors, wErr)
 	}
 
 	switch w.session.writeLevel {
 	case topology.ConsistencyLevelOne:
-		if successful > 0 || remaining == 0 {
+		if w.success > 0 || w.pending == 0 {
 			w.Signal()
 		}
 	case topology.ConsistencyLevelMajority:
-		if successful >= w.majority || remaining == 0 {
+		if w.success >= w.majority || w.pending == 0 {
 			w.Signal()
 		}
 	case topology.ConsistencyLevelAll:
-		if remaining == 0 {
+		if w.pending == 0 {
 			w.Signal()
 		}
 	}

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/topology"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteToAvailableShards(t *testing.T) {
+	assert.Equal(t, int32(sessionTestReplicas), shardStateWriteTest(t, shard.Available))
+}
+
+func TestWriteToInitializingShards(t *testing.T) {
+	assert.Equal(t, int32(0), shardStateWriteTest(t, shard.Initializing))
+}
+
+func TestWriteToLeavingShards(t *testing.T) {
+	assert.Equal(t, int32(0), shardStateWriteTest(t, shard.Leaving))
+}
+
+func shardStateWriteTest(t *testing.T, state shard.State) int32 {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s := newDefaultTestSession(t).(*session)
+	w := newWriteStub()
+
+	var completionFn completionFn
+	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
+		completionFn = op.CompletionFn()
+	}})
+
+	s.Open()
+	defer s.Close()
+
+	host := s.topoMap.Hosts()[0] // any host
+	setShardStates(t, s, host, state)
+
+	wState := getWriteState(s)
+	for i := 0; i < sessionTestReplicas+1; i++ {
+		wState.incRef()
+	}
+	defer wState.decRef() // add an extra incRef so we can inspect wState
+
+	// Begin write
+	var writeWg sync.WaitGroup
+	writeWg.Add(1)
+	go func() {
+		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
+		writeWg.Done()
+	}()
+
+	// Callbacks
+
+	enqueueWg.Wait()
+	require.True(t, s.topoMap.Replicas() == sessionTestReplicas)
+	for i := 0; i < s.topoMap.Replicas(); i++ {
+		completionFn(host, nil)        // maintain session state
+		wState.completionFn(host, nil) // for the test
+	}
+
+	// Wait for write to complete
+	writeWg.Wait()
+
+	return wState.success
+}
+
+func getWriteState(s *session) *writeState {
+	wState := s.writeStatePool.Get().(*writeState)
+	wState.topoMap = s.topoMap
+	wState.op = s.writeOpPool.Get()
+	wState.op.shardID = 0 // Any valid shardID
+	return wState
+}
+
+func setShardStates(t *testing.T, s *session, host topology.Host, state shard.State) {
+	hostShardSet, ok := s.topoMap.LookupHostShardSet(host.ID())
+	require.True(t, ok)
+
+	for _, hostShard := range hostShardSet.ShardSet().All() {
+		hostShard.SetState(state)
+	}
+}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -39,10 +39,10 @@ import (
 	"github.com/m3db/m3db/storage/bootstrap/result"
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
-	"github.com/m3db/m3db/x/metrics"
+	xmetrics "github.com/m3db/m3db/x/metrics"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/instrument"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
 	"github.com/uber-go/tally"
 

--- a/integration/options.go
+++ b/integration/options.go
@@ -57,6 +57,10 @@ const (
 
 	// defaultUseTChannelClientForTruncation determines whether we use the tchannel client for truncation by default.
 	defaultUseTChannelClientForTruncation = true
+
+	// defaultWriteConsistencyLevel is the default write consistency level. This
+	// should match the default in client/options.
+	defaultWriteConsistencyLevel = topology.ConsistencyLevelMajority
 )
 
 type testOptions interface {
@@ -163,6 +167,12 @@ type testOptions interface {
 
 	// VerifySeriesDebugFilePathPrefix returns the file path prefix for writing a debug file of series comparisons.
 	VerifySeriesDebugFilePathPrefix() string
+
+	// WriteConsistencyLevel returns the consistency level for writing with the m3db client.
+	WriteConsistencyLevel() topology.ConsistencyLevel
+
+	// SetWriteConsistencyLevel sets the consistency level for writing with the m3db client.
+	SetWriteConsistencyLevel(topology.ConsistencyLevel) testOptions
 }
 
 type options struct {
@@ -183,6 +193,7 @@ type options struct {
 	useTChannelClientForWriting        bool
 	useTChannelClientForTruncation     bool
 	verifySeriesDebugFilePathPrefix    string
+	writeConsistencyLevel              topology.ConsistencyLevel
 }
 
 func newTestOptions() testOptions {
@@ -202,6 +213,7 @@ func newTestOptions() testOptions {
 		useTChannelClientForReading:    defaultUseTChannelClientForReading,
 		useTChannelClientForWriting:    defaultUseTChannelClientForWriting,
 		useTChannelClientForTruncation: defaultUseTChannelClientForTruncation,
+		writeConsistencyLevel:          defaultWriteConsistencyLevel,
 	}
 }
 
@@ -373,4 +385,14 @@ func (o *options) SetVerifySeriesDebugFilePathPrefix(value string) testOptions {
 
 func (o *options) VerifySeriesDebugFilePathPrefix() string {
 	return o.verifySeriesDebugFilePathPrefix
+}
+
+func (o *options) WriteConsistencyLevel() topology.ConsistencyLevel {
+	return o.writeConsistencyLevel
+}
+
+func (o *options) SetWriteConsistencyLevel(cLevel topology.ConsistencyLevel) testOptions {
+	opts := *o
+	opts.writeConsistencyLevel = cLevel
+	return &opts
 }

--- a/integration/peers_bootstrap_high_concurrency_test.go
+++ b/integration/peers_bootstrap_high_concurrency_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/peers_bootstrap_merge_local_test.go
+++ b/integration/peers_bootstrap_merge_local_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
-	"github.com/m3db/m3db/x/metrics"
-	"github.com/m3db/m3x/log"
+	xmetrics "github.com/m3db/m3db/x/metrics"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/peers_bootstrap_merge_peer_blocks_test.go
+++ b/integration/peers_bootstrap_merge_peer_blocks_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/ts"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/peers_bootstrap_node_down_test.go
+++ b/integration/peers_bootstrap_node_down_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/peers_bootstrap_select_best_test.go
+++ b/integration/peers_bootstrap_select_best_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/ts"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/peers_bootstrap_simple_test.go
+++ b/integration/peers_bootstrap_simple_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -29,13 +29,17 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/client"
 	"github.com/m3db/m3db/clock"
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/persist"
 	"github.com/m3db/m3db/persist/fs"
+	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/services/m3dbnode/server"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/storage"
@@ -43,11 +47,12 @@ import (
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/sync"
 
-	"github.com/uber/tchannel-go"
+	"github.com/stretchr/testify/require"
+	tchannel "github.com/uber/tchannel-go"
 )
 
 var (
@@ -100,8 +105,7 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 
 	storageOpts := storage.NewOptions()
 
-	nativePooling :=
-		strings.ToLower(os.Getenv("TEST_NATIVE_POOLING")) == "true"
+	nativePooling := strings.ToLower(os.Getenv("TEST_NATIVE_POOLING")) == "true"
 	if nativePooling {
 		buckets := testNativePoolingBuckets
 		bytesPool := pool.NewCheckedBytesPool(buckets, nil, func(s []pool.Bucket) pool.BytesPool {
@@ -109,13 +113,11 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 		})
 		bytesPool.Init()
 
-		storageOpts = storageOpts.
-			SetBytesPool(bytesPool)
+		storageOpts = storageOpts.SetBytesPool(bytesPool)
 
 		idPool := ts.NewNativeIdentifierPool(bytesPool, nil)
 
-		storageOpts = storageOpts.
-			SetIdentifierPool(idPool)
+		storageOpts = storageOpts.SetIdentifierPool(idPool)
 	}
 
 	// Set up shard set
@@ -143,7 +145,8 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 	}
 
 	clientOpts := server.DefaultClientOptions(topoInit).
-		SetClusterConnectTimeout(opts.ClusterConnectionTimeout())
+		SetClusterConnectTimeout(opts.ClusterConnectionTimeout()).
+		SetWriteConsistencyLevel(opts.WriteConsistencyLevel())
 
 	// Set up tchannel client
 	channel, tc, err := tchannelClient(tchannelNodeAddr)
@@ -218,23 +221,25 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 	}, nil
 }
 
+func (ts *testSetup) serverIsUp() bool {
+	resp, err := ts.health()
+	return err == nil && resp.Bootstrapped
+}
+
+func (ts *testSetup) serverIsDown() bool {
+	_, err := ts.health()
+	return err != nil
+}
+
 func (ts *testSetup) waitUntilServerIsUp() error {
-	serverIsUp := func() bool {
-		resp, err := ts.health()
-		return err == nil && resp.Bootstrapped
-	}
-	if waitUntil(serverIsUp, ts.opts.ServerStateChangeTimeout()) {
+	if waitUntil(ts.serverIsUp, ts.opts.ServerStateChangeTimeout()) {
 		return nil
 	}
 	return errServerStartTimedOut
 }
 
 func (ts *testSetup) waitUntilServerIsDown() error {
-	serverIsDown := func() bool {
-		_, err := ts.health()
-		return err != nil
-	}
-	if waitUntil(serverIsDown, ts.opts.ServerStateChangeTimeout()) {
+	if waitUntil(ts.serverIsDown, ts.opts.ServerStateChangeTimeout()) {
 		return nil
 	}
 	return errServerStopTimedOut
@@ -365,4 +370,64 @@ func (ts testSetups) parallel(fn func(s *testSetup)) {
 		}()
 	}
 	wg.Wait()
+}
+
+// node generates service instances with reasonable defaults
+func node(t *testing.T, n int, shards shard.Shards) services.ServiceInstance {
+	require.True(t, n < 250) // keep ports sensible
+	return services.NewServiceInstance().
+		SetInstanceID(fmt.Sprintf("testhost%v", n)).
+		SetEndpoint(fmt.Sprintf("127.0.0.1:%v", 9000+4*n)).
+		SetShards(shards)
+}
+
+// newNodes creates a set of testSetups with reasonable defaults
+func newNodes(
+	t *testing.T,
+	instances []services.ServiceInstance,
+	nspaces []namespace.Metadata,
+) (testSetups, topology.Initializer, closeFn) {
+
+	log := xlog.SimpleLogger
+	opts := newTestOptions().SetNamespaces(nspaces)
+
+	// NB(bl): We set replication to 3 to mimic production. This can be made
+	// into a variable if needed.
+	svc := NewFakeM3ClusterService().
+		SetInstances(instances).
+		SetReplication(services.NewServiceReplication().SetReplicas(3)).
+		SetSharding(services.NewServiceSharding().SetNumShards(1024))
+
+	svcs := NewFakeM3ClusterServices()
+	svcs.RegisterService("m3db", svc)
+
+	topoOpts := topology.NewDynamicOptions().
+		SetConfigServiceClient(NewM3FakeClusterClient(svcs, nil))
+	topoInit := topology.NewDynamicInitializer(topoOpts)
+	retentionOpts := retention.NewOptions().SetRetentionPeriod(6 * time.Hour)
+
+	nodeOpt := bootstrappableTestSetupOptions{
+		disablePeersBootstrapper: true,
+		topologyInitializer:      topoInit,
+	}
+
+	nodeOpts := make([]bootstrappableTestSetupOptions, len(instances))
+	for i := range instances {
+		nodeOpts[i] = nodeOpt
+	}
+
+	nodes, closeFn := newDefaultBootstrappableTestSetups(t, opts, retentionOpts, nodeOpts)
+
+	nodeClose := func() { // Clean up running servers at end of test
+		log.Debug("servers closing")
+		nodes.parallel(func(s *testSetup) {
+			if s.serverIsUp() {
+				require.NoError(t, s.stopServer())
+			}
+		})
+		log.Debug("servers are now down")
+		closeFn()
+	}
+
+	return nodes, topoInit, nodeClose
 }

--- a/integration/write_quorum_test.go
+++ b/integration/write_quorum_test.go
@@ -1,0 +1,139 @@
+// +build integration
+
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/client"
+	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/topology"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/shard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalQuorum(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// nodes = m3db nodes
+	nodes, closeFn, testWrite := makeTestWrite(t, []services.ServiceInstance{
+		node(t, 0, newClusterShardsRange(0, 1023, shard.Available)),
+		node(t, 1, newClusterShardsRange(0, 1023, shard.Available)),
+		node(t, 2, newClusterShardsRange(0, 1023, shard.Available)),
+	})
+
+	defer closeFn()
+
+	// Writes succeed to one node
+	require.NoError(t, nodes[0].startServer())
+	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
+	assert.Error(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.Error(t, testWrite(topology.ConsistencyLevelAll))
+
+	// Writes succeed to two nodes
+	require.NoError(t, nodes[1].startServer())
+	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
+	assert.NoError(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.Error(t, testWrite(topology.ConsistencyLevelAll))
+
+	// Writes succeed to all nodes
+	require.NoError(t, nodes[2].startServer())
+	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
+	assert.NoError(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.NoError(t, testWrite(topology.ConsistencyLevelAll))
+}
+
+func TestAddNodeQuorum(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// nodes = m3db nodes
+	nodes, closeFn, testWrite := makeTestWrite(t, []services.ServiceInstance{
+		node(t, 0, newClusterShardsRange(0, 1023, shard.Leaving)),
+		node(t, 1, newClusterShardsRange(0, 1023, shard.Available)),
+		node(t, 2, newClusterShardsRange(0, 1023, shard.Available)),
+		node(t, 3, newClusterShardsRange(0, 1023, shard.Initializing)),
+	})
+
+	defer closeFn()
+
+	// No writes succeed to available nodes
+	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[3].startServer())
+	assert.Error(t, testWrite(topology.ConsistencyLevelOne))
+	assert.Error(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.Error(t, testWrite(topology.ConsistencyLevelAll))
+
+	// Writes succeed to one available node
+	require.NoError(t, nodes[1].startServer())
+	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
+	assert.Error(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.Error(t, testWrite(topology.ConsistencyLevelAll))
+
+	// Writes succeed to two available nodes
+	require.NoError(t, nodes[2].startServer())
+	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
+	assert.NoError(t, testWrite(topology.ConsistencyLevelMajority))
+	assert.Error(t, testWrite(topology.ConsistencyLevelAll))
+}
+
+type testWriteFn func(topology.ConsistencyLevel) error
+
+func makeTestWrite(t *testing.T, instances []services.ServiceInstance) (testSetups,
+	closeFn, testWriteFn) {
+
+	nspaces := []namespace.Metadata{
+		namespace.NewMetadata(testNamespaces[0], namespace.NewOptions()),
+	}
+
+	nodes, topoInit, closeFn := newNodes(t, instances, nspaces)
+
+	now := nodes[0].getNowFn()
+
+	testWrite := func(cLevel topology.ConsistencyLevel) error {
+		opts := client.NewOptions().
+			SetClusterConnectConsistencyLevel(client.ConnectConsistencyLevelNone).
+			SetClusterConnectTimeout(10 * time.Millisecond).
+			SetWriteRequestTimeout(100 * time.Millisecond).
+			SetTopologyInitializer(topoInit).
+			SetWriteConsistencyLevel(cLevel)
+
+		c, err := client.NewClient(opts)
+		require.NoError(t, err)
+
+		s, err := c.NewSession()
+		require.NoError(t, err)
+
+		return s.Write(nspaces[0].ID().String(), "quorumTest", now, 42, xtime.Second, nil)
+	}
+
+	return nodes, closeFn, testWrite
+}

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -60,7 +60,7 @@ func (s *set) set(i uint64) {
 	// case each reallocation only grows the internal slice in
 	// the bitset implementation by 1 slot and copies the existing data
 	// over, causing significant CPU overhead and GC time. Therefore
-	// we explicitly controls when the reallocation happens and grows
+	// we explicitly control when the reallocation happens and grow
 	// the slice explicitly to amortize the allocation cost.
 	if bitsetLen := s.Len(); uint(i) >= bitsetLen {
 		newLength := uint(math.Max(float64(i+1), growthFactor*float64(bitsetLen)))

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -21,10 +21,15 @@
 package commitlog
 
 import (
+	"math"
+
 	bset "github.com/willf/bitset"
 )
 
-const newBitsetLength = 65536
+const (
+	defaultBitsetLength = 65536
+	growthFactor        = 2.0
+)
 
 // bitset is a shim for providing a bitset
 type bitset interface {
@@ -39,7 +44,7 @@ type set struct {
 }
 
 func newBitset() bitset {
-	return &set{bset.New(newBitsetLength)}
+	return &set{bset.New(defaultBitsetLength)}
 }
 
 func (s *set) has(i uint64) bool {
@@ -47,6 +52,22 @@ func (s *set) has(i uint64) bool {
 }
 
 func (s *set) set(i uint64) {
+	// NB(xichen): the bitset implementation keeps track of
+	// the maximum value it has seen so far and triggers a
+	// reallocation if it needs to set a value larger than
+	// the current max. However it only reallocates space large
+	// enough to represent the new value, which means in our
+	// case each reallocation only grows the internal slice in
+	// the bitset implementation by 1 slot and copies the existing data
+	// over, causing significant CPU overhead and GC time. Therefore
+	// we explicitly controls when the reallocation happens and grows
+	// the slice explicitly to amortize the allocation cost.
+	if bitsetLen := s.Len(); uint(i) >= bitsetLen {
+		newLength := uint(math.Max(float64(i+1), growthFactor*float64(bitsetLen)))
+		newBitSet := bset.New(newLength)
+		s.BitSet.Copy(newBitSet)
+		s.BitSet = newBitSet
+	}
 	s.Set(uint(i))
 }
 

--- a/persist/fs/commitlog/bitset_test.go
+++ b/persist/fs/commitlog/bitset_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitSetSetValue(t *testing.T) {
+	bs := newBitset().(*set)
+	var values []uint64
+
+	// Setting a value smaller than the bitset length doesn't
+	// trigger reallocations
+	oldLen := bs.Len()
+	values = append(values, uint64(oldLen-1))
+	bs.set(values[len(values)-1])
+	require.Equal(t, oldLen, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+
+	// Setting a value bigger than the bitset length,
+	// which triggers an reallocation, and verify the capacity
+	// has grown and all the existing data are kept
+	values = append(values, uint64(oldLen+1))
+	bs.set(values[len(values)-1])
+	require.Equal(t, 2*oldLen, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+
+	// Setting a value bigger than 2 times the bitset length
+	// will trigger an reallocation and set the length of
+	// the new underlying bitset to value + 1
+	newVal := bs.Len()*2 + 10
+	values = append(values, uint64(newVal))
+	bs.set(values[len(values)-1])
+	require.Equal(t, newVal+1, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+}

--- a/sharding/shardset.go
+++ b/sharding/shardset.go
@@ -33,12 +33,16 @@ import (
 var (
 	// ErrDuplicateShards returned when shard set is empty
 	ErrDuplicateShards = errors.New("duplicate shards")
+
+	// ErrInvalidShardID is returned on an invalid shard ID
+	ErrInvalidShardID = errors.New("no shard with given ID")
 )
 
 type shardSet struct {
-	shards []shard.Shard
-	ids    []uint32
-	fn     HashFn
+	shards   []shard.Shard
+	ids      []uint32
+	shardMap map[uint32]shard.Shard
+	fn       HashFn
 }
 
 // NewShardSet creates a new sharding scheme with a set of shards
@@ -56,18 +60,29 @@ func NewEmptyShardSet(fn HashFn) ShardSet {
 
 func newValidatedShardSet(shards []shard.Shard, fn HashFn) ShardSet {
 	ids := make([]uint32, len(shards))
-	for i := range ids {
-		ids[i] = shards[i].ID()
+	shardMap := make(map[uint32]shard.Shard, len(shards))
+	for i, shard := range shards {
+		ids[i] = shard.ID()
+		shardMap[shard.ID()] = shard
 	}
 	return &shardSet{
-		shards: shards,
-		ids:    ids,
-		fn:     fn,
+		shards:   shards,
+		ids:      ids,
+		shardMap: shardMap,
+		fn:       fn,
 	}
 }
 
 func (s *shardSet) Lookup(identifier ts.ID) uint32 {
 	return s.fn(identifier)
+}
+
+func (s *shardSet) LookupStateByID(shardID uint32) (shard.State, error) {
+	hostShard, ok := s.shardMap[shardID]
+	if !ok {
+		return shard.State(0), ErrInvalidShardID
+	}
+	return hostShard.State(), nil
 }
 
 func (s *shardSet) All() []shard.Shard {

--- a/sharding/shardset_test.go
+++ b/sharding/shardset_test.go
@@ -56,3 +56,22 @@ func TestShardSet(t *testing.T) {
 	fn := ss.HashFn()
 	require.Equal(t, staticShard, fn(id))
 }
+
+func TestLookupShardState(t *testing.T) {
+	staticShard := uint32(1)
+	ss, err := NewShardSet(
+		NewShards([]uint32{1, 5, 3}, shard.Available),
+		func(id ts.ID) uint32 {
+			return staticShard
+		})
+	require.NoError(t, err)
+
+	shardOneState, err := ss.LookupStateByID(1)
+	require.NoError(t, err)
+	require.Equal(t, shard.Available, shardOneState)
+
+	var noState shard.State
+	shardTwoState, err := ss.LookupStateByID(2)
+	require.Equal(t, ErrInvalidShardID, err)
+	require.Equal(t, noState, shardTwoState)
+}

--- a/sharding/types.go
+++ b/sharding/types.go
@@ -43,6 +43,9 @@ type ShardSet interface {
 	// Lookup will return a shard for a given identifier
 	Lookup(id ts.ID) uint32
 
+	// LookupStateByID returns the state of the shard with a given ID
+	LookupStateByID(shardID uint32) (shard.State, error)
+
 	// Min returns the smallest shard owned by this shard set
 	Min() uint32
 

--- a/storage/cluster/database.go
+++ b/storage/cluster/database.go
@@ -31,13 +31,13 @@ import (
 	"github.com/m3db/m3db/storage"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 )
 
 var (
 	// newStorageDatabase is the injected constructor to construct a database,
 	// useful for replacing which database constructor is called in tests
-	newStorageDatabase newStorageDatabaseFn = storage.NewDatabase
+	newStorageDatabase = storage.NewDatabase
 
 	errAlreadyWatchingTopology = errors.New("cluster db is already watching topology")
 	errNotWatchingTopology     = errors.New("cluster db is not watching topology")


### PR DESCRIPTION
cc @robskillington @kobolog @martin-mao @cw9 

This PR addresses an inefficiency in how we use bitset in commit logs. The current bitset implementation keeps track of the maximum value it has seen so far and triggers a reallocation if it needs to set a value larger the current max. However it only reallocates space enough to represent the new value, which means in case each reallocation only grows the internal slice the bitset implementation by 1 slot and copies the existing over, causing significant CPU overhead and GC time. As a result, we explicitly control when the reallocation happens and grow the slice explicitly to amortize the allocation cost.