### PR TITLE
Explicitly control bitset reallocation in commit logs

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a24ea9a4ca6dce78a27abcd75db43c68ac00a460a68e1603770a55dc94502674
-updated: 2017-01-23T16:23:13.981943905-05:00
+hash: 029ba941f724d765bde940f3b4ab40f4d61c19fafac214db369d9b32117e22f3
+updated: 2017-02-01T14:26:06.521913538-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -72,9 +72,9 @@ imports:
   - trand
   - typed
 - name: github.com/willf/bitset
-  version: 2e6e8094ef4745224150c88c16191c7dceaad16f
+  version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c
 - name: golang.org/x/net
-  version: 45e771701b814666a7eb299e6c7a57d0b1799e91
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,7 +30,7 @@ import:
   - thrift
 
 - package: github.com/willf/bitset
-  version: 2e6e8094ef4745224150c88c16191c7dceaad16f
+  version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c
 
 - package: github.com/uber-go/tally
   version: 1f0f7171f312a8cff5f697fe5f4d45dbaec8c3ac

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -21,10 +21,15 @@
 package commitlog
 
 import (
+	"math"
+
 	bset "github.com/willf/bitset"
 )
 
-const newBitsetLength = 65536
+const (
+	defaultBitsetLength = 65536
+	growthFactor        = 2.0
+)
 
 // bitset is a shim for providing a bitset
 type bitset interface {
@@ -39,7 +44,7 @@ type set struct {
 }
 
 func newBitset() bitset {
-	return &set{bset.New(newBitsetLength)}
+	return &set{bset.New(defaultBitsetLength)}
 }
 
 func (s *set) has(i uint64) bool {
@@ -47,6 +52,22 @@ func (s *set) has(i uint64) bool {
 }
 
 func (s *set) set(i uint64) {
+	// NB(xichen): the bitset implementation keeps track of
+	// the maximum value it has seen so far and triggers a
+	// reallocation if it needs to set a value larger than
+	// the current max. However it only reallocates space large
+	// enough to represent the new value, which means in our
+	// case each reallocation only grows the internal slice in
+	// the bitset implementation by 1 slot and copies the existing data
+	// over, causing significant CPU overhead and GC time. Therefore
+	// we explicitly control when the reallocation happens and grow
+	// the slice explicitly to amortize the allocation cost.
+	if bitsetLen := s.Len(); uint(i) >= bitsetLen {
+		newLength := uint(math.Max(float64(i+1), growthFactor*float64(bitsetLen)))
+		newBitSet := bset.New(newLength)
+		s.BitSet.Copy(newBitSet)
+		s.BitSet = newBitSet
+	}
 	s.Set(uint(i))
 }
 

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -20,15 +20,10 @@
 
 package commitlog
 
-import (
-	"math"
-
-	bset "github.com/willf/bitset"
-)
+import bset "github.com/willf/bitset"
 
 const (
 	defaultBitsetLength = 65536
-	growthFactor        = 2.0
 )
 
 // bitset is a shim for providing a bitset
@@ -52,22 +47,6 @@ func (s *set) has(i uint64) bool {
 }
 
 func (s *set) set(i uint64) {
-	// NB(xichen): the bitset implementation keeps track of
-	// the maximum value it has seen so far and triggers a
-	// reallocation if it needs to set a value larger than
-	// the current max. However it only reallocates space large
-	// enough to represent the new value, which means in our
-	// case each reallocation only grows the internal slice in
-	// the bitset implementation by 1 slot and copies the existing data
-	// over, causing significant CPU overhead and GC time. Therefore
-	// we explicitly control when the reallocation happens and grow
-	// the slice explicitly to amortize the allocation cost.
-	if bitsetLen := s.Len(); uint(i) >= bitsetLen {
-		newLength := uint(math.Max(float64(i+1), growthFactor*float64(bitsetLen)))
-		newBitSet := bset.New(newLength)
-		s.BitSet.Copy(newBitSet)
-		s.BitSet = newBitSet
-	}
 	s.Set(uint(i))
 }
 

--- a/persist/fs/commitlog/bitset_test.go
+++ b/persist/fs/commitlog/bitset_test.go
@@ -32,10 +32,10 @@ func TestBitSetSetValue(t *testing.T) {
 
 	// Setting a value smaller than the bitset length doesn't
 	// trigger reallocations
-	oldLen := bs.Len()
-	values = append(values, uint64(oldLen-1))
+	oldCap := cap(bs.Bytes())
+	values = append(values, uint64(oldCap-1))
 	bs.set(values[len(values)-1])
-	require.Equal(t, oldLen, bs.Len())
+	require.Equal(t, oldCap, cap(bs.Bytes()))
 	for _, v := range values {
 		require.True(t, bs.has(v))
 	}
@@ -43,20 +43,20 @@ func TestBitSetSetValue(t *testing.T) {
 	// Setting a value bigger than the bitset length,
 	// which triggers an reallocation, and verify the capacity
 	// has grown and all the existing data are kept
-	values = append(values, uint64(oldLen+1))
+	values = append(values, uint64(defaultBitsetLength+1))
 	bs.set(values[len(values)-1])
-	require.Equal(t, 2*oldLen, bs.Len())
+	require.True(t, cap(bs.Bytes()) >= 2*oldCap)
 	for _, v := range values {
 		require.True(t, bs.has(v))
 	}
 
-	// Setting a value bigger than 2 times the bitset length
-	// will trigger an reallocation and set the length of
-	// the new underlying bitset to value + 1
-	newVal := bs.Len()*2 + 10
+	// Setting a value slightly bigger than the last value
+	// and verify it doesn't trigger a reallocation
+	oldCap = cap(bs.Bytes())
+	newVal := values[len(values)-1] + 100
 	values = append(values, uint64(newVal))
 	bs.set(values[len(values)-1])
-	require.Equal(t, newVal+1, bs.Len())
+	require.Equal(t, oldCap, cap(bs.Bytes()))
 	for _, v := range values {
 		require.True(t, bs.has(v))
 	}

--- a/persist/fs/commitlog/bitset_test.go
+++ b/persist/fs/commitlog/bitset_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitSetSetValue(t *testing.T) {
+	bs := newBitset().(*set)
+	var values []uint64
+
+	// Setting a value smaller than the bitset length doesn't
+	// trigger reallocations
+	oldLen := bs.Len()
+	values = append(values, uint64(oldLen-1))
+	bs.set(values[len(values)-1])
+	require.Equal(t, oldLen, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+
+	// Setting a value bigger than the bitset length,
+	// which triggers an reallocation, and verify the capacity
+	// has grown and all the existing data are kept
+	values = append(values, uint64(oldLen+1))
+	bs.set(values[len(values)-1])
+	require.Equal(t, 2*oldLen, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+
+	// Setting a value bigger than 2 times the bitset length
+	// will trigger an reallocation and set the length of
+	// the new underlying bitset to value + 1
+	newVal := bs.Len()*2 + 10
+	values = append(values, uint64(newVal))
+	bs.set(values[len(values)-1])
+	require.Equal(t, newVal+1, bs.Len())
+	for _, v := range values {
+		require.True(t, bs.has(v))
+	}
+}


### PR DESCRIPTION
cc @robskillington @kobolog @martin-mao @cw9

This PR addresses an inefficiency in how we use bitset in commit logs. The current bitset implementation keeps track of the maximum value it has seen so far and triggers a reallocation if it needs to set a value larger the current max. However it only reallocates space enough to represent the new value, which means in case each reallocation only grows the internal slice the bitset implementation by 1 slot and copies the existing over, causing significant CPU overhead and GC time. As a result, we explicitly control when the reallocation happens and grow the slice explicitly to amortize the allocation cost.