### PR TITLE
Add identifier pool to client session to avoid allocations and potential stack splits

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -1422,6 +1422,26 @@ func (_mr *_MockOptionsRecorder) FetchBatchSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchSize")
 }
 
+func (_m *MockOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
+	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+}
+
+func (_m *MockOptions) IdentifierPool() ts.IdentifierPool {
+	ret := _m.ctrl.Call(_m, "IdentifierPool")
+	ret0, _ := ret[0].(ts.IdentifierPool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) IdentifierPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
+}
+
 func (_m *MockOptions) SetHostQueueOpsFlushSize(value int) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushSize", value)
 	ret0, _ := ret[0].(Options)
@@ -2083,6 +2103,26 @@ func (_mr *_MockAdminOptionsRecorder) FetchBatchSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchSize")
 }
 
+func (_m *MockAdminOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
+	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+}
+
+func (_m *MockAdminOptions) IdentifierPool() ts.IdentifierPool {
+	ret := _m.ctrl.Call(_m, "IdentifierPool")
+	ret0, _ := ret[0].(ts.IdentifierPool)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) IdentifierPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
+}
+
 func (_m *MockAdminOptions) SetHostQueueOpsFlushSize(value int) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushSize", value)
 	ret0, _ := ret[0].(Options)
@@ -2321,24 +2361,4 @@ func (_m *MockAdminOptions) FetchSeriesBlocksBatchConcurrency() int {
 
 func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchConcurrency() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchConcurrency")
-}
-
-func (_m *MockAdminOptions) SetFetchSeriesBlocksResultsProcessors(value int) AdminOptions {
-	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksResultsProcessors", value)
-	ret0, _ := ret[0].(AdminOptions)
-	return ret0
-}
-
-func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksResultsProcessors(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksResultsProcessors", arg0)
-}
-
-func (_m *MockAdminOptions) FetchSeriesBlocksResultsProcessors() int {
-	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksResultsProcessors")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksResultsProcessors() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksResultsProcessors")
 }

--- a/client/session.go
+++ b/client/session.go
@@ -659,7 +659,7 @@ func (s *session) Write(namespace, id string, t time.Time, value float64, unit x
 
 	// todo@bl: Can we combine the writeOpPool and the writeStatePool?
 	state.op, state.majority = s.writeOpPool.Get(), majority
-	state.ctx, state.nsID, state.tsID = ctx, state.nsID, state.tsID
+	state.ctx, state.nsID, state.tsID = ctx, nsID, tsID
 
 	state.op.namespace = nsID
 	state.op.request.ID = tsID.Data().Get()

--- a/client/types.go
+++ b/client/types.go
@@ -467,6 +467,12 @@ type Options interface {
 	// FetchBatchSize returns the fetchBatchSize
 	FetchBatchSize() int
 
+	// SetIdentifierPool sets the identifier pool
+	SetIdentifierPool(value ts.IdentifierPool) Options
+
+	// IdentifierPool returns the identifier pool
+	IdentifierPool() ts.IdentifierPool
+
 	// SetHostQueueOpsFlushSize sets the hostQueueOpsFlushSize
 	SetHostQueueOpsFlushSize(value int) Options
 

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/topology"
 
 	"github.com/golang/mock/gomock"
@@ -126,6 +127,7 @@ func TestShardNotAvailable(t *testing.T) {
 
 func getWriteState(s *session) *writeState {
 	wState := s.writeStatePool.Get().(*writeState)
+	wState.ctx = context.NewContext()
 	wState.topoMap = s.topoMap
 	wState.op = s.writeOpPool.Get()
 	wState.op.shardID = 0 // Any valid shardID

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -26,12 +26,12 @@ package encoding
 import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
-	io0 "github.com/m3db/m3db/x/io"
+	io "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	io "io"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	io0 "io"
+	time0 "time"
 )
 
 // Mock of Encoder interface
@@ -55,7 +55,7 @@ func (_m *MockEncoder) EXPECT() *_MockEncoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Encode", dp, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -65,9 +65,9 @@ func (_mr *_MockEncoderRecorder) Encode(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0, arg1, arg2)
 }
 
-func (_m *MockEncoder) Stream() io0.SegmentReader {
+func (_m *MockEncoder) Stream() io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "Stream")
-	ret0, _ := ret[0].(io0.SegmentReader)
+	ret0, _ := ret[0].(io.SegmentReader)
 	return ret0
 }
 
@@ -75,7 +75,7 @@ func (_mr *_MockEncoderRecorder) Stream() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stream")
 }
 
-func (_m *MockEncoder) Reset(t time.Time, capacity int) {
+func (_m *MockEncoder) Reset(t time0.Time, capacity int) {
 	_m.ctrl.Call(_m, "Reset", t, capacity)
 }
 
@@ -101,7 +101,7 @@ func (_mr *_MockEncoderRecorder) Discard() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Discard")
 }
 
-func (_m *MockEncoder) DiscardReset(t time.Time, capacity int) ts.Segment {
+func (_m *MockEncoder) DiscardReset(t time0.Time, capacity int) ts.Segment {
 	ret := _m.ctrl.Call(_m, "DiscardReset", t, capacity)
 	ret0, _ := ret[0].(ts.Segment)
 	return ret0
@@ -132,7 +132,7 @@ func (_m *MockOptions) EXPECT() *_MockOptionsRecorder {
 	return _m.recorder
 }
 
-func (_m *MockOptions) SetDefaultTimeUnit(tu time0.Unit) Options {
+func (_m *MockOptions) SetDefaultTimeUnit(tu time.Unit) Options {
 	ret := _m.ctrl.Call(_m, "SetDefaultTimeUnit", tu)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -142,9 +142,9 @@ func (_mr *_MockOptionsRecorder) SetDefaultTimeUnit(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultTimeUnit", arg0)
 }
 
-func (_m *MockOptions) DefaultTimeUnit() time0.Unit {
+func (_m *MockOptions) DefaultTimeUnit() time.Unit {
 	ret := _m.ctrl.Call(_m, "DefaultTimeUnit")
-	ret0, _ := ret[0].(time0.Unit)
+	ret0, _ := ret[0].(time.Unit)
 	return ret0
 }
 
@@ -252,7 +252,7 @@ func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }
 
-func (_m *MockOptions) SetSegmentReaderPool(value io0.SegmentReaderPool) Options {
+func (_m *MockOptions) SetSegmentReaderPool(value io.SegmentReaderPool) Options {
 	ret := _m.ctrl.Call(_m, "SetSegmentReaderPool", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -262,9 +262,9 @@ func (_mr *_MockOptionsRecorder) SetSegmentReaderPool(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSegmentReaderPool", arg0)
 }
 
-func (_m *MockOptions) SegmentReaderPool() io0.SegmentReaderPool {
+func (_m *MockOptions) SegmentReaderPool() io.SegmentReaderPool {
 	ret := _m.ctrl.Call(_m, "SegmentReaderPool")
-	ret0, _ := ret[0].(io0.SegmentReaderPool)
+	ret0, _ := ret[0].(io.SegmentReaderPool)
 	return ret0
 }
 
@@ -303,10 +303,10 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -364,10 +364,10 @@ func (_mr *_MockReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -394,7 +394,7 @@ func (_mr *_MockReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockReaderIterator) Reset(reader io.Reader) {
+func (_m *MockReaderIterator) Reset(reader io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", reader)
 }
 
@@ -433,10 +433,10 @@ func (_mr *_MockMultiReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -463,7 +463,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockMultiReaderIterator) Reset(readers []io.Reader) {
+func (_m *MockMultiReaderIterator) Reset(readers []io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", readers)
 }
 
@@ -471,7 +471,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Reset(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0)
 }
 
-func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io0.ReaderSliceOfSlicesIterator) {
+func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io.ReaderSliceOfSlicesIterator) {
 	_m.ctrl.Call(_m, "ResetSliceOfSlices", readers)
 }
 
@@ -510,10 +510,10 @@ func (_mr *_MockSeriesIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockSeriesIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockSeriesIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -550,9 +550,9 @@ func (_mr *_MockSeriesIteratorRecorder) ID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ID")
 }
 
-func (_m *MockSeriesIterator) Start() time.Time {
+func (_m *MockSeriesIterator) Start() time0.Time {
 	ret := _m.ctrl.Call(_m, "Start")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -560,9 +560,9 @@ func (_mr *_MockSeriesIteratorRecorder) Start() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Start")
 }
 
-func (_m *MockSeriesIterator) End() time.Time {
+func (_m *MockSeriesIterator) End() time0.Time {
 	ret := _m.ctrl.Call(_m, "End")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -570,7 +570,7 @@ func (_mr *_MockSeriesIteratorRecorder) End() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "End")
 }
 
-func (_m *MockSeriesIterator) Reset(id string, startInclusive time.Time, endExclusive time.Time, replicas []Iterator) {
+func (_m *MockSeriesIterator) Reset(id string, startInclusive time0.Time, endExclusive time0.Time, replicas []Iterator) {
 	_m.ctrl.Call(_m, "Reset", id, startInclusive, endExclusive, replicas)
 }
 
@@ -723,7 +723,7 @@ func (_m *MockDecoder) EXPECT() *_MockDecoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDecoder) Decode(reader io.Reader) ReaderIterator {
+func (_m *MockDecoder) Decode(reader io0.Reader) ReaderIterator {
 	ret := _m.ctrl.Call(_m, "Decode", reader)
 	ret0, _ := ret[0].(ReaderIterator)
 	return ret0
@@ -798,7 +798,7 @@ func (_mr *_MockIStreamRecorder) PeekBits(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PeekBits", arg0)
 }
 
-func (_m *MockIStream) Reset(r io.Reader) {
+func (_m *MockIStream) Reset(r io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", r)
 }
 

--- a/integration/fake_cluster_services.go
+++ b/integration/fake_cluster_services.go
@@ -179,6 +179,18 @@ func (s *fakeM3ClusterServices) Watch(
 	return nil, fmt.Errorf("service not found: %s", service.Name())
 }
 
+func (s *fakeM3ClusterServices) Metadata(
+	sid services.ServiceID,
+) (services.Metadata, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *fakeM3ClusterServices) SetMetadata(
+	sid services.ServiceID, m services.Metadata,
+) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (s *fakeM3ClusterServices) PlacementService(
 	service services.ServiceID,
 	popts services.PlacementOptions,
@@ -238,9 +250,15 @@ func (s *fakeM3ClusterPlacementService) MarkInstanceAvailable(
 	return fmt.Errorf("not implemented")
 }
 func (s *fakeM3ClusterPlacementService) Placement() (
-	services.ServicePlacement, error,
+	services.ServicePlacement, int, error,
 ) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, 0, fmt.Errorf("not implemented")
+}
+
+func (s *fakeM3ClusterPlacementService) SetPlacement(
+	p services.ServicePlacement,
+) error {
+	return fmt.Errorf("not implemented")
 }
 
 // NewFakeM3ClusterService creates a new fake m3cluster service

--- a/persist/fs/commitlog/commit_log_mock.go
+++ b/persist/fs/commitlog/commit_log_mock.go
@@ -31,8 +31,9 @@ import (
 	retention "github.com/m3db/m3db/retention"
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	pool "github.com/m3db/m3x/pool"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of CommitLog interface
@@ -66,7 +67,7 @@ func (_mr *_MockCommitLogRecorder) Open() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open")
 }
 
-func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -76,7 +77,7 @@ func (_mr *_MockCommitLogRecorder) Write(arg0, arg1, arg2, arg3, arg4 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "WriteBehind", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -138,11 +139,11 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (Series, ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (Series, ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(Series)
 	ret1, _ := ret[1].(ts.Datapoint)
-	ret2, _ := ret[2].(time0.Unit)
+	ret2, _ := ret[2].(time.Unit)
 	ret3, _ := ret[3].(ts.Annotation)
 	return ret0, ret1, ret2, ret3
 }
@@ -310,7 +311,7 @@ func (_mr *_MockOptionsRecorder) Strategy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Strategy")
 }
 
-func (_m *MockOptions) SetFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -320,9 +321,9 @@ func (_mr *_MockOptionsRecorder) SetFlushInterval(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFlushInterval", arg0)
 }
 
-func (_m *MockOptions) FlushInterval() time.Duration {
+func (_m *MockOptions) FlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -348,4 +349,24 @@ func (_m *MockOptions) BacklogQueueSize() int {
 
 func (_mr *_MockOptionsRecorder) BacklogQueueSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BacklogQueueSize")
+}
+
+func (_m *MockOptions) SetBytesPool(value pool.CheckedBytesPool) Options {
+	ret := _m.ctrl.Call(_m, "SetBytesPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetBytesPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBytesPool", arg0)
+}
+
+func (_m *MockOptions) BytesPool() pool.CheckedBytesPool {
+	ret := _m.ctrl.Call(_m, "BytesPool")
+	ret0, _ := ret[0].(pool.CheckedBytesPool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }

--- a/storage/block/block_mock.go
+++ b/storage/block/block_mock.go
@@ -126,6 +126,16 @@ func (_mr *_MockFetchBlockResultRecorder) Err() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Err")
 }
 
+func (_m *MockFetchBlockResult) Checksum() *uint32 {
+	ret := _m.ctrl.Call(_m, "Checksum")
+	ret0, _ := ret[0].(*uint32)
+	return ret0
+}
+
+func (_mr *_MockFetchBlockResultRecorder) Checksum() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Checksum")
+}
+
 // Mock of FetchBlockMetadataResults interface
 type MockFetchBlockMetadataResults struct {
 	ctrl     *gomock.Controller

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -24,8 +24,6 @@
 package series
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
@@ -36,7 +34,8 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of DatabaseSeries interface
@@ -81,7 +80,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Tick() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick")
 }
 
-func (_m *MockDatabaseSeries) Write(ctx context.Context, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockDatabaseSeries) Write(ctx context.Context, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -91,7 +90,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Write(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabaseSeries) ReadEncoded(ctx context.Context, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabaseSeries) ReadEncoded(ctx context.Context, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -102,7 +101,7 @@ func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
+func (_m *MockDatabaseSeries) FetchBlocks(ctx context.Context, starts []time0.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -112,7 +111,7 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockDatabaseSeries) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, includeSizes bool, includeChecksums bool) block.FetchBlocksMetadataResult {
+func (_m *MockDatabaseSeries) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, includeSizes bool, includeChecksums bool) block.FetchBlocksMetadataResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResult)
 	return ret0
@@ -162,7 +161,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Update(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
 }
 
-func (_m *MockDatabaseSeries) Flush(ctx context.Context, blockStart time.Time, persistFn persist.Fn) error {
+func (_m *MockDatabaseSeries) Flush(ctx context.Context, blockStart time0.Time, persistFn persist.Fn) error {
 	ret := _m.ctrl.Call(_m, "Flush", ctx, blockStart, persistFn)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -248,7 +247,7 @@ func (_m *MockdatabaseBuffer) EXPECT() *_MockdatabaseBufferRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -258,7 +257,7 @@ func (_mr *_MockdatabaseBufferRecorder) Write(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time.Time, end time.Time) [][]io.SegmentReader {
+func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time0.Time, end time0.Time) [][]io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	return ret0
@@ -268,7 +267,7 @@ func (_mr *_MockdatabaseBufferRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
+func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time0.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -278,7 +277,7 @@ func (_mr *_MockdatabaseBufferRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
+func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlockMetadataResults)
 	return ret0
@@ -298,10 +297,10 @@ func (_mr *_MockdatabaseBufferRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockdatabaseBuffer) MinMax() (time.Time, time.Time) {
+func (_m *MockdatabaseBuffer) MinMax() (time0.Time, time0.Time) {
 	ret := _m.ctrl.Call(_m, "MinMax")
-	ret0, _ := ret[0].(time.Time)
-	ret1, _ := ret[1].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
+	ret1, _ := ret[1].(time0.Time)
 	return ret0, ret1
 }
 

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -24,8 +24,6 @@
 package storage
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
@@ -45,6 +43,7 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of Database interface
@@ -1441,6 +1440,26 @@ func (_m *MockOptions) CommitLogOptions() commitlog.Options {
 
 func (_mr *_MockOptionsRecorder) CommitLogOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CommitLogOptions")
+}
+
+func (_m *MockOptions) SetRepairEnabled(b bool) Options {
+	ret := _m.ctrl.Call(_m, "SetRepairEnabled", b)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetRepairEnabled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRepairEnabled", arg0)
+}
+
+func (_m *MockOptions) RepairEnabled() bool {
+	ret := _m.ctrl.Call(_m, "RepairEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) RepairEnabled() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RepairEnabled")
 }
 
 func (_m *MockOptions) SetRepairOptions(value repair.Options) Options {

--- a/ts/identifier.go
+++ b/ts/identifier.go
@@ -110,6 +110,7 @@ func (v *id) Finalize() {
 	v.data.DecRef()
 	v.data.Finalize()
 	v.data = nil
+	v.hash = null
 
 	if v.pool == nil {
 		return


### PR DESCRIPTION
Using `ts.ID` with `checked.Bytes` the allocations become quite heavy at large write volumes.  This change adds an identifier pool to the client session to avoid these ongoing heavy allocations.

cc @xichen2020 @cw9 @prateek @ben-lerner 