### PR TITLE
Make seeker reusable

### DIFF
--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -181,6 +181,13 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 		return err
 	}
 
+	if !s.keepUnreadBuf {
+		// NB(r): Free the unread buffer and reset the decoder as unless
+		// using this seeker in the seeker manager we never use this buffer again
+		s.unreadBuf = nil
+		s.decoder.Reset(nil)
+	}
+
 	s.dataFd = dataFd
 	return nil
 }
@@ -256,12 +263,6 @@ func (s *seeker) readIndex(size int) error {
 			id := ts.BinaryID(checked.NewBytes(entryID, nil))
 			s.indexIDs = append(s.indexIDs, id)
 		}
-	}
-
-	if !s.keepUnreadBuf {
-		// NB(r): Free the unread buffer and reset the decoder as unless
-		// using this seeker in the seeker manager we never use this buffer again
-		s.unreadBuf = nil
 	}
 
 	return nil

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -262,7 +262,6 @@ func (s *seeker) readIndex(size int) error {
 		// NB(r): Free the unread buffer and reset the decoder as unless
 		// using this seeker in the seeker manager we never use this buffer again
 		s.unreadBuf = nil
-		s.decoder = nil
 	}
 
 	return nil


### PR DESCRIPTION
We were setting decoder to nil after calling seeker.readIndex, which causes future read calls to panic on nil decoder, I don't think it's necessary to set the decoder to nil, let me know your thoughts, will add unit test if this approach looks good.

@xichen2020 @robskillington @martin-mao 