### PR TITLE
Format session errors with fmt.Sprintf(..) vs custom fmt

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -146,14 +146,3 @@ func (e consistencyResultErr) numResponded() int {
 func (e consistencyResultErr) numSuccess() int {
 	return e.success
 }
-
-type errs []error
-
-func (e errs) String() string {
-	strs := make([]string, len(e))
-	for i, e := range e {
-		strs[i] = e.Error()
-	}
-	return strings.Join(strs, ", ")
-}
-

--- a/client/errors.go
+++ b/client/errors.go
@@ -146,3 +146,14 @@ func (e consistencyResultErr) numResponded() int {
 func (e consistencyResultErr) numSuccess() int {
 	return e.success
 }
+
+type errs []error
+
+func (e errs) String() string {
+	strs := make([]string, len(e))
+	for i, e := range e {
+		strs[i] = e.Error()
+	}
+	return strings.Join(strs, ", ")
+}
+

--- a/client/session.go
+++ b/client/session.go
@@ -1680,7 +1680,7 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 				xlog.NewLogField("id", currID.String()),
 				xlog.NewLogField("start", earliestStart),
 				xlog.NewLogField("attempted", unselected.reattempt.attempt),
-				xlog.NewLogField("attemptErrs", errs(unselected.reattempt.errs)),
+				xlog.NewLogField("attemptErrs", xerrors.Errors(unselected.reattempt.errs).Error()),
 			).Error("retries failed for streaming blocks from peers")
 
 			// Remove the block from all peers

--- a/client/session.go
+++ b/client/session.go
@@ -1680,7 +1680,7 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 				xlog.NewLogField("id", currID.String()),
 				xlog.NewLogField("start", earliestStart),
 				xlog.NewLogField("attempted", unselected.reattempt.attempt),
-				xlog.NewLogField("attemptErrs", fmt.Sprintf("%v", unselected.reattempt.errs)),
+				xlog.NewLogField("attemptErrs", errs(unselected.reattempt.errs)),
 			).Error("retries failed for streaming blocks from peers")
 
 			// Remove the block from all peers

--- a/client/session.go
+++ b/client/session.go
@@ -1674,30 +1674,13 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 		}
 
 		if len(currEligible) == 0 {
-			// Format errors
-			var fmtErrs bytes.Buffer
-			fmtErrs.WriteString("[")
-			allErrs := currStart[0].unselectedBlocks()[0].reattempt.errs
-			for i, err := range allErrs {
-				if err == nil {
-					fmtErrs.WriteString("{nil}")
-				} else {
-					fmtErrs.WriteString("{")
-					fmtErrs.WriteString(err.Error())
-					fmtErrs.WriteString("}")
-				}
-				if i < len(allErrs)-1 {
-					fmtErrs.WriteString(",")
-				}
-			}
-			fmtErrs.WriteString("]")
-
 			// No current eligible peers to select from
+			unselected := currStart[0].unselectedBlocks()[0]
 			s.log.WithFields(
 				xlog.NewLogField("id", currID.String()),
 				xlog.NewLogField("start", earliestStart),
-				xlog.NewLogField("attempted", currStart[0].unselectedBlocks()[0].reattempt.attempt),
-				xlog.NewLogField("attemptErrs", fmtErrs.String()),
+				xlog.NewLogField("attempted", unselected.reattempt.attempt),
+				xlog.NewLogField("attemptErrs", fmt.Sprintf("%v", unselected.reattempt.errs)),
 			).Error("retries failed for streaming blocks from peers")
 
 			// Remove the block from all peers

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 09ab13f73be8ab74741d9f986ae8809c1e514542ae11820f449cbce196b08a09
-updated: 2017-02-08T01:10:53.55187587-05:00
+hash: 2838ee948517d8c6d2f184fccb096cf6aa891f3b8c60df4665451012b67b70e4
+updated: 2017-02-11T15:25:24.689588906-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -28,7 +28,7 @@ imports:
   - services/placement
   - shard
 - name: github.com/m3db/m3x
-  version: 41e3f053bd721ec1d6ba8d4eef3e036290aa7977
+  version: 02e9797823472696a38526146e820d3faf2bc807
   vcs: git
   subpackages:
   - checked

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,7 +45,7 @@ import:
   - services
 
 - package: github.com/m3db/m3x
-  version: 41e3f053bd721ec1d6ba8d4eef3e036290aa7977
+  version: 02e9797823472696a38526146e820d3faf2bc807
   vcs: git
   subpackages:
   - checked


### PR DESCRIPTION
This PR uses the inbuilt `fmt.Sprintf(...)` to format errors in the session select blocks from peers method.