### PR TITLE
Ensure client write errors propagate retryable, non-retryable, and bad request errors

### DIFF
--- a/client/write.go
+++ b/client/write.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
+	xerrors "github.com/m3db/m3x/errors"
 	"github.com/m3db/m3x/pool"
 )
 
@@ -147,21 +148,25 @@ func (w *writeState) completionFn(result interface{}, err error) {
 	var wErr error
 
 	if err != nil {
-		wErr = fmt.Errorf("error writing to host %s: %v", hostID, err)
+		wErr = xerrors.NewRenamedError(err, fmt.Errorf("error writing to host %s: %v", hostID, err))
 	} else if hostShardSet, ok := w.topoMap.LookupHostShardSet(hostID); !ok {
-		wErr = fmt.Errorf("missing host shard in writeState completionFn: %s", hostID)
+		errStr := "missing host shard in writeState completionFn: %s"
+		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, hostID))
 	} else if shardState, err := hostShardSet.ShardSet().LookupStateByID(w.op.shardID); err != nil {
-		wErr = fmt.Errorf("missing shard %d in host %s", w.op.shardID, hostID)
+		errStr := "missing shard %d in host %s"
+		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
 	} else if shardState != shard.Available {
 		// NB(bl): only count writes to available shards towards success
+		var errStr string
 		switch shardState {
 		case shard.Initializing:
-			wErr = fmt.Errorf("shard %d in host %s is not available (initializing)", w.op.shardID, hostID)
+			errStr = "shard %d in host %s is not available (initializing)"
 		case shard.Leaving:
-			wErr = fmt.Errorf("shard %d in host %s not available (leaving)", w.op.shardID, hostID)
+			errStr = "shard %d in host %s not available (leaving)"
 		default:
-			wErr = fmt.Errorf("shard %d in host %s not available (unknown state)", w.op.shardID, hostID)
+			errStr = "shard %d in host %s not available (unknown state)"
 		}
+		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
 	} else {
 		w.success++
 	}

--- a/client/write.go
+++ b/client/write.go
@@ -151,10 +151,10 @@ func (w *writeState) completionFn(result interface{}, err error) {
 		wErr = xerrors.NewRenamedError(err, fmt.Errorf("error writing to host %s: %v", hostID, err))
 	} else if hostShardSet, ok := w.topoMap.LookupHostShardSet(hostID); !ok {
 		errStr := "missing host shard in writeState completionFn: %s"
-		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, hostID))
+		wErr = xerrors.NewRetryableError(fmt.Errorf(errStr, hostID))
 	} else if shardState, err := hostShardSet.ShardSet().LookupStateByID(w.op.shardID); err != nil {
 		errStr := "missing shard %d in host %s"
-		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
+		wErr = xerrors.NewRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
 	} else if shardState != shard.Available {
 		// NB(bl): only count writes to available shards towards success
 		var errStr string
@@ -166,7 +166,7 @@ func (w *writeState) completionFn(result interface{}, err error) {
 		default:
 			errStr = "shard %d in host %s not available (unknown state)"
 		}
-		wErr = xerrors.NewNonRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
+		wErr = xerrors.NewRetryableError(fmt.Errorf(errStr, w.op.shardID, hostID))
 	} else {
 		w.success++
 	}

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -59,8 +59,10 @@ func shardStateWriteTest(t *testing.T, state shard.State) int32 {
 		completionFn = op.CompletionFn()
 	}})
 
-	s.Open()
-	defer s.Close()
+	require.NoError(t, s.Open())
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
 
 	host := s.topoMap.Hosts()[0] // any host
 	setShardStates(t, s, host, state)
@@ -135,8 +137,10 @@ func TestErrorRetryability(t *testing.T) {
 			completionFn = op.CompletionFn()
 		}})
 
-		s.Open()
-		defer s.Close()
+		require.NoError(t, s.Open())
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
 
 		host = s.topoMap.Hosts()[0] // any host
 

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -107,3 +107,53 @@ func setShardStates(t *testing.T, s *session, host topology.Host, state shard.St
 		hostShard.SetState(state)
 	}
 }
+
+// func TestErrorRetryability(t *testing.T) {
+// 	// pass retryable
+
+// 	ctrl := gomock.NewController(t)
+// 	defer ctrl.Finish()
+
+// 	s := newDefaultTestSession(t).(*session)
+// 	w := newWriteStub()
+
+// 	var completionFn completionFn
+// 	enqueueWg := mockHostQueues(ctrl, s, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
+// 		completionFn = op.CompletionFn()
+// 	}})
+
+// 	s.Open()
+// 	defer s.Close()
+
+// 	host := s.topoMap.Hosts()[0] // any host
+// 	setShardStates(t, s, host, shard.Active)
+
+// 	// Begin write
+// 	var writeWg sync.WaitGroup
+// 	writeWg.Add(1)
+// 	go func() {
+// 		s.Write(w.ns, w.id, w.t, w.value, w.unit, w.annotation)
+// 		writeWg.Done()
+// 	}()
+
+// 	// Callbacks
+
+// 	enqueueWg.Wait()
+// 	require.True(t, s.topoMap.Replicas() == sessionTestReplicas)
+// 	for i := 0; i < s.topoMap.Replicas(); i++ {
+// 		completionFn(host, nil)        // maintain session state
+// 		wState.completionFn(host, nil) // for the test
+// 	}
+
+// 	// Wait for write to complete
+// 	writeWg.Wait()
+
+// 	return wState.success
+
+// 	// pass non-retryable
+// 	// try other errors
+// }
+
+// func getWriteError(t *testing.T) error {
+// 	xerrors.foo
+// }


### PR DESCRIPTION
Correctly propagate error types in write.go