### PR TITLE
Minor fixes in Expire-Blocks-Data-And-Fetch-On-Read

### DIFF
--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -267,6 +267,9 @@ func (s *fileSystemSource) bootstrapFromReaders(
 					}
 
 					resultLock.Lock()
+					// NB(prateek): re-checking if the series was created in the interim while
+					// we released the lock
+					series, seriesExists = shardResult.AllSeries()[idHash]
 					if seriesExists {
 						series.Blocks.AddBlock(seriesBlock)
 					} else {

--- a/storage/options.go
+++ b/storage/options.go
@@ -295,7 +295,14 @@ func (o *options) SetEncodingM3TSZPooled() Options {
 	opts.blockOpts = opts.blockOpts.
 		SetEncoderPool(encoderPool).
 		SetReaderIteratorPool(readerIteratorPool).
-		SetMultiReaderIteratorPool(multiReaderIteratorPool)
+		SetMultiReaderIteratorPool(multiReaderIteratorPool).
+		SetSegmentReaderPool(segmentReaderPool)
+
+	dbBlockPool := block.NewDatabaseBlockPool(nil)
+	dbBlockPool.Init(func() block.DatabaseBlock {
+		return block.NewDatabaseBlock(timeZero, ts.Segment{}, opts.blockOpts)
+	})
+	opts.blockOpts = opts.blockOpts.SetDatabaseBlockPool(dbBlockPool)
 
 	opts.seriesPool = series.NewDatabaseSeriesPool(NewSeriesOptionsFromOptions(&opts), nil)
 


### PR DESCRIPTION
- Fix a race in fs-bootstrapper
- Fix db block pool initialization in `storage.Options`

/cc @r @xichen2020 