### PR TITLE
Append all client-side errors

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -824,17 +824,14 @@ func (s *session) FetchAll(namespace string, ids []string, startInclusive, endEx
 		completionFn := func(result interface{}, err error) {
 			var snapshotSuccess int32
 			if err != nil {
-				n := atomic.AddInt32(&errs, 1)
-				if n == 1 {
-					// NB(r): reuse the error lock here as we do not want to create
-					// a whole lot of locks for every single ID fetched due to size
-					// of mutex being non-trivial and likely to cause more stack growth
-					// or GC pressure if ends up on heap which is likely due to naive
-					// escape analysis.
-					resultErrLock.Lock()
-					errors = append(errors, err)
-					resultErrLock.Unlock()
-				}
+				atomic.AddInt32(&errs, 1)
+				// NB(r): reuse the error lock here as we do not want to create
+				// a whole lot of locks for every single ID fetched due to size
+				// of mutex being non-trivial and likely to cause more stack growth
+				// or GC pressure if ends up on heap which is likely due to naive
+				// escape analysis.
+				errors = append(errors, err)
+				resultErrLock.Unlock()
 			} else {
 				slicesIter := s.readerSliceOfSlicesIteratorPool.Get()
 				slicesIter.Reset(result.([]*rpc.Segments))

--- a/client/session.go
+++ b/client/session.go
@@ -830,6 +830,7 @@ func (s *session) FetchAll(namespace string, ids []string, startInclusive, endEx
 				// of mutex being non-trivial and likely to cause more stack growth
 				// or GC pressure if ends up on heap which is likely due to naive
 				// escape analysis.
+				resultErrLock.Lock()
 				errors = append(errors, err)
 				resultErrLock.Unlock()
 			} else {

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -277,7 +277,7 @@ func testFetchConsistencyLevel(
 		assert.True(t, IsInternalServerError(err))
 		assert.False(t, IsBadRequestError(err))
 		resultErrStr := fmt.Sprintf("%v", err)
-		assert.True(t, strings.Contains(resultErrStr, fmt.Sprintf("failed to meet %s", level.String())))
+		assert.True(t, strings.Contains(resultErrStr, fmt.Sprintf("failed to meet %s with %d/3 success", level.String(), 3-failures)))
 		assert.True(t, strings.Contains(resultErrStr, fetchFailureErrStr))
 	}
 


### PR DESCRIPTION
cc @robskillington @cw9 

We use the length of the `errors` slice as the number of errors so we need to append all errors. Besides it provides full context about the errors, which helps debuggability