### PR TITLE
Avoid checking namespace path exists when creating a retriever

### DIFF
--- a/persist/fs/retriever.go
+++ b/persist/fs/retriever.go
@@ -22,8 +22,6 @@ package fs
 
 import (
 	"errors"
-	"fmt"
-	"os"
 	"sort"
 	"sync"
 	"time"
@@ -109,20 +107,6 @@ func (r *blockRetriever) Open(namespace ts.ID) error {
 
 	if r.status != blockRetrieverNotOpen {
 		return errBlockRetrieverAlreadyOpenOrClosed
-	}
-
-	filePathPrefix := r.fsOpts.FilePathPrefix()
-	dir, err := os.Open(NamespaceDirPath(filePathPrefix, namespace))
-	if err != nil {
-		return err
-	}
-	stat, err := dir.Stat()
-	if err != nil {
-		return err
-	}
-	if !stat.IsDir() {
-		return fmt.Errorf("path for namespace %s is not a directory",
-			namespace.String())
 	}
 
 	seekerMgrs := make([]FileSetSeekerManager, 0, r.opts.FetchConcurrency())


### PR DESCRIPTION
This change avoids checking the namespace path exists when a new retriever is opened.  There is the possibility no flushes have ever occurred and since the seeker already validates before opening the fileset exists at the namespace there is no need to check this before use.

On seek to a block it will validate the namespace, shard and block fileset all exists before trying to open it.

cc @xichen2020 @cw9 @prateek @ben-lerner 