### PR TITLE
Add an option to disable repair on database level

### DIFF
--- a/storage/database.go
+++ b/storage/database.go
@@ -208,11 +208,14 @@ func NewDatabase(
 
 	d.bsm = newBootstrapManager(d, d.fsm)
 
-	repairer, err := newDatabaseRepairer(d)
-	if err != nil {
-		return nil, err
+	if opts.RepairEnabled() {
+		d.repairer, err = newDatabaseRepairer(d)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		d.repairer = newNoopDatabaseRepairer()
 	}
-	d.repairer = repairer
 
 	return d, nil
 }

--- a/storage/options.go
+++ b/storage/options.go
@@ -60,6 +60,9 @@ const (
 
 	// defaultBytesPoolBucketCount is the default count of elements for the default bytes pool bucket
 	defaultBytesPoolBucketCount = 4096
+
+	// defaultRepairEnabled enables repair by default
+	defaultRepairEnabled = true
 )
 
 var (
@@ -95,6 +98,7 @@ type options struct {
 	retentionOpts                  retention.Options
 	blockOpts                      block.Options
 	commitLogOpts                  commitlog.Options
+	repairEnabled                  bool
 	repairOpts                     repair.Options
 	fileOpOpts                     FileOpOptions
 	newEncoderFn                   encoding.NewEncoderFn
@@ -130,6 +134,7 @@ func NewOptions() Options {
 		retentionOpts:                  retention.NewOptions(),
 		blockOpts:                      block.NewOptions(),
 		commitLogOpts:                  commitlog.NewOptions(),
+		repairEnabled:                  defaultRepairEnabled,
 		repairOpts:                     repair.NewOptions(),
 		fileOpOpts:                     NewFileOpOptions(),
 		newBootstrapFn:                 defaultNewBootstrapFn,
@@ -205,6 +210,16 @@ func (o *options) SetCommitLogOptions(value commitlog.Options) Options {
 
 func (o *options) CommitLogOptions() commitlog.Options {
 	return o.commitLogOpts
+}
+
+func (o *options) SetRepairEnabled(b bool) Options {
+	opts := *o
+	opts.repairEnabled = b
+	return &opts
+}
+
+func (o *options) RepairEnabled() bool {
+	return o.repairEnabled
 }
 
 func (o *options) SetRepairOptions(value repair.Options) Options {

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -372,3 +372,14 @@ func (r *dbRepairer) repairWithTimeRange(tr xtime.Range) error {
 func (r *dbRepairer) IsRepairing() bool {
 	return atomic.LoadInt32(&r.running) == 1
 }
+
+type noopRepairer struct{}
+
+func newNoopDatabaseRepairer() databaseRepairer {
+	return noopRepairer{}
+}
+
+func (r noopRepairer) Start()            {}
+func (r noopRepairer) Stop()             {}
+func (r noopRepairer) Repair() error     { return nil }
+func (r noopRepairer) IsRepairing() bool { return false }

--- a/storage/types.go
+++ b/storage/types.go
@@ -439,6 +439,12 @@ type Options interface {
 	// CommitLogOptions returns the commit log options
 	CommitLogOptions() commitlog.Options
 
+	// SetRepairEnabled sets whether or not to enable the repair
+	SetRepairEnabled(b bool) Options
+
+	// RepairEnabled returns whether the repair is enabled
+	RepairEnabled() bool
+
 	// SetRepairOptions sets the repair options
 	SetRepairOptions(value repair.Options) Options
 


### PR DESCRIPTION
Use a noop repairer if no repair is needed, this is in order to avoid having to pass in a repair option with a valid admin client when the user don't need to repair at all.

A similar commit has been made on dev branch (#239), but cherry-picking that is too hard because that commit also touches several repair integration tests that are not in the master branch

@xichen2020 @robskillington 