### PR TITLE
Add metrics to report final errors during peer streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,9 @@ test-internal:
 	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report
 	@$(VENDOR_ENV) $(test) $(coverfile) | tee $(test_log)
 
+# Do not test native pooling for now due to slow travis builds
 test-integration:
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false go test -v -tags=integration ./integration
-	@$(VENDOR_ENV) TEST_NATIVE_POOLING=true go test -v -tags=integration ./integration
 
 test-xml: test-internal
 	go-junit-report < $(test_log) > $(junit_xml)
@@ -129,9 +129,9 @@ test-ci-unit: test-internal
 	@which goveralls > /dev/null || go get -u -f github.com/mattn/goveralls
 	goveralls -coverprofile=$(coverfile) -service=travis-ci || echo -e "Coveralls failed"
 
+# Do not test native pooling for now due to slow travis builds
 test-ci-integration:
 	@$(VENDOR_ENV) TEST_NATIVE_POOLING=false $(test_ci_integration)
-	@$(VENDOR_ENV) TEST_NATIVE_POOLING=true $(test_ci_integration)
 
 # run as: make test-one-integration test=<test_name>
 test-one-integration:

--- a/client/session.go
+++ b/client/session.go
@@ -1721,7 +1721,7 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 		// If all the peers have the same non-nil checksum, we pick the peer with the
 		// fewest attempts and fewest outstanding requests
 		if singlePeer || sameNonNilChecksum {
-			// Prepare the reattempt peers metadata
+			// Prepare the reattempt peers metadata so we can retry from any of the peers on failure
 			peersMetadata := make([]blockMetadataReattemptPeerMetadata, 0, len(currEligible))
 			for i := range currEligible {
 				unselected := currEligible[i].unselectedBlocks()

--- a/client/session.go
+++ b/client/session.go
@@ -1795,6 +1795,9 @@ func (s *session) selectBlocksForSeriesFromPeerBlocksMetadata(
 				currStart[i].idx = idx + 1
 
 				// Set the reattempt metadata
+				// NB(xichen): each block will only be retried on the same peer because we
+				// already fan out the request to all peers. This means we merge data on
+				// a best-effort basis and only fail if we failed to read data from all peers.
 				peer := currStart[i].peer
 				block := currStart[i].blocks[idx]
 				currStart[i].blocks[idx].reattempt.id = currID

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -586,6 +586,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAllPeersSucceed(t *testing.T
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peers            = preparedMockPeers(peerA, peerB)
@@ -619,7 +620,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAllPeersSucceed(t *testing.T
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 1, len(perPeer[0].blocks))
@@ -645,6 +646,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peers            = preparedMockPeers(peerA, peerB)
@@ -680,7 +682,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 2, len(perPeer[0].blocks))
@@ -727,6 +729,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeAvailableBlocks(t *testi
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peerC            = NewMockpeer(ctrl)
@@ -768,7 +771,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeAvailableBlocks(t *testi
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 1, len(perPeer[0].blocks))
@@ -811,6 +814,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsReattemptingFromAttemp
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peerC            = NewMockpeer(ctrl)
@@ -862,7 +866,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsReattemptingFromAttemp
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 0, len(perPeer[0].blocks))
@@ -892,6 +896,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peerC            = NewMockpeer(ctrl)
@@ -944,7 +949,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataAvoidsExhaustedBlocks(t *tes
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	require.Equal(t, 1, len(perPeer[0].blocks))
@@ -974,6 +979,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries(t *testing.T
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peers            = preparedMockPeers(peerA, peerB)
@@ -1020,7 +1026,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataPerformsRetries(t *testing.T
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 0, len(perPeer[0].blocks))
@@ -1056,6 +1062,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peers            = preparedMockPeers(peerA, peerB)
@@ -1102,7 +1109,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 0, len(perPeer[0].blocks))
@@ -1136,6 +1143,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	session := s.(*session)
 
 	var (
+		metrics          = session.streamFromPeersMetricsForShard(0, resultTypeTest)
 		peerA            = NewMockpeer(ctrl)
 		peerB            = NewMockpeer(ctrl)
 		peers            = preparedMockPeers(peerA, peerB)
@@ -1176,7 +1184,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataMaintainsBlockOrderAfterPeer
 	// Perform selection
 	session.selectBlocksForSeriesFromPeerBlocksMetadata(
 		perPeer, peerBlocksQueues,
-		currStart, currEligible, blocksMetadataQueues)
+		currStart, currEligible, blocksMetadataQueues, metrics)
 
 	// Assert selection first peer
 	assert.Equal(t, 0, len(perPeer[0].blocks))

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -689,15 +689,15 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, int64(2), perPeer[0].blocks[0].size)
 	assert.Equal(t, &checksums[1], perPeer[0].blocks[0].checksum)
 
-	assert.Equal(t, 2, perPeer[0].blocks[0].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[0].blocks[0].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[0].blocks[0].reattempt.attempt)
+	assert.Equal(t, []peer{peerA}, perPeer[0].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[0].blocks[1].start)
 	assert.Equal(t, int64(1), perPeer[0].blocks[1].size)
 	assert.Equal(t, &checksums[0], perPeer[0].blocks[1].checksum)
 
-	assert.Equal(t, 2, perPeer[0].blocks[1].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[0].blocks[1].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[0].blocks[1].reattempt.attempt)
+	assert.Equal(t, []peer{peerA}, perPeer[0].blocks[1].reattempt.attempted)
 
 	// Assert selection second peer
 	assert.Equal(t, 2, len(perPeer[1].blocks))
@@ -706,7 +706,7 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, int64(1), perPeer[1].blocks[0].size)
 	assert.Equal(t, &checksums[0], perPeer[1].blocks[0].checksum)
 
-	assert.Equal(t, 2, perPeer[1].blocks[0].reattempt.attempt)
+	assert.Equal(t, 1, perPeer[1].blocks[0].reattempt.attempt)
 	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[1].blocks[1].start)

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -707,14 +707,14 @@ func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeLargerBlocks(t *testing.
 	assert.Equal(t, &checksums[0], perPeer[1].blocks[0].checksum)
 
 	assert.Equal(t, 1, perPeer[1].blocks[0].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[0].reattempt.attempted)
+	assert.Equal(t, []peer{peerB}, perPeer[1].blocks[0].reattempt.attempted)
 
 	assert.Equal(t, start.Add(time.Hour*2), perPeer[1].blocks[1].start)
 	assert.Equal(t, int64(2), perPeer[1].blocks[1].size)
 	assert.Equal(t, &checksums[1], perPeer[1].blocks[1].checksum)
 
-	assert.Equal(t, 2, perPeer[1].blocks[1].reattempt.attempt)
-	assert.Equal(t, []peer{peerA, peerB}, perPeer[1].blocks[1].reattempt.attempted)
+	assert.Equal(t, 1, perPeer[1].blocks[1].reattempt.attempt)
+	assert.Equal(t, []peer{peerB}, perPeer[1].blocks[1].reattempt.attempted)
 }
 
 func TestSelectBlocksForSeriesFromPeerBlocksMetadataTakeAvailableBlocks(t *testing.T) {


### PR DESCRIPTION
cc @robskillington @prateek @ben-lerner 

This PR adds a metric to report final errors (as opposed to intermediate errors we are reporting now) during peer streaming, which is likely to be the high-level metric we care about.

Also converted some logging messages to be debugging messages since they pollute logs with intermediate block fetch errors and we already capture them in reattempt data structures.