### PR TITLE
Don't flush data during bootstrapping

### DIFF
--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -72,12 +72,10 @@ type bootstrapManager struct {
 	newBootstrapFn NewBootstrapFn
 	state          bootstrapState
 	hasPending     bool
-	fsManager      databaseFileSystemManager
 }
 
 func newBootstrapManager(
 	database database,
-	fsManager databaseFileSystemManager,
 ) databaseBootstrapManager {
 	opts := database.Options()
 	return &bootstrapManager{
@@ -86,7 +84,6 @@ func newBootstrapManager(
 		log:            opts.InstrumentOptions().Logger(),
 		nowFn:          opts.ClockOptions().NowFn(),
 		newBootstrapFn: opts.NewBootstrapFn(),
-		fsManager:      fsManager,
 	}
 }
 

--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -187,14 +187,5 @@ func (m *bootstrapManager) bootstrap() error {
 			xlog.NewLogField("duration", end.Sub(start).String()),
 		).Info("bootstrap finished")
 	}
-
-	// At this point we have bootstrapped everything between now - retentionPeriod
-	// and now, so we should run the filesystem manager to clean up files and flush
-	// all the data we bootstrapped.
-	rateLimitOpts := m.fsManager.RateLimitOptions()
-	m.fsManager.SetRateLimitOptions(rateLimitOpts.SetLimitEnabled(false))
-	m.fsManager.Run(m.nowFn(), false)
-	m.fsManager.SetRateLimitOptions(rateLimitOpts)
-
 	return multiErr.FinalError()
 }

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3db/ratelimit"
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/ts"
 
@@ -55,12 +54,7 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 	}
 
 	db := &mockDatabase{namespaces: namespaces, opts: opts}
-	rateLimitOpts := ratelimit.NewOptions()
-	fsm := NewMockdatabaseFileSystemManager(ctrl)
-	fsm.EXPECT().RateLimitOptions().Return(rateLimitOpts)
-	fsm.EXPECT().Run(now, false)
-	fsm.EXPECT().SetRateLimitOptions(gomock.Any()).Times(2)
-	bsm := newBootstrapManager(db, fsm).(*bootstrapManager)
+	bsm := newBootstrapManager(db).(*bootstrapManager)
 	err := bsm.Bootstrap()
 
 	require.NotNil(t, err)
@@ -89,7 +83,7 @@ func TestDatabaseBootstrapTargetRanges(t *testing.T) {
 
 	db := &mockDatabase{opts: opts}
 
-	bsm := newBootstrapManager(db, nil).(*bootstrapManager)
+	bsm := newBootstrapManager(db).(*bootstrapManager)
 	ranges := bsm.targetRanges(now)
 
 	var all [][]time.Time

--- a/storage/database.go
+++ b/storage/database.go
@@ -206,7 +206,7 @@ func NewDatabase(
 	}
 	d.fsm = fsm
 
-	d.bsm = newBootstrapManager(d, d.fsm)
+	d.bsm = newBootstrapManager(d)
 
 	if opts.RepairEnabled() {
 		d.repairer, err = newDatabaseRepairer(d)

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -113,7 +113,7 @@ func newTestDatabase(t *testing.T, bs bootstrapState) *db {
 	database, err := NewDatabase(nil, nil, opts)
 	require.NoError(t, err)
 	d := database.(*db)
-	bsm := newBootstrapManager(d, nil).(*bootstrapManager)
+	bsm := newBootstrapManager(d).(*bootstrapManager)
 	bsm.state = bs
 	d.bsm = bsm
 	return d


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @ben-lerner 

This PR addresses an issue where we used to flush data at the end of bootstrapping but not drain the buffer for the most recent 2-hour block, causing them not to be flushed to filesystem and permanent lost due to interaction with block retrieval manager.

This PR temporarily disables data flushing during bootstrapping, a longer-term fix will be in an upcoming PR shortly.