### PR TITLE
Peer streaming only fails when unable to read data from any peer during merging reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,9 @@ test-internal:
 	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
 	@$(VENDOR_ENV) $(test) $(coverfile) | tee $(test_log)
 
+# Do not test native pooling for now due to slow travis builds
 test-integration:
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false go test -v -tags=integration ./integration
-	@$(VENDOR_ENV) TEST_NATIVE_POOLING=true go test -v -tags=integration ./integration
 
 test-xml: test-internal
 	go-junit-report < $(test_log) > $(junit_xml)
@@ -129,9 +129,9 @@ test-ci-unit: test-internal
 	@which goveralls > /dev/null || go get -u -f github.com/mattn/goveralls
 	goveralls -coverprofile=$(coverfile) -service=travis-ci || echo -e "Coveralls failed"
 
+# Do not test native pooling for now due to slow travis builds
 test-ci-integration:
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false $(test_ci_integration)
-	@$(VENDOR_ENV) TEST_NATIVE_POOLING=true $(test_ci_integration)
 
 # run as: make test-one-integration test=<test_name>
 test-one-integration:

--- a/client/session.go
+++ b/client/session.go
@@ -1721,7 +1721,7 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 		// If all the peers have the same non-nil checksum, we pick the peer with the
 		// fewest attempts and fewest outstanding requests
 		if singlePeer || sameNonNilChecksum {
-			// Prepare the reattempt peers metadata
+			// Prepare the reattempt peers metadata so we can retry from any of the peers on failure
 			peersMetadata := make([]blockMetadataReattemptPeerMetadata, 0, len(currEligible))
 			for i := range currEligible {
 				unselected := currEligible[i].unselectedBlocks()

--- a/client/session.go
+++ b/client/session.go
@@ -1795,6 +1795,9 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 				currStart[i].idx = idx + 1
 
 				// Set the reattempt metadata
+				// NB(xichen): each block will only be retried on the same peer because we
+				// already fan out the request to all peers. This means we merge data on
+				// a best-effort basis and only fail if we failed to read data from all peers.
 				peer := currStart[i].peer
 				block := currStart[i].blocks[idx]
 				currStart[i].blocks[idx].reattempt.id = currID

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -689,15 +689,15 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, int64(2), perPeer[0].blocks[0].size)
 	assert.Equal(t, &checksums[1], perPeer[0].blocks[0].checksum)
 
-	assert.Equal(t, 2, perPeer[0].blocks[0].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[0].blocks[0].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[0].blocks[0].reattempt.attempt)
+	assert.Equal(t, []peer{peerA}, perPeer[0].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[0].blocks[1].start)
 	assert.Equal(t, int64(1), perPeer[0].blocks[1].size)
 	assert.Equal(t, &checksums[0], perPeer[0].blocks[1].checksum)
 
-	assert.Equal(t, 2, perPeer[0].blocks[1].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[0].blocks[1].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[0].blocks[1].reattempt.attempt)
+	assert.Equal(t, []peer{peerA}, perPeer[0].blocks[1].reattempt.attempted)
 
 	// Assert selection second peer
 	assert.Equal(t, 2, len(perPeer[1].blocks))
@@ -706,7 +706,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, int64(1), perPeer[1].blocks[0].size)
 	assert.Equal(t, &checksums[0], perPeer[1].blocks[0].checksum)
 
-	assert.Equal(t, 2, perPeer[1].blocks[0].reattempt.attempt)
+	assert.Equal(t, 1, perPeer[1].blocks[0].reattempt.attempt)
 	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[1].blocks[1].start)

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -707,14 +707,14 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, &checksums[0], perPeer[1].blocks[0].checksum)
 
 	assert.Equal(t, 1, perPeer[1].blocks[0].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[0].reattempt.attempted)
+	assert.Equal(t, []peer{peerB}, perPeer[1].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[1].blocks[1].start)
 	assert.Equal(t, int64(2), perPeer[1].blocks[1].size)
 	assert.Equal(t, &checksums[1], perPeer[1].blocks[1].checksum)
 
-	assert.Equal(t, 2, perPeer[1].blocks[1].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[1].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[1].blocks[1].reattempt.attempt)
+	assert.Equal(t, []peer{peerB}, perPeer[1].blocks[1].reattempt.attempted)
 }
 
 func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeAvailableBlocks(t *testing.T) {


### PR DESCRIPTION
cc @robskillington @ben-lerner @prateek 

This PR fixes an issue during merging reads where if we failed to read from even one peer, the block will be retried across all peers, tripling the load on the cluster. Additionally, it is considered as a failure if we couldn't  read from any of the peers. This is not what we want, in particular if one peer is malfunctioning, we should still consider it a success if we could read from the other peers.

This PR changes it so that if we manage to read data from at least one of the peers, we consider it a success. In addition, if we fail to read data from a peer during a merging read, the attempt will only be retried on that peer and therefore significantly reducing the number of attempts.