### PR TITLE
Keep less open file descriptors for fs Seeker and Reader

### DIFF
--- a/digest/fd_digest.go
+++ b/digest/fd_digest.go
@@ -67,7 +67,10 @@ func (fwd *fdWithDigest) Reset(fd *os.File) {
 
 // Close closes the file descriptor.
 func (fwd *fdWithDigest) Close() error {
-	fd := fwd.fd
+	if fwd.fd == nil {
+		return nil
+	}
+	err := fwd.fd.Close()
 	fwd.fd = nil
-	return fd.Close()
+	return err
 }

--- a/persist/fs/read.go
+++ b/persist/fs/read.go
@@ -126,7 +126,7 @@ func (r *reader) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	r.digestFdWithDigestContents.Reset(digestFd)
 
 	defer func() {
-		// NB(r): We don't need to keep these FDs open as we these up front
+		// NB(r): We don't need to keep these FDs open as we use these up front
 		r.infoFdWithDigest.Close()
 		r.indexFdWithDigest.Close()
 		r.digestFdWithDigestContents.Close()

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -110,7 +110,7 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	s.digestFdWithDigestContents.Reset(digestFd)
 
 	defer func() {
-		// NB(r): We don't need to keep these FDs open as we these up front
+		// NB(r): We don't need to keep these FDs open as we use these up front
 		s.infoFdWithDigest.Close()
 		s.indexFdWithDigest.Close()
 		s.digestFdWithDigestContents.Close()
@@ -274,6 +274,9 @@ func (s *seeker) Close() error {
 	// Prepare for reuse
 	for key := range s.indexMap {
 		delete(s.indexMap, key)
+	}
+	if s.dataFd == nil {
+		return nil
 	}
 	err := s.dataFd.Close()
 	s.dataFd = nil

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -104,9 +104,18 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	}); err != nil {
 		return err
 	}
+
 	s.infoFdWithDigest.Reset(infoFd)
 	s.indexFdWithDigest.Reset(indexFd)
 	s.digestFdWithDigestContents.Reset(digestFd)
+
+	defer func() {
+		// NB(r): We don't need to keep these FDs open as we these up front
+		s.infoFdWithDigest.Close()
+		s.indexFdWithDigest.Close()
+		s.digestFdWithDigestContents.Close()
+	}()
+
 	if err := s.readDigest(); err != nil {
 		// Try to close if failed to read
 		s.Close()
@@ -262,8 +271,11 @@ func (s *seeker) Entries() int {
 }
 
 func (s *seeker) Close() error {
-	return closeAll(
-		s.infoFdWithDigest,
-		s.indexFdWithDigest,
-	)
+	// Prepare for reuse
+	for key := range s.indexMap {
+		delete(s.indexMap, key)
+	}
+	err := s.dataFd.Close()
+	s.dataFd = nil
+	return err
 }


### PR DESCRIPTION
Using a high shard count with a lot of open seekers the process can use a ton of FDs:
```
250 shards * 24 filesets * (info fd + index fd + digest fd + data fd) = 24,000
```

We can cut down the amount of idle open FDs by 75% by closing them after the initial open.