### PR TITLE
Add option to disable repair in database

### DIFF
--- a/integration/options.go
+++ b/integration/options.go
@@ -212,11 +212,11 @@ type testOptions interface {
 	// FetchSeriesBlocksBatchConcurrency returns the number of series blocks to fetch in batch concurrently.
 	FetchSeriesBlocksBatchConcurrency() int
 
-	// SetRepairerEnabled controls whether the repairer is enabled.
-	SetRepairerEnabled(f bool) testOptions
+	// SetRepairEnabled controls whether the repair is enabled.
+	SetRepairEnabled(f bool) testOptions
 
-	// RepairerEnabled returns whether the repairer is enabled.
-	RepairerEnabled() bool
+	// RepairEnabled returns whether the repair is enabled.
+	RepairEnabled() bool
 }
 
 type options struct {
@@ -237,7 +237,7 @@ type options struct {
 	useTChannelClientForWriting        bool
 	useTChannelClientForTruncation     bool
 	verifySeriesDebugFilePathPrefix    string
-	repairerEnabled                    bool
+	repairEnabled                      bool
 	repairThrottle                     time.Duration
 	repairTimeJitter                   time.Duration
 	repairInterval                     time.Duration
@@ -500,12 +500,12 @@ func (o *options) FetchSeriesBlocksBatchConcurrency() int {
 	return o.fetchSeriesBlocksBatchConcurrency
 }
 
-func (o *options) SetRepairerEnabled(f bool) testOptions {
+func (o *options) SetRepairEnabled(f bool) testOptions {
 	opts := *o
-	opts.repairerEnabled = f
+	opts.repairEnabled = f
 	return &opts
 }
 
-func (o *options) RepairerEnabled() bool {
-	return o.repairerEnabled
+func (o *options) RepairEnabled() bool {
+	return o.repairEnabled
 }

--- a/integration/repair_high_concurrency_test.go
+++ b/integration/repair_high_concurrency_test.go
@@ -44,7 +44,7 @@ func TestRepairHighConcurrency(t *testing.T) {
 	namesp := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions())
 	opts := newTestOptions().
 		SetNamespaces([]namespace.Metadata{namesp}).
-		SetRepairerEnabled(true).
+		SetRepairEnabled(true).
 		SetRepairInterval(3 * time.Second).
 		SetRepairThrottle(1 * time.Second).
 		SetRepairTimeJitter(0 * time.Second).

--- a/integration/repair_merge_test.go
+++ b/integration/repair_merge_test.go
@@ -43,7 +43,7 @@ func TestRepairMerge(t *testing.T) {
 	namesp := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions())
 	opts := newTestOptions().
 		SetNamespaces([]namespace.Metadata{namesp}).
-		SetRepairerEnabled(true).
+		SetRepairEnabled(true).
 		SetRepairInterval(3 * time.Second).
 		SetRepairThrottle(1 * time.Second).
 		SetRepairTimeJitter(0 * time.Second).

--- a/integration/repair_simple_test.go
+++ b/integration/repair_simple_test.go
@@ -43,7 +43,7 @@ func TestRepairSimple(t *testing.T) {
 	namesp := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions())
 	opts := newTestOptions().
 		SetNamespaces([]namespace.Metadata{namesp}).
-		SetRepairerEnabled(true).
+		SetRepairEnabled(true).
 		SetRepairInterval(5 * time.Second).
 		SetRepairThrottle(1 * time.Second).
 		SetRepairTimeJitter(0 * time.Second)

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -202,16 +202,13 @@ func newTestSetup(opts testOptions) (*testSetup, error) {
 		return nil, err
 	}
 
-	if opts.RepairEnabled() {
-		storageOpts = storageOpts.SetRepairEnabled(true)
-		storageOpts = storageOpts.SetRepairOptions(storageOpts.RepairOptions().
-			SetRepairInterval(opts.RepairInterval()).
-			SetRepairThrottle(opts.RepairThrottle()).
-			SetRepairTimeJitter(opts.RepairTimeJitter()).
-			SetAdminClient(adminClient))
-	} else {
-		storageOpts = storageOpts.SetRepairEnabled(false)
-	}
+	storageOpts = storageOpts.SetRepairOptions(storageOpts.RepairOptions().
+		SetRepairInterval(opts.RepairInterval()).
+		SetRepairThrottle(opts.RepairThrottle()).
+		SetRepairTimeJitter(opts.RepairTimeJitter()).
+		SetAdminClient(adminClient))
+
+	storageOpts = storageOpts.SetRepairEnabled(opts.RepairEnabled())
 
 	return &testSetup{
 		opts:            opts,

--- a/storage/options.go
+++ b/storage/options.go
@@ -60,6 +60,9 @@ const (
 
 	// defaultBytesPoolBucketCount is the default count of elements for the default bytes pool bucket
 	defaultBytesPoolBucketCount = 4096
+
+	// defaultRepairEnabled enables repair by default
+	defaultRepairEnabled = true
 )
 
 var (
@@ -95,6 +98,7 @@ type options struct {
 	retentionOpts                  retention.Options
 	blockOpts                      block.Options
 	commitLogOpts                  commitlog.Options
+	repairEnabled                  bool
 	repairOpts                     repair.Options
 	fileOpOpts                     FileOpOptions
 	newEncoderFn                   encoding.NewEncoderFn
@@ -129,6 +133,7 @@ func NewOptions() Options {
 		retentionOpts:                  retention.NewOptions(),
 		blockOpts:                      block.NewOptions(),
 		commitLogOpts:                  commitlog.NewOptions(),
+		repairEnabled:                  defaultRepairEnabled,
 		repairOpts:                     repair.NewOptions(),
 		fileOpOpts:                     NewFileOpOptions(),
 		newBootstrapFn:                 defaultNewBootstrapFn,
@@ -204,6 +209,16 @@ func (o *options) SetCommitLogOptions(value commitlog.Options) Options {
 
 func (o *options) CommitLogOptions() commitlog.Options {
 	return o.commitLogOpts
+}
+
+func (o *options) SetRepairEnabled(b bool) Options {
+	opts := *o
+	opts.repairEnabled = b
+	return &opts
+}
+
+func (o *options) RepairEnabled() bool {
+	return o.repairEnabled
 }
 
 func (o *options) SetRepairOptions(value repair.Options) Options {

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -614,5 +614,5 @@ func newNoopDatabaseRepairer() databaseRepairer {
 }
 
 func (r noopRepairer) ShouldRun(start time.Time) bool    { return false }
-func (r noopRepairer) Run(start time.Time, mode runType) { return }
+func (r noopRepairer) Run(start time.Time, mode runType) {}
 func (r noopRepairer) IsRepairing() bool                 { return false }

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -606,3 +606,13 @@ func (r *dbRepairer) repairWithTimeRange(tr xtime.Range) error {
 func (r *dbRepairer) IsRepairing() bool {
 	return atomic.LoadInt32(&r.running) == 1
 }
+
+type noopRepairer struct{}
+
+func newNoopDatabaseRepairer() databaseRepairer {
+	return noopRepairer{}
+}
+
+func (r noopRepairer) ShouldRun(start time.Time) bool    { return false }
+func (r noopRepairer) Run(start time.Time, mode runType) { return }
+func (r noopRepairer) IsRepairing() bool                 { return false }

--- a/storage/types.go
+++ b/storage/types.go
@@ -457,6 +457,12 @@ type Options interface {
 	// CommitLogOptions returns the commit log options
 	CommitLogOptions() commitlog.Options
 
+	// SetRepairEnabled sets whether or not to enable the repair
+	SetRepairEnabled(b bool) Options
+
+	// RepairEnabled returns whether the repair is enabled
+	RepairEnabled() bool
+
 	// SetRepairOptions sets the repair options
 	SetRepairOptions(value repair.Options) Options
 


### PR DESCRIPTION
For the m3db in collector, there will be no peers to repair from,
should have an option to just turn repair off and save some resource