### PR TITLE
Add incremental bootstrapping for the peers bootstrapper

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -35,9 +35,9 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time "github.com/m3db/m3x/time"
+	time0 "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time0 "time"
+	time "time"
 )
 
 // Mock of Client interface
@@ -104,7 +104,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,7 +114,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -125,7 +125,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -348,7 +348,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -358,7 +358,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -369,7 +369,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -432,7 +432,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -443,7 +443,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -486,7 +486,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -496,7 +496,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -507,7 +507,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -570,7 +570,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -581,7 +581,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1082,7 +1082,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1092,9 +1092,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1102,7 +1102,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1112,9 +1112,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1142,7 +1142,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1152,9 +1152,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1162,7 +1162,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1172,9 +1172,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1182,7 +1182,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1192,9 +1192,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1202,7 +1202,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1212,9 +1212,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1222,7 +1222,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1232,9 +1232,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1242,7 +1242,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1252,9 +1252,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1262,7 +1262,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1272,9 +1272,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1462,7 +1462,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1472,9 +1472,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1763,7 +1763,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1773,9 +1773,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1783,7 +1783,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1793,9 +1793,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1823,7 +1823,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1833,9 +1833,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1843,7 +1843,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1853,9 +1853,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1863,7 +1863,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1873,9 +1873,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1883,7 +1883,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1893,9 +1893,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1903,7 +1903,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1913,9 +1913,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1923,7 +1923,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1933,9 +1933,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1943,7 +1943,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1953,9 +1953,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2143,7 +2143,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2153,9 +2153,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2303,7 +2303,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2313,9 +2313,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2323,7 +2323,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2333,9 +2333,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 

--- a/persist/fs/fs_mock.go
+++ b/persist/fs/fs_mock.go
@@ -27,8 +27,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
 	checked "github.com/m3db/m3x/checked"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of FileSetWriter interface
@@ -62,7 +62,7 @@ func (_mr *_MockFileSetWriterRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
+func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -143,7 +143,7 @@ func (_mr *_MockFileSetReaderRecorder) EntriesRead() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EntriesRead")
 }
 
-func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
+func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -153,9 +153,9 @@ func (_mr *_MockFileSetReaderRecorder) Open(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open", arg0, arg1, arg2)
 }
 
-func (_m *MockFileSetReader) Range() time.Range {
+func (_m *MockFileSetReader) Range() time0.Range {
 	ret := _m.ctrl.Call(_m, "Range")
-	ret0, _ := ret[0].(time.Range)
+	ret0, _ := ret[0].(time0.Range)
 	return ret0
 }
 

--- a/persist/fs/manager.go
+++ b/persist/fs/manager.go
@@ -102,9 +102,10 @@ func (pm *persistManager) persist(
 	return err
 }
 
-func (pm *persistManager) close() {
-	pm.writer.Close()
+func (pm *persistManager) close() error {
+	err := pm.writer.Close()
 	pm.reset()
+	return err
 }
 
 func (pm *persistManager) reset() {

--- a/persist/types.go
+++ b/persist/types.go
@@ -32,7 +32,7 @@ type Fn func(id ts.ID, segment ts.Segment, checksum uint32) error
 
 // Closer is a function that performs cleanup after persisting the data
 // blocks for a (shard, blockStart) combination
-type Closer func()
+type Closer func() error
 
 // PreparedPersist is an object that wraps holds a persist function and a closer
 type PreparedPersist struct {

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -27,7 +27,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	result "github.com/m3db/m3db/storage/bootstrap/result"
 	ts "github.com/m3db/m3db/ts"
-	time "github.com/m3db/m3x/time"
 )
 
 // Mock of Bootstrap interface
@@ -51,8 +50,8 @@ func (_m *MockBootstrap) EXPECT() *_MockBootstrapRecorder {
 	return _m.recorder
 }
 
-func (_m *MockBootstrap) Run(targetRanges time.Ranges, namespace ts.ID, shards []uint32) (result.BootstrapResult, error) {
-	ret := _m.ctrl.Call(_m, "Run", targetRanges, namespace, shards)
+func (_m *MockBootstrap) Run(namespace ts.ID, shards []uint32, targetRanges []TargetRange) (result.BootstrapResult, error) {
+	ret := _m.ctrl.Call(_m, "Run", namespace, shards, targetRanges)
 	ret0, _ := ret[0].(result.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -60,6 +59,47 @@ func (_m *MockBootstrap) Run(targetRanges time.Ranges, namespace ts.ID, shards [
 
 func (_mr *_MockBootstrapRecorder) Run(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0, arg1, arg2)
+}
+
+// Mock of RunOptions interface
+type MockRunOptions struct {
+	ctrl     *gomock.Controller
+	recorder *_MockRunOptionsRecorder
+}
+
+// Recorder for MockRunOptions (not exported)
+type _MockRunOptionsRecorder struct {
+	mock *MockRunOptions
+}
+
+func NewMockRunOptions(ctrl *gomock.Controller) *MockRunOptions {
+	mock := &MockRunOptions{ctrl: ctrl}
+	mock.recorder = &_MockRunOptionsRecorder{mock}
+	return mock
+}
+
+func (_m *MockRunOptions) EXPECT() *_MockRunOptionsRecorder {
+	return _m.recorder
+}
+
+func (_m *MockRunOptions) SetIncremental(value bool) RunOptions {
+	ret := _m.ctrl.Call(_m, "SetIncremental", value)
+	ret0, _ := ret[0].(RunOptions)
+	return ret0
+}
+
+func (_mr *_MockRunOptionsRecorder) SetIncremental(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIncremental", arg0)
+}
+
+func (_m *MockRunOptions) Incremental() bool {
+	ret := _m.ctrl.Call(_m, "Incremental")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockRunOptionsRecorder) Incremental() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Incremental")
 }
 
 // Mock of Bootstrapper interface
@@ -103,15 +143,15 @@ func (_mr *_MockBootstrapperRecorder) Can(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Can", arg0)
 }
 
-func (_m *MockBootstrapper) Bootstrap(namespace ts.ID, shardsTimeRanges result.ShardTimeRanges) (result.BootstrapResult, error) {
-	ret := _m.ctrl.Call(_m, "Bootstrap", namespace, shardsTimeRanges)
+func (_m *MockBootstrapper) Bootstrap(namespace ts.ID, shardsTimeRanges result.ShardTimeRanges, opts RunOptions) (result.BootstrapResult, error) {
+	ret := _m.ctrl.Call(_m, "Bootstrap", namespace, shardsTimeRanges, opts)
 	ret0, _ := ret[0].(result.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBootstrapperRecorder) Bootstrap(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
+func (_mr *_MockBootstrapperRecorder) Bootstrap(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1, arg2)
 }
 
 // Mock of Source interface
@@ -155,13 +195,13 @@ func (_mr *_MockSourceRecorder) Available(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Available", arg0, arg1)
 }
 
-func (_m *MockSource) Read(namespace ts.ID, shardsTimeRanges result.ShardTimeRanges) (result.BootstrapResult, error) {
-	ret := _m.ctrl.Call(_m, "Read", namespace, shardsTimeRanges)
+func (_m *MockSource) Read(namespace ts.ID, shardsTimeRanges result.ShardTimeRanges, opts RunOptions) (result.BootstrapResult, error) {
+	ret := _m.ctrl.Call(_m, "Read", namespace, shardsTimeRanges, opts)
 	ret0, _ := ret[0].(result.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockSourceRecorder) Read(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Read", arg0, arg1)
+func (_mr *_MockSourceRecorder) Read(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Read", arg0, arg1, arg2)
 }

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -81,7 +81,7 @@ func (s *commitLogSource) Available(
 func (s *commitLogSource) Read(
 	namespace ts.ID,
 	shardsTimeRanges result.ShardTimeRanges,
-	opts bootstrap.RunOptions,
+	_ bootstrap.RunOptions,
 ) (result.BootstrapResult, error) {
 	if shardsTimeRanges.IsEmpty() {
 		return nil, nil

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -81,6 +81,7 @@ func (s *commitLogSource) Available(
 func (s *commitLogSource) Read(
 	namespace ts.ID,
 	shardsTimeRanges result.ShardTimeRanges,
+	opts bootstrap.RunOptions,
 ) (result.BootstrapResult, error) {
 	if shardsTimeRanges.IsEmpty() {
 		return nil, nil

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -354,7 +354,7 @@ func (s *fileSystemSource) bootstrapFromReaders(
 func (s *fileSystemSource) Read(
 	namespace ts.ID,
 	shardsTimeRanges result.ShardTimeRanges,
-	opts bootstrap.RunOptions,
+	_ bootstrap.RunOptions,
 ) (result.BootstrapResult, error) {
 	if shardsTimeRanges.IsEmpty() {
 		return nil, nil

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -354,6 +354,7 @@ func (s *fileSystemSource) bootstrapFromReaders(
 func (s *fileSystemSource) Read(
 	namespace ts.ID,
 	shardsTimeRanges result.ShardTimeRanges,
+	opts bootstrap.RunOptions,
 ) (result.BootstrapResult, error) {
 	if shardsTimeRanges.IsEmpty() {
 		return nil, nil

--- a/storage/bootstrap/bootstrapper/noop.go
+++ b/storage/bootstrap/bootstrapper/noop.go
@@ -52,9 +52,13 @@ func (noop *noOpNoneBootstrapper) Can(strategy bootstrap.Strategy) bool {
 	return true
 }
 
-func (noop *noOpNoneBootstrapper) Bootstrap(_ ts.ID, str result.ShardTimeRanges) (result.BootstrapResult, error) {
+func (noop *noOpNoneBootstrapper) Bootstrap(
+	_ ts.ID,
+	targetRanges result.ShardTimeRanges,
+	_ bootstrap.RunOptions,
+) (result.BootstrapResult, error) {
 	res := result.NewBootstrapResult()
-	res.SetUnfulfilled(str)
+	res.SetUnfulfilled(targetRanges)
 	return res, nil
 }
 
@@ -75,7 +79,11 @@ func (noop *noOpAllBootstrapper) Can(strategy bootstrap.Strategy) bool {
 	return true
 }
 
-func (noop *noOpAllBootstrapper) Bootstrap(_ ts.ID, _ result.ShardTimeRanges) (result.BootstrapResult, error) {
+func (noop *noOpAllBootstrapper) Bootstrap(
+	_ ts.ID,
+	_ result.ShardTimeRanges,
+	_ bootstrap.RunOptions,
+) (result.BootstrapResult, error) {
 	return result.NewBootstrapResult(), nil
 }
 

--- a/storage/bootstrap/bootstrapper/noop_test.go
+++ b/storage/bootstrap/bootstrapper/noop_test.go
@@ -24,13 +24,14 @@ import (
 	"testing"
 
 	"github.com/m3db/m3db/ts"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestNoOpNoneBootstrapperBootstrap(t *testing.T) {
 	bs := NewNoOpNoneBootstrapper()
 	ranges := testShardTimeRanges()
-	res, err := bs.Bootstrap(ts.StringID("testNs"), ranges)
+	res, err := bs.Bootstrap(ts.StringID("testNs"), ranges, testDefaultRunOpts)
 	require.Equal(t, ranges, res.Unfulfilled())
 	require.Nil(t, err)
 }
@@ -38,7 +39,7 @@ func TestNoOpNoneBootstrapperBootstrap(t *testing.T) {
 func TestNoOpAllBootstrapperBootstrap(t *testing.T) {
 	bs := NewNoOpAllBootstrapper()
 	ranges := testShardTimeRanges()
-	res, err := bs.Bootstrap(ts.StringID("testNs"), ranges)
+	res, err := bs.Bootstrap(ts.StringID("testNs"), ranges, testDefaultRunOpts)
 	require.True(t, res.Unfulfilled().IsEmpty())
 	require.Nil(t, err)
 }

--- a/storage/bootstrap/bootstrapper/peers/options.go
+++ b/storage/bootstrap/bootstrapper/peers/options.go
@@ -21,6 +21,7 @@
 package peers
 
 import (
+	"math"
 	"runtime"
 
 	"github.com/m3db/m3db/client"
@@ -31,8 +32,8 @@ import (
 
 var (
 	defaultDefaultBootstrapShardConcurrency    = runtime.NumCPU()
-	defaultIncrementalShardConcurrency         = 4
-	defaultIncrementalBootstrapPersistMaxQueue = 1
+	defaultIncrementalShardConcurrency         = int(math.Max(1, float64(runtime.NumCPU())/2))
+	defaultIncrementalBootstrapPersistMaxQueue = 0
 )
 
 type options struct {

--- a/storage/bootstrap/bootstrapper/peers/options.go
+++ b/storage/bootstrap/bootstrapper/peers/options.go
@@ -31,28 +31,28 @@ import (
 )
 
 var (
-	defaultDefaultBootstrapShardConcurrency    = runtime.NumCPU()
-	defaultIncrementalShardConcurrency         = int(math.Max(1, float64(runtime.NumCPU())/2))
-	defaultIncrementalBootstrapPersistMaxQueue = 0
+	defaultDefaultShardConcurrency        = runtime.NumCPU()
+	defaultIncrementalShardConcurrency    = int(math.Max(1, float64(runtime.NumCPU())/2))
+	defaultIncrementalPersistMaxQueueSize = 0
 )
 
 type options struct {
-	resultOpts                           result.Options
-	client                               client.AdminClient
-	defaultBootstrapShardConcurrency     int
-	incrementalBootstrapShardConcurrency int
-	incrementalBootstrapPersistMaxQueue  int
-	newPersistManagerFn                  storage.NewPersistManagerFn
-	blockRetrieverManager                block.DatabaseBlockRetrieverManager
+	resultOpts                     result.Options
+	client                         client.AdminClient
+	defaultShardConcurrency        int
+	incrementalShardConcurrency    int
+	incrementalPersistMaxQueueSize int
+	newPersistManagerFn            storage.NewPersistManagerFn
+	blockRetrieverManager          block.DatabaseBlockRetrieverManager
 }
 
 // NewOptions creates new bootstrap options
 func NewOptions() Options {
 	return &options{
-		resultOpts:                           result.NewOptions(),
-		defaultBootstrapShardConcurrency:     defaultDefaultBootstrapShardConcurrency,
-		incrementalBootstrapShardConcurrency: defaultIncrementalShardConcurrency,
-		incrementalBootstrapPersistMaxQueue:  defaultIncrementalBootstrapPersistMaxQueue,
+		resultOpts:                     result.NewOptions(),
+		defaultShardConcurrency:        defaultDefaultShardConcurrency,
+		incrementalShardConcurrency:    defaultIncrementalShardConcurrency,
+		incrementalPersistMaxQueueSize: defaultIncrementalPersistMaxQueueSize,
 	}
 }
 
@@ -76,34 +76,34 @@ func (o *options) AdminClient() client.AdminClient {
 	return o.client
 }
 
-func (o *options) SetDefaultBootstrapShardConcurrency(value int) Options {
+func (o *options) SetDefaultShardConcurrency(value int) Options {
 	opts := *o
-	opts.defaultBootstrapShardConcurrency = value
+	opts.defaultShardConcurrency = value
 	return &opts
 }
 
-func (o *options) DefaultBootstrapShardConcurrency() int {
-	return o.defaultBootstrapShardConcurrency
+func (o *options) DefaultShardConcurrency() int {
+	return o.defaultShardConcurrency
 }
 
-func (o *options) SetIncrementalBootstrapShardConcurrency(value int) Options {
+func (o *options) SetIncrementalShardConcurrency(value int) Options {
 	opts := *o
-	opts.incrementalBootstrapShardConcurrency = value
+	opts.incrementalShardConcurrency = value
 	return &opts
 }
 
-func (o *options) IncrementalBootstrapShardConcurrency() int {
-	return o.incrementalBootstrapShardConcurrency
+func (o *options) IncrementalShardConcurrency() int {
+	return o.incrementalShardConcurrency
 }
 
-func (o *options) SetIncrementalBootstrapPersistMaxQueue(value int) Options {
+func (o *options) SetIncrementalPersistMaxQueueSize(value int) Options {
 	opts := *o
-	opts.incrementalBootstrapPersistMaxQueue = value
+	opts.incrementalPersistMaxQueueSize = value
 	return &opts
 }
 
-func (o *options) IncrementalBootstrapPersistMaxQueue() int {
-	return o.incrementalBootstrapPersistMaxQueue
+func (o *options) IncrementalPersistMaxQueueSize() int {
+	return o.incrementalPersistMaxQueueSize
 }
 
 func (o *options) SetNewPersistManagerFn(value storage.NewPersistManagerFn) Options {

--- a/storage/bootstrap/bootstrapper/peers/options.go
+++ b/storage/bootstrap/bootstrapper/peers/options.go
@@ -24,24 +24,34 @@ import (
 	"runtime"
 
 	"github.com/m3db/m3db/client"
+	"github.com/m3db/m3db/storage"
+	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 )
 
 var (
-	defaultBootstrapShardConcurrency = runtime.NumCPU()
+	defaultDefaultBootstrapShardConcurrency    = runtime.NumCPU()
+	defaultIncrementalShardConcurrency         = 4
+	defaultIncrementalBootstrapPersistMaxQueue = 1
 )
 
 type options struct {
-	resultOpts                result.Options
-	client                    client.AdminClient
-	bootstrapShardConcurrency int
+	resultOpts                           result.Options
+	client                               client.AdminClient
+	defaultBootstrapShardConcurrency     int
+	incrementalBootstrapShardConcurrency int
+	incrementalBootstrapPersistMaxQueue  int
+	newPersistManagerFn                  storage.NewPersistManagerFn
+	blockRetrieverManager                block.DatabaseBlockRetrieverManager
 }
 
 // NewOptions creates new bootstrap options
 func NewOptions() Options {
 	return &options{
-		resultOpts:                result.NewOptions(),
-		bootstrapShardConcurrency: defaultBootstrapShardConcurrency,
+		resultOpts:                           result.NewOptions(),
+		defaultBootstrapShardConcurrency:     defaultDefaultBootstrapShardConcurrency,
+		incrementalBootstrapShardConcurrency: defaultIncrementalShardConcurrency,
+		incrementalBootstrapPersistMaxQueue:  defaultIncrementalBootstrapPersistMaxQueue,
 	}
 }
 
@@ -65,12 +75,54 @@ func (o *options) AdminClient() client.AdminClient {
 	return o.client
 }
 
-func (o *options) SetBootstrapShardConcurrency(value int) Options {
+func (o *options) SetDefaultBootstrapShardConcurrency(value int) Options {
 	opts := *o
-	opts.bootstrapShardConcurrency = value
+	opts.defaultBootstrapShardConcurrency = value
 	return &opts
 }
 
-func (o *options) BootstrapShardConcurrency() int {
-	return o.bootstrapShardConcurrency
+func (o *options) DefaultBootstrapShardConcurrency() int {
+	return o.defaultBootstrapShardConcurrency
+}
+
+func (o *options) SetIncrementalBootstrapShardConcurrency(value int) Options {
+	opts := *o
+	opts.incrementalBootstrapShardConcurrency = value
+	return &opts
+}
+
+func (o *options) IncrementalBootstrapShardConcurrency() int {
+	return o.incrementalBootstrapShardConcurrency
+}
+
+func (o *options) SetIncrementalBootstrapPersistMaxQueue(value int) Options {
+	opts := *o
+	opts.incrementalBootstrapPersistMaxQueue = value
+	return &opts
+}
+
+func (o *options) IncrementalBootstrapPersistMaxQueue() int {
+	return o.incrementalBootstrapPersistMaxQueue
+}
+
+func (o *options) SetNewPersistManagerFn(value storage.NewPersistManagerFn) Options {
+	opts := *o
+	opts.newPersistManagerFn = value
+	return &opts
+}
+
+func (o *options) NewPersistManagerFn() storage.NewPersistManagerFn {
+	return o.newPersistManagerFn
+}
+
+func (o *options) SetDatabaseBlockRetrieverManager(
+	value block.DatabaseBlockRetrieverManager,
+) Options {
+	opts := *o
+	opts.blockRetrieverManager = value
+	return &opts
+}
+
+func (o *options) DatabaseBlockRetrieverManager() block.DatabaseBlockRetrieverManager {
+	return o.blockRetrieverManager
 }

--- a/storage/bootstrap/bootstrapper/peers/peers_test.go
+++ b/storage/bootstrap/bootstrapper/peers/peers_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package peers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPeersBotstrapper(t *testing.T) {
+	b := NewPeersBootstrapper(NewOptions(), nil)
+	assert.Equal(t, PeersBootstrapperName, b.String())
+}

--- a/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -290,15 +290,18 @@ func TestPeersSourceIncrementalRun(t *testing.T) {
 
 	block, ok := r.ShardResults()[0].BlockAt(ts.StringID("foo"), start)
 	require.True(t, ok)
-	require.Equal(t, fooBlock, block)
+	assert.Equal(t, fooBlock, block)
+	assert.False(t, fooBlock.IsRetrieved())
 
 	block, ok = r.ShardResults()[0].BlockAt(ts.StringID("bar"), start.Add(ropts.BlockSize()))
 	require.True(t, ok)
-	require.Equal(t, barBlock, block)
+	assert.Equal(t, barBlock, block)
+	assert.False(t, barBlock.IsRetrieved())
 
 	block, ok = r.ShardResults()[1].BlockAt(ts.StringID("baz"), start)
 	require.True(t, ok)
-	require.Equal(t, bazBlock, block)
+	assert.Equal(t, bazBlock, block)
+	assert.False(t, bazBlock.IsRetrieved())
 
 	assert.Equal(t, map[string]int{
 		"foo": 1, "bar": 1, "baz": 1,
@@ -461,19 +464,19 @@ func TestPeersSourceContinuesOnIncrementalFlushErrors(t *testing.T) {
 
 	block, ok := r.ShardResults()[0].BlockAt(ts.StringID("foo"), start)
 	require.True(t, ok)
-	require.Equal(t, fooBlock, block)
+	assert.Equal(t, fooBlock, block)
 
 	block, ok = r.ShardResults()[1].BlockAt(ts.StringID("bar"), start)
 	require.True(t, ok)
-	require.Equal(t, barBlock, block)
+	assert.Equal(t, barBlock, block)
 
 	block, ok = r.ShardResults()[2].BlockAt(ts.StringID("baz"), start)
 	require.True(t, ok)
-	require.Equal(t, bazBlock, block)
+	assert.Equal(t, bazBlock, block)
 
 	block, ok = r.ShardResults()[3].BlockAt(ts.StringID("qux"), start)
 	require.True(t, ok)
-	require.Equal(t, quxBlock, block)
+	assert.Equal(t, quxBlock, block)
 
 	assert.Equal(t, map[string]int{
 		"baz": 1, "qux": 1,

--- a/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,24 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package bootstrap
+package peers
 
-import (
-	"github.com/m3db/m3db/storage/bootstrap/result"
-	"github.com/m3db/m3db/ts"
-)
+import "testing"
 
-type noOpBootstrapProcess struct{}
+func TestPeersSource(t *testing.T) {
 
-// NewNoOpBootstrapProcess creates a no-op bootstrap process.
-func NewNoOpBootstrapProcess() Bootstrap {
-	return &noOpBootstrapProcess{}
-}
-
-func (b *noOpBootstrapProcess) Run(
-	namespace ts.ID,
-	shards []uint32,
-	targetRanges []TargetRange,
-) (result.BootstrapResult, error) {
-	return result.NewBootstrapResult(), nil
 }

--- a/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -164,7 +164,10 @@ func TestPeersSourceIncrementalRun(t *testing.T) {
 	opts = opts.SetAdminClient(mockAdminClient)
 
 	mockRetriever := block.NewMockDatabaseBlockRetriever(ctrl)
-	mockRetriever.EXPECT().CacheShardIndices([]uint32{0, 1}).Return(nil)
+	// The shard indices are computed from iterating over a map, they can
+	// come in any order
+	mockRetriever.EXPECT().CacheShardIndices([]uint32{0, 1}).AnyTimes()
+	mockRetriever.EXPECT().CacheShardIndices([]uint32{1, 0}).AnyTimes()
 
 	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
 	mockRetrieverMgr.EXPECT().

--- a/storage/bootstrap/bootstrapper/peers/types.go
+++ b/storage/bootstrap/bootstrapper/peers/types.go
@@ -41,31 +41,31 @@ type Options interface {
 	// AdminClient returns the admin client
 	AdminClient() client.AdminClient
 
-	// SetDefaultBootstrapShardConcurrency sets the concurrency for
+	// SetDefaultShardConcurrency sets the concurrency for
 	// bootstrapping shards when performing a non-incremental bootstrap.
-	SetDefaultBootstrapShardConcurrency(value int) Options
+	SetDefaultShardConcurrency(value int) Options
 
-	// DefaultBootstrapShardConcurrency returns the concurrency for
+	// DefaultShardConcurrency returns the concurrency for
 	// bootstrapping shards when performing a non-incremental bootstrap.
-	DefaultBootstrapShardConcurrency() int
+	DefaultShardConcurrency() int
 
-	// SetIncrementalBootstrapShardConcurrency sets the concurrency for
+	// SetIncrementalShardConcurrency sets the concurrency for
 	// bootstrapping shards when performing an incremental bootstrap.
-	SetIncrementalBootstrapShardConcurrency(value int) Options
+	SetIncrementalShardConcurrency(value int) Options
 
-	// IncrementalBootstrapShardConcurrency returns the concurrency for
+	// IncrementalShardConcurrency returns the concurrency for
 	// bootstrapping shards when performing an incremental bootstrap.
-	IncrementalBootstrapShardConcurrency() int
+	IncrementalShardConcurrency() int
 
-	// SetIncrementalBootstrapPersistMaxQueue sets the max queue for
+	// SetIncrementalPersistMaxQueueSize sets the max queue for
 	// bootstrapping shards waiting in line to persist without blocking
 	// the concurrent shard fetchers.
-	SetIncrementalBootstrapPersistMaxQueue(value int) Options
+	SetIncrementalPersistMaxQueueSize(value int) Options
 
-	// IncrementalBootstrapPersistMaxQueue returns the max queue for
+	// IncrementalPersistMaxQueueSize returns the max queue for
 	// bootstrapping shards waiting in line to persist without blocking
 	// the concurrent shard fetchers.
-	IncrementalBootstrapPersistMaxQueue() int
+	IncrementalPersistMaxQueueSize() int
 
 	// SetNewPersistManagerFn sets the function for creating a new persistence manager
 	// used to flush blocks when performing an incremental bootstrap run.

--- a/storage/bootstrap/bootstrapper/peers/types.go
+++ b/storage/bootstrap/bootstrapper/peers/types.go
@@ -22,6 +22,8 @@ package peers
 
 import (
 	"github.com/m3db/m3db/client"
+	"github.com/m3db/m3db/storage"
+	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 )
 
@@ -39,9 +41,47 @@ type Options interface {
 	// AdminClient returns the admin client
 	AdminClient() client.AdminClient
 
-	// SetBootstrapShardConcurrency sets the concurrency for bootstrapping shards
-	SetBootstrapShardConcurrency(value int) Options
+	// SetDefaultBootstrapShardConcurrency sets the concurrency for
+	// bootstrapping shards when performing a non-incremental bootstrap.
+	SetDefaultBootstrapShardConcurrency(value int) Options
 
-	// BootstrapShardConcurrency returns the concurrency for bootstrapping shards
-	BootstrapShardConcurrency() int
+	// DefaultBootstrapShardConcurrency returns the concurrency for
+	// bootstrapping shards when performing a non-incremental bootstrap.
+	DefaultBootstrapShardConcurrency() int
+
+	// SetIncrementalBootstrapShardConcurrency sets the concurrency for
+	// bootstrapping shards when performing an incremental bootstrap.
+	SetIncrementalBootstrapShardConcurrency(value int) Options
+
+	// IncrementalBootstrapShardConcurrency returns the concurrency for
+	// bootstrapping shards when performing an incremental bootstrap.
+	IncrementalBootstrapShardConcurrency() int
+
+	// SetIncrementalBootstrapPersistMaxQueue sets the max queue for
+	// bootstrapping shards waiting in line to persist without blocking
+	// the concurrent shard fetchers.
+	SetIncrementalBootstrapPersistMaxQueue(value int) Options
+
+	// IncrementalBootstrapPersistMaxQueue returns the max queue for
+	// bootstrapping shards waiting in line to persist without blocking
+	// the concurrent shard fetchers.
+	IncrementalBootstrapPersistMaxQueue() int
+
+	// SetNewPersistManagerFn sets the function for creating a new persistence manager
+	// used to flush blocks when performing an incremental bootstrap run.
+	SetNewPersistManagerFn(value storage.NewPersistManagerFn) Options
+
+	// NewPersistManagerFn returns the function for creating a new persistence manager
+	// used to flush blocks when performing an incremental bootstrap run.
+	NewPersistManagerFn() storage.NewPersistManagerFn
+
+	// SetDatabaseBlockRetrieverManager sets the block retriever manager to
+	// pass to newly flushed blocks when performing an incremental bootstrap run.
+	SetDatabaseBlockRetrieverManager(
+		value block.DatabaseBlockRetrieverManager,
+	) Options
+
+	// NewBlockRetrieverFn returns the block retriever manager to
+	// pass to newly flushed blocks when performing an incremental bootstrap run.
+	DatabaseBlockRetrieverManager() block.DatabaseBlockRetrieverManager
 }

--- a/storage/bootstrap/run_options.go
+++ b/storage/bootstrap/run_options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,22 +20,29 @@
 
 package bootstrap
 
-import (
-	"github.com/m3db/m3db/storage/bootstrap/result"
-	"github.com/m3db/m3db/ts"
+const (
+	// defaultIncremental declares the intent to by default not perform an
+	// incremental bootstrap.
+	defaultIncremental = false
 )
 
-type noOpBootstrapProcess struct{}
-
-// NewNoOpBootstrapProcess creates a no-op bootstrap process.
-func NewNoOpBootstrapProcess() Bootstrap {
-	return &noOpBootstrapProcess{}
+type runOptions struct {
+	incremental bool
 }
 
-func (b *noOpBootstrapProcess) Run(
-	namespace ts.ID,
-	shards []uint32,
-	targetRanges []TargetRange,
-) (result.BootstrapResult, error) {
-	return result.NewBootstrapResult(), nil
+// NewRunOptions creates new bootstrap run options
+func NewRunOptions() RunOptions {
+	return &runOptions{
+		incremental: defaultIncremental,
+	}
+}
+
+func (o *runOptions) SetIncremental(value bool) RunOptions {
+	opts := *o
+	opts.incremental = value
+	return &opts
+}
+
+func (o *runOptions) Incremental() bool {
+	return o.incremental
 }

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -87,9 +87,8 @@ func TestDatabaseBootstrapTargetRanges(t *testing.T) {
 	ranges := bsm.targetRanges(now)
 
 	var all [][]time.Time
-	it := ranges.Iter()
-	for it.Next() {
-		value := it.Value()
+	for _, target := range ranges {
+		value := target.Range
 		var times []time.Time
 		for st := value.Start; st.Before(value.End); st = st.Add(ropts.BlockSize()) {
 			times = append(times, st)

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -356,7 +356,7 @@ func (n *dbNamespace) FetchBlocksMetadata(
 
 func (n *dbNamespace) Bootstrap(
 	bs bootstrap.Bootstrap,
-	targetRanges xtime.Ranges,
+	targetRanges []bootstrap.TargetRange,
 ) error {
 	callStart := n.nowFn()
 
@@ -402,7 +402,7 @@ func (n *dbNamespace) Bootstrap(
 		shardIDs[i] = shard.ID()
 	}
 
-	bootstrapResult, err := bs.Run(targetRanges, n.id, shardIDs)
+	bootstrapResult, err := bs.Run(n.id, shardIDs, targetRanges)
 	if err != nil {
 		n.log.Errorf("bootstrap for namespace %s aborted due to error: %v",
 			n.id.String(), err)

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -28,10 +28,9 @@ import (
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
 	block "github.com/m3db/m3db/storage/block"
-	series "github.com/m3db/m3db/storage/series"
 	ts "github.com/m3db/m3db/ts"
-	time "github.com/m3db/m3x/time"
 	io "github.com/m3db/m3db/x/io"
+	time "github.com/m3db/m3x/time"
 	time0 "time"
 )
 
@@ -145,7 +144,7 @@ func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 series.QueryableBlockRetriever) {
+func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 QueryableBlockRetriever) {
 	_m.ctrl.Call(_m, "Reset", _param0, _param1, _param2)
 }
 
@@ -153,9 +152,9 @@ func (_mr *_MockDatabaseSeriesRecorder) Reset(arg0, arg1, arg2 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Tick() (series.TickResult, error) {
+func (_m *MockDatabaseSeries) Tick() (TickResult, error) {
 	ret := _m.ctrl.Call(_m, "Tick")
-	ret0, _ := ret[0].(series.TickResult)
+	ret0, _ := ret[0].(TickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -24,15 +24,15 @@
 package series
 
 import (
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
 	block "github.com/m3db/m3db/storage/block"
-	series "github.com/m3db/m3db/storage/series"
 	ts "github.com/m3db/m3db/ts"
-	time0 "github.com/m3db/m3x/time"
 	io "github.com/m3db/m3db/x/io"
-	time "time"
+	time0 "github.com/m3db/m3x/time"
 )
 
 // Mock of DatabaseSeries interface
@@ -145,7 +145,7 @@ func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 series.QueryableBlockRetriever) {
+func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 QueryableBlockRetriever) {
 	_m.ctrl.Call(_m, "Reset", _param0, _param1, _param2)
 }
 
@@ -153,9 +153,9 @@ func (_mr *_MockDatabaseSeriesRecorder) Reset(arg0, arg1, arg2 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Tick() (series.TickResult, error) {
+func (_m *MockDatabaseSeries) Tick() (TickResult, error) {
 	ret := _m.ctrl.Call(_m, "Tick")
-	ret0, _ := ret[0].(series.TickResult)
+	ret0, _ := ret[0].(TickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -28,10 +28,11 @@ import (
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
 	block "github.com/m3db/m3db/storage/block"
+	series "github.com/m3db/m3db/storage/series"
 	ts "github.com/m3db/m3db/ts"
+	time0 "github.com/m3db/m3x/time"
 	io "github.com/m3db/m3db/x/io"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time "time"
 )
 
 // Mock of DatabaseSeries interface
@@ -73,7 +74,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time0.Time) []block.FetchBlockResult {
+func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", _param0, _param1)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -83,7 +84,7 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 bool, _param4 bool) block.FetchBlocksMetadataResult {
+func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time.Time, _param2 time.Time, _param3 bool, _param4 bool) block.FetchBlocksMetadataResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResult)
 	return ret0
@@ -93,7 +94,7 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocksMetadata(arg0, arg1, arg2, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time0.Time, _param2 persist.Fn) error {
+func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time.Time, _param2 persist.Fn) error {
 	ret := _m.ctrl.Call(_m, "Flush", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -133,7 +134,7 @@ func (_mr *_MockDatabaseSeriesRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time0.Time, _param2 time0.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time.Time, _param2 time.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", _param0, _param1, _param2)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -144,7 +145,7 @@ func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 QueryableBlockRetriever) {
+func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 series.QueryableBlockRetriever) {
 	_m.ctrl.Call(_m, "Reset", _param0, _param1, _param2)
 }
 
@@ -152,9 +153,9 @@ func (_mr *_MockDatabaseSeriesRecorder) Reset(arg0, arg1, arg2 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0, arg1, arg2)
 }
 
-func (_m *MockDatabaseSeries) Tick() (TickResult, error) {
+func (_m *MockDatabaseSeries) Tick() (series.TickResult, error) {
 	ret := _m.ctrl.Call(_m, "Tick")
-	ret0, _ := ret[0].(TickResult)
+	ret0, _ := ret[0].(series.TickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -163,7 +164,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Tick() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick")
 }
 
-func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time0.Time, _param2 float64, _param3 time.Unit, _param4 []byte) error {
+func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time.Time, _param2 float64, _param3 time0.Unit, _param4 []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -686,7 +686,6 @@ func (s *dbShard) Flush(
 		s.markFlushStateSuccess(blockStart)
 		return nil
 	}
-	defer prepared.Close()
 
 	// If we encounter an error when persisting a series, we continue regardless.
 	tmpCtx := context.NewContext()
@@ -700,6 +699,10 @@ func (s *dbShard) Flush(
 		multiErr = multiErr.Add(err)
 		return true
 	})
+
+	if err := prepared.Close(); err != nil {
+		multiErr = multiErr.Add(err)
+	}
 
 	resultErr := multiErr.FinalError()
 

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -197,7 +197,7 @@ func TestShardFlushSeriesFlushError(t *testing.T) {
 	pm := persist.NewMockManager(ctrl)
 	prepared := persist.PreparedPersist{
 		Persist: func(ts.ID, ts.Segment, uint32) error { return nil },
-		Close:   func() { closed = true },
+		Close:   func() error { closed = true; return nil },
 	}
 	expectedErr := errors.New("error foo")
 	pm.EXPECT().Prepare(testNamespaceID, s.shard, blockStart).Return(prepared, expectedErr)
@@ -255,7 +255,7 @@ func TestShardFlushSeriesFlushSuccess(t *testing.T) {
 	pm := persist.NewMockManager(ctrl)
 	prepared := persist.PreparedPersist{
 		Persist: func(ts.ID, ts.Segment, uint32) error { return nil },
-		Close:   func() { closed = true },
+		Close:   func() error { closed = true; return nil },
 	}
 
 	pm.EXPECT().Prepare(testNamespaceID, s.shard, blockStart).Return(prepared, nil)

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -42,8 +42,8 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of Database interface
@@ -115,7 +115,7 @@ func (_mr *_MockDatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -125,7 +125,7 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -136,7 +136,7 @@ func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -147,7 +147,7 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -269,7 +269,7 @@ func (_mr *_MockdatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -279,7 +279,7 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -290,7 +290,7 @@ func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -301,7 +301,7 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -474,7 +474,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) AssignShardSet(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignShardSet", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Tick(softDeadline time.Duration) {
+func (_m *MockdatabaseNamespace) Tick(softDeadline time0.Duration) {
 	_m.ctrl.Call(_m, "Tick", softDeadline)
 }
 
@@ -482,7 +482,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Tick(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -492,7 +492,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -503,7 +503,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, shardID, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -514,7 +514,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -526,7 +526,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocksMetadata(arg0, arg1, arg2,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
-func (_m *MockdatabaseNamespace) Bootstrap(bs bootstrap.Bootstrap, targetRanges time0.Ranges) error {
+func (_m *MockdatabaseNamespace) Bootstrap(bs bootstrap.Bootstrap, targetRanges []bootstrap.TargetRange) error {
 	ret := _m.ctrl.Call(_m, "Bootstrap", bs, targetRanges)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -536,7 +536,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Bootstrap(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Flush(blockStart time.Time, pm persist.Manager) error {
+func (_m *MockdatabaseNamespace) Flush(blockStart time0.Time, pm persist.Manager) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, pm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -546,7 +546,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time.Time) bool {
+func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", blockStart)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -556,7 +556,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) NeedsFlush(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time.Time) error {
+func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -577,7 +577,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Truncate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate")
 }
 
-func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time0.Range) error {
+func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time.Range) error {
 	ret := _m.ctrl.Call(_m, "Repair", repairer, tr)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -719,7 +719,7 @@ func (_mr *_MockdatabaseShardRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockdatabaseShard) Tick(softDeadline time.Duration) tickResult {
+func (_m *MockdatabaseShard) Tick(softDeadline time0.Duration) tickResult {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline)
 	ret0, _ := ret[0].(tickResult)
 	return ret0
@@ -729,7 +729,7 @@ func (_mr *_MockdatabaseShardRecorder) Tick(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0)
 }
 
-func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -739,7 +739,7 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -750,7 +750,7 @@ func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -761,7 +761,7 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -782,7 +782,7 @@ func (_mr *_MockdatabaseShardRecorder) Bootstrap(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0)
 }
 
-func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time.Time, pm persist.Manager) error {
+func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time0.Time, pm persist.Manager) error {
 	ret := _m.ctrl.Call(_m, "Flush", namespace, blockStart, pm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -792,7 +792,7 @@ func (_mr *_MockdatabaseShardRecorder) Flush(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FlushState(blockStart time.Time) fileOpState {
+func (_m *MockdatabaseShard) FlushState(blockStart time0.Time) fileOpState {
 	ret := _m.ctrl.Call(_m, "FlushState", blockStart)
 	ret0, _ := ret[0].(fileOpState)
 	return ret0
@@ -802,7 +802,7 @@ func (_mr *_MockdatabaseShardRecorder) FlushState(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushState", arg0)
 }
 
-func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time.Time) error {
+func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", namespace, earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -812,7 +812,7 @@ func (_mr *_MockdatabaseShardRecorder) CleanupFileset(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupFileset", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -905,7 +905,7 @@ func (_mr *_MockdatabaseFlushManagerRecorder) IsFlushing() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFlushing")
 }
 
-func (_m *MockdatabaseFlushManager) NeedsFlush(t time.Time) bool {
+func (_m *MockdatabaseFlushManager) NeedsFlush(t time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -915,9 +915,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) NeedsFlush(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeStart(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeStart(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -925,9 +925,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeStart(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -935,7 +935,7 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeEnd(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) Flush(t time.Time) error {
+func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -994,7 +994,7 @@ func (_mr *_MockdatabaseCleanupManagerRecorder) IsCleaningUp() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsCleaningUp")
 }
 
-func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseCleanupManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1045,7 +1045,7 @@ func (_mr *_MockFileOpOptionsRecorder) RetentionOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RetentionOptions")
 }
 
-func (_m *MockFileOpOptions) SetJitter(value time.Duration) FileOpOptions {
+func (_m *MockFileOpOptions) SetJitter(value time0.Duration) FileOpOptions {
 	ret := _m.ctrl.Call(_m, "SetJitter", value)
 	ret0, _ := ret[0].(FileOpOptions)
 	return ret0
@@ -1055,9 +1055,9 @@ func (_mr *_MockFileOpOptionsRecorder) SetJitter(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetJitter", arg0)
 }
 
-func (_m *MockFileOpOptions) Jitter() time.Duration {
+func (_m *MockFileOpOptions) Jitter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "Jitter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1106,7 +1106,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) IsFlushing() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFlushing")
 }
 
-func (_m *MockdatabaseFileSystemManager) NeedsFlush(t time.Time) bool {
+func (_m *MockdatabaseFileSystemManager) NeedsFlush(t time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1116,9 +1116,9 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) NeedsFlush(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) FlushTimeStart(t time.Time) time.Time {
+func (_m *MockdatabaseFileSystemManager) FlushTimeStart(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -1126,9 +1126,9 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) FlushTimeStart(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) FlushTimeEnd(t time.Time) time.Time {
+func (_m *MockdatabaseFileSystemManager) FlushTimeEnd(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -1136,7 +1136,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) FlushTimeEnd(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) Flush(t time.Time) error {
+func (_m *MockdatabaseFileSystemManager) Flush(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1174,7 +1174,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) IsCleaningUp() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsCleaningUp")
 }
 
-func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseFileSystemManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1184,7 +1184,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Cleanup(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) ShouldRun(t time.Time) bool {
+func (_m *MockdatabaseFileSystemManager) ShouldRun(t time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "ShouldRun", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1194,7 +1194,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) ShouldRun(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShouldRun", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) Run(t time.Time, async bool) {
+func (_m *MockdatabaseFileSystemManager) Run(t time0.Time, async bool) {
 	_m.ctrl.Call(_m, "Run", t, async)
 }
 
@@ -1233,7 +1233,7 @@ func (_mr *_MockdatabaseShardRepairerRecorder) Options() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
-func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -1432,6 +1432,26 @@ func (_mr *_MockOptionsRecorder) CommitLogOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CommitLogOptions")
 }
 
+func (_m *MockOptions) SetRepairEnabled(b bool) Options {
+	ret := _m.ctrl.Call(_m, "SetRepairEnabled", b)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetRepairEnabled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRepairEnabled", arg0)
+}
+
+func (_m *MockOptions) RepairEnabled() bool {
+	ret := _m.ctrl.Call(_m, "RepairEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) RepairEnabled() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RepairEnabled")
+}
+
 func (_m *MockOptions) SetRepairOptions(value repair.Options) Options {
 	ret := _m.ctrl.Call(_m, "SetRepairOptions", value)
 	ret0, _ := ret[0].(Options)
@@ -1552,7 +1572,7 @@ func (_mr *_MockOptionsRecorder) DatabaseBlockRetrieverManager() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockRetrieverManager")
 }
 
-func (_m *MockOptions) SetShardCloseDeadline(value time.Duration) Options {
+func (_m *MockOptions) SetShardCloseDeadline(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetShardCloseDeadline", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1562,9 +1582,9 @@ func (_mr *_MockOptionsRecorder) SetShardCloseDeadline(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetShardCloseDeadline", arg0)
 }
 
-func (_m *MockOptions) ShardCloseDeadline() time.Duration {
+func (_m *MockOptions) ShardCloseDeadline() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ShardCloseDeadline")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -193,7 +193,7 @@ type databaseNamespace interface {
 	// Bootstrap performs bootstrapping
 	Bootstrap(
 		bs bootstrap.Bootstrap,
-		targetRanges xtime.Ranges,
+		targetRanges []bootstrap.TargetRange,
 	) error
 
 	// Flush flushes in-memory data


### PR DESCRIPTION
This change makes the first time range that's bootstrapped an incremental bootstrap which means if raw data is being read for blocks it is incrementally flushed and replaced with retrievable blocks in place of the full raw block.

The peers bootstrapper uses these semantics to flush raw block data as it finishes each shard.  This avoids having to hold the entire set of data in memory when doing a full peer stream.

cc @xichen2020 @cw9 @prateek @ben-lerner 