### PR TITLE
Maintain block order after peer selection or exhaustion during peer streaming

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -1684,12 +1684,12 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 			).Error("retries failed for streaming blocks from peers")
 
 			// Remove the block from all peers
+			// NB(xichen): we shift the blocks instead of swapping in order to maintain the
+			// invariant that the blocks are sorted by the block start times in ascending order
 			for i := range currStart {
 				blocksLen := len(currStart[i].blocks)
 				idx := currStart[i].idx
-				tailIdx := blocksLen - 1
-				currStart[i].blocks[idx], currStart[i].blocks[tailIdx] =
-					currStart[i].blocks[tailIdx], currStart[i].blocks[idx]
+				copy(currStart[i].blocks[idx:], currStart[i].blocks[idx+1:])
 				currStart[i].blocks = currStart[i].blocks[:blocksLen-1]
 			}
 			continue
@@ -1766,11 +1766,11 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 				}
 
 				// Removing this block
+				// NB(xichen): we shift the blocks instead of swapping in order to maintain the
+				// invariant that the blocks are sorted by the block start times in ascending order
 				blocksLen := len(currStart[i].blocks)
 				idx := currStart[i].idx
-				tailIdx := blocksLen - 1
-				currStart[i].blocks[idx], currStart[i].blocks[tailIdx] =
-					currStart[i].blocks[tailIdx], currStart[i].blocks[idx]
+				copy(currStart[i].blocks[idx:], currStart[i].blocks[idx+1:])
 				currStart[i].blocks = currStart[i].blocks[:blocksLen-1]
 			}
 		} else {

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -96,7 +96,7 @@ func TestFetchBootstrapBlocksAllPeersSucceed(t *testing.T) {
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
@@ -122,7 +122,7 @@ func TestFetchBootstrapBlocksAllPeersSucceed(t *testing.T) {
 		return q
 	}
 
-	assert.NoError(t, session.Open())
+	require.NoError(t, session.Open())
 
 	batchSize := opts.FetchSeriesBlocksBatchSize()
 	blockSize := 2 * time.Hour
@@ -226,7 +226,7 @@ func fetchBlocksFromPeersTestsHelper(
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
@@ -252,7 +252,7 @@ func fetchBlocksFromPeersTestsHelper(
 		return q
 	}
 
-	assert.NoError(t, session.Open())
+	require.NoError(t, session.Open())
 
 	batchSize := opts.FetchSeriesBlocksBatchSize()
 	blockSize := 2 * time.Hour
@@ -582,7 +582,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAllPeersSucceed(t *testing.T
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -641,7 +641,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -723,7 +723,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeAvailableBlocks(t *testi
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -807,7 +807,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsReattemptingFromAttemp
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -888,7 +888,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	opts := newSessionTestAdminOptions().
 		SetFetchSeriesBlocksMaxBlockRetries(0)
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -970,7 +970,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries(t *testing.T
 	opts := newSessionTestAdminOptions().
 		SetFetchSeriesBlocksMaxBlockRetries(2)
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -1052,7 +1052,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	opts := newSessionTestAdminOptions().
 		SetFetchSeriesBlocksMaxBlockRetries(2)
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -1132,7 +1132,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	opts := newSessionTestAdminOptions().
 		SetFetchSeriesBlocksMaxBlockRetries(2)
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 
 	var (
@@ -1212,7 +1212,7 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 	session.reattemptStreamBlocksFromPeersFn = func(
 		blocks []blockMetadata,
@@ -1227,7 +1227,7 @@ func TestStreamBlocksBatchFromPeerReenqueuesOnFailCall(t *testing.T) {
 
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
 	session.newHostQueueFn = mockHostQueues.newHostQueueFn()
-	assert.NoError(t, session.Open())
+	require.NoError(t, session.Open())
 
 	var (
 		blockSize = 2 * time.Hour
@@ -1292,7 +1292,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 	session.reattemptStreamBlocksFromPeersFn = func(
 		blocks []blockMetadata,
@@ -1307,7 +1307,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
 	session.newHostQueueFn = mockHostQueues.newHostQueueFn()
-	assert.NoError(t, session.Open())
+	require.NoError(t, session.Open())
 
 	blockSize := 2 * time.Hour
 	start := time.Now().Truncate(blockSize).Add(blockSize * -(24 - 1))
@@ -1421,7 +1421,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 
 	opts := newSessionTestAdminOptions()
 	s, err := newSession(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	session := s.(*session)
 	session.reattemptStreamBlocksFromPeersFn = func(
 		blocks []blockMetadata,
@@ -1437,7 +1437,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 	mockHostQueues, mockClients := mockHostQueuesAndClientsForFetchBootstrapBlocks(ctrl, opts)
 	session.newHostQueueFn = mockHostQueues.newHostQueueFn()
 
-	assert.NoError(t, session.Open())
+	require.NoError(t, session.Open())
 
 	blockSize := 2 * time.Hour
 	start := time.Now().Truncate(blockSize).Add(blockSize * -(24 - 1))
@@ -1554,8 +1554,6 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 
 	assert.NoError(t, session.Close())
 }
-
-// TODO: add test TestVerifyFetchedBlockSize
 
 func TestBlocksResultAddBlockFromPeerReadMerged(t *testing.T) {
 	opts := newSessionTestAdminOptions()


### PR DESCRIPTION
cc @robskillington @prateek @ben-lerner 

This PR fixes an issue when removing blocks from peers after we select a block from multiple peer candidate or the peer list has been exhausted. In particular when a block is removed, we used to swap it with the last block and shrink the block list, thereby destroying invariant that the blocks are sorted by their start times. This in turn causes issues because we use the block start times to determine which peers can provide the block and relies on the block order to align the peers. When the block ordering is disrupted, it leads to the error case where a block is only selected from one peer, even though multiple peers are eligible to provide this block.

Also added two test cases to catch the error cases. Both cases are failing against HEAD and passing against this PR.