### PR TITLE
Add an inbuilt facility to perform write and fetch retries

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -35,6 +35,7 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
+	retry "github.com/m3db/m3x/retry"
 	time "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
 	time0 "time"
@@ -912,6 +913,16 @@ func (_mr *_MockOptionsRecorder) Validate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Validate")
 }
 
+func (_m *MockOptions) SetEncodingM3TSZ() Options {
+	ret := _m.ctrl.Call(_m, "SetEncodingM3TSZ")
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetEncodingM3TSZ() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetEncodingM3TSZ")
+}
+
 func (_m *MockOptions) SetClockOptions(value clock.Options) Options {
 	ret := _m.ctrl.Call(_m, "SetClockOptions", value)
 	ret0, _ := ret[0].(Options)
@@ -950,16 +961,6 @@ func (_m *MockOptions) InstrumentOptions() instrument.Options {
 
 func (_mr *_MockOptionsRecorder) InstrumentOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "InstrumentOptions")
-}
-
-func (_m *MockOptions) SetEncodingM3TSZ() Options {
-	ret := _m.ctrl.Call(_m, "SetEncodingM3TSZ")
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockOptionsRecorder) SetEncodingM3TSZ() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetEncodingM3TSZ")
 }
 
 func (_m *MockOptions) SetTopologyInitializer(value topology.Initializer) Options {
@@ -1322,64 +1323,44 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckFailThrottleFactor() *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckFailThrottleFactor")
 }
 
-func (_m *MockOptions) SetWriteOpPoolSize(value int) Options {
-	ret := _m.ctrl.Call(_m, "SetWriteOpPoolSize", value)
+func (_m *MockOptions) SetWriteRetrier(value retry.Retrier) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteRetrier", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) SetWriteOpPoolSize(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteOpPoolSize", arg0)
+func (_mr *_MockOptionsRecorder) SetWriteRetrier(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRetrier", arg0)
 }
 
-func (_m *MockOptions) WriteOpPoolSize() int {
-	ret := _m.ctrl.Call(_m, "WriteOpPoolSize")
-	ret0, _ := ret[0].(int)
+func (_m *MockOptions) WriteRetrier() retry.Retrier {
+	ret := _m.ctrl.Call(_m, "WriteRetrier")
+	ret0, _ := ret[0].(retry.Retrier)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) WriteOpPoolSize() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteOpPoolSize")
+func (_mr *_MockOptionsRecorder) WriteRetrier() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRetrier")
 }
 
-func (_m *MockOptions) SetFetchBatchOpPoolSize(value int) Options {
-	ret := _m.ctrl.Call(_m, "SetFetchBatchOpPoolSize", value)
+func (_m *MockOptions) SetFetchRetrier(value retry.Retrier) Options {
+	ret := _m.ctrl.Call(_m, "SetFetchRetrier", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) SetFetchBatchOpPoolSize(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchBatchOpPoolSize", arg0)
+func (_mr *_MockOptionsRecorder) SetFetchRetrier(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRetrier", arg0)
 }
 
-func (_m *MockOptions) FetchBatchOpPoolSize() int {
-	ret := _m.ctrl.Call(_m, "FetchBatchOpPoolSize")
-	ret0, _ := ret[0].(int)
+func (_m *MockOptions) FetchRetrier() retry.Retrier {
+	ret := _m.ctrl.Call(_m, "FetchRetrier")
+	ret0, _ := ret[0].(retry.Retrier)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) FetchBatchOpPoolSize() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchOpPoolSize")
-}
-
-func (_m *MockOptions) SetContextPool(value context.Pool) Options {
-	ret := _m.ctrl.Call(_m, "SetContextPool", value)
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockOptionsRecorder) SetContextPool(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetContextPool", arg0)
-}
-
-func (_m *MockOptions) ContextPool() context.Pool {
-	ret := _m.ctrl.Call(_m, "ContextPool")
-	ret0, _ := ret[0].(context.Pool)
-	return ret0
-}
-
-func (_mr *_MockOptionsRecorder) ContextPool() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContextPool")
+func (_mr *_MockOptionsRecorder) FetchRetrier() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRetrier")
 }
 
 func (_m *MockOptions) SetWriteBatchSize(value int) Options {
@@ -1422,24 +1403,44 @@ func (_mr *_MockOptionsRecorder) FetchBatchSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchSize")
 }
 
-func (_m *MockOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
-	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+func (_m *MockOptions) SetWriteOpPoolSize(value int) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteOpPoolSize", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+func (_mr *_MockOptionsRecorder) SetWriteOpPoolSize(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteOpPoolSize", arg0)
 }
 
-func (_m *MockOptions) IdentifierPool() ts.IdentifierPool {
-	ret := _m.ctrl.Call(_m, "IdentifierPool")
-	ret0, _ := ret[0].(ts.IdentifierPool)
+func (_m *MockOptions) WriteOpPoolSize() int {
+	ret := _m.ctrl.Call(_m, "WriteOpPoolSize")
+	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) IdentifierPool() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
+func (_mr *_MockOptionsRecorder) WriteOpPoolSize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteOpPoolSize")
+}
+
+func (_m *MockOptions) SetFetchBatchOpPoolSize(value int) Options {
+	ret := _m.ctrl.Call(_m, "SetFetchBatchOpPoolSize", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetFetchBatchOpPoolSize(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchBatchOpPoolSize", arg0)
+}
+
+func (_m *MockOptions) FetchBatchOpPoolSize() int {
+	ret := _m.ctrl.Call(_m, "FetchBatchOpPoolSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) FetchBatchOpPoolSize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchOpPoolSize")
 }
 
 func (_m *MockOptions) SetHostQueueOpsFlushSize(value int) Options {
@@ -1480,6 +1481,46 @@ func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
 
 func (_mr *_MockOptionsRecorder) HostQueueOpsFlushInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushInterval")
+}
+
+func (_m *MockOptions) SetContextPool(value context.Pool) Options {
+	ret := _m.ctrl.Call(_m, "SetContextPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetContextPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetContextPool", arg0)
+}
+
+func (_m *MockOptions) ContextPool() context.Pool {
+	ret := _m.ctrl.Call(_m, "ContextPool")
+	ret0, _ := ret[0].(context.Pool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) ContextPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContextPool")
+}
+
+func (_m *MockOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
+	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+}
+
+func (_m *MockOptions) IdentifierPool() ts.IdentifierPool {
+	ret := _m.ctrl.Call(_m, "IdentifierPool")
+	ret0, _ := ret[0].(ts.IdentifierPool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) IdentifierPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
 }
 
 func (_m *MockOptions) SetHostQueueOpsArrayPoolSize(value int) Options {
@@ -1593,6 +1634,16 @@ func (_mr *_MockAdminOptionsRecorder) Validate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Validate")
 }
 
+func (_m *MockAdminOptions) SetEncodingM3TSZ() Options {
+	ret := _m.ctrl.Call(_m, "SetEncodingM3TSZ")
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetEncodingM3TSZ() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetEncodingM3TSZ")
+}
+
 func (_m *MockAdminOptions) SetClockOptions(value clock.Options) Options {
 	ret := _m.ctrl.Call(_m, "SetClockOptions", value)
 	ret0, _ := ret[0].(Options)
@@ -1631,16 +1682,6 @@ func (_m *MockAdminOptions) InstrumentOptions() instrument.Options {
 
 func (_mr *_MockAdminOptionsRecorder) InstrumentOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "InstrumentOptions")
-}
-
-func (_m *MockAdminOptions) SetEncodingM3TSZ() Options {
-	ret := _m.ctrl.Call(_m, "SetEncodingM3TSZ")
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockAdminOptionsRecorder) SetEncodingM3TSZ() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetEncodingM3TSZ")
 }
 
 func (_m *MockAdminOptions) SetTopologyInitializer(value topology.Initializer) Options {
@@ -2003,64 +2044,44 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckFailThrottleFactor() 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckFailThrottleFactor")
 }
 
-func (_m *MockAdminOptions) SetWriteOpPoolSize(value int) Options {
-	ret := _m.ctrl.Call(_m, "SetWriteOpPoolSize", value)
+func (_m *MockAdminOptions) SetWriteRetrier(value retry.Retrier) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteRetrier", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) SetWriteOpPoolSize(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteOpPoolSize", arg0)
+func (_mr *_MockAdminOptionsRecorder) SetWriteRetrier(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRetrier", arg0)
 }
 
-func (_m *MockAdminOptions) WriteOpPoolSize() int {
-	ret := _m.ctrl.Call(_m, "WriteOpPoolSize")
-	ret0, _ := ret[0].(int)
+func (_m *MockAdminOptions) WriteRetrier() retry.Retrier {
+	ret := _m.ctrl.Call(_m, "WriteRetrier")
+	ret0, _ := ret[0].(retry.Retrier)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) WriteOpPoolSize() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteOpPoolSize")
+func (_mr *_MockAdminOptionsRecorder) WriteRetrier() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRetrier")
 }
 
-func (_m *MockAdminOptions) SetFetchBatchOpPoolSize(value int) Options {
-	ret := _m.ctrl.Call(_m, "SetFetchBatchOpPoolSize", value)
+func (_m *MockAdminOptions) SetFetchRetrier(value retry.Retrier) Options {
+	ret := _m.ctrl.Call(_m, "SetFetchRetrier", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) SetFetchBatchOpPoolSize(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchBatchOpPoolSize", arg0)
+func (_mr *_MockAdminOptionsRecorder) SetFetchRetrier(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRetrier", arg0)
 }
 
-func (_m *MockAdminOptions) FetchBatchOpPoolSize() int {
-	ret := _m.ctrl.Call(_m, "FetchBatchOpPoolSize")
-	ret0, _ := ret[0].(int)
+func (_m *MockAdminOptions) FetchRetrier() retry.Retrier {
+	ret := _m.ctrl.Call(_m, "FetchRetrier")
+	ret0, _ := ret[0].(retry.Retrier)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) FetchBatchOpPoolSize() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchOpPoolSize")
-}
-
-func (_m *MockAdminOptions) SetContextPool(value context.Pool) Options {
-	ret := _m.ctrl.Call(_m, "SetContextPool", value)
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockAdminOptionsRecorder) SetContextPool(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetContextPool", arg0)
-}
-
-func (_m *MockAdminOptions) ContextPool() context.Pool {
-	ret := _m.ctrl.Call(_m, "ContextPool")
-	ret0, _ := ret[0].(context.Pool)
-	return ret0
-}
-
-func (_mr *_MockAdminOptionsRecorder) ContextPool() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContextPool")
+func (_mr *_MockAdminOptionsRecorder) FetchRetrier() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRetrier")
 }
 
 func (_m *MockAdminOptions) SetWriteBatchSize(value int) Options {
@@ -2103,24 +2124,44 @@ func (_mr *_MockAdminOptionsRecorder) FetchBatchSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchSize")
 }
 
-func (_m *MockAdminOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
-	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+func (_m *MockAdminOptions) SetWriteOpPoolSize(value int) Options {
+	ret := _m.ctrl.Call(_m, "SetWriteOpPoolSize", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+func (_mr *_MockAdminOptionsRecorder) SetWriteOpPoolSize(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteOpPoolSize", arg0)
 }
 
-func (_m *MockAdminOptions) IdentifierPool() ts.IdentifierPool {
-	ret := _m.ctrl.Call(_m, "IdentifierPool")
-	ret0, _ := ret[0].(ts.IdentifierPool)
+func (_m *MockAdminOptions) WriteOpPoolSize() int {
+	ret := _m.ctrl.Call(_m, "WriteOpPoolSize")
+	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-func (_mr *_MockAdminOptionsRecorder) IdentifierPool() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
+func (_mr *_MockAdminOptionsRecorder) WriteOpPoolSize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteOpPoolSize")
+}
+
+func (_m *MockAdminOptions) SetFetchBatchOpPoolSize(value int) Options {
+	ret := _m.ctrl.Call(_m, "SetFetchBatchOpPoolSize", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetFetchBatchOpPoolSize(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchBatchOpPoolSize", arg0)
+}
+
+func (_m *MockAdminOptions) FetchBatchOpPoolSize() int {
+	ret := _m.ctrl.Call(_m, "FetchBatchOpPoolSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) FetchBatchOpPoolSize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBatchOpPoolSize")
 }
 
 func (_m *MockAdminOptions) SetHostQueueOpsFlushSize(value int) Options {
@@ -2161,6 +2202,46 @@ func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
 
 func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushInterval")
+}
+
+func (_m *MockAdminOptions) SetContextPool(value context.Pool) Options {
+	ret := _m.ctrl.Call(_m, "SetContextPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetContextPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetContextPool", arg0)
+}
+
+func (_m *MockAdminOptions) ContextPool() context.Pool {
+	ret := _m.ctrl.Call(_m, "ContextPool")
+	ret0, _ := ret[0].(context.Pool)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) ContextPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContextPool")
+}
+
+func (_m *MockAdminOptions) SetIdentifierPool(value ts.IdentifierPool) Options {
+	ret := _m.ctrl.Call(_m, "SetIdentifierPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) SetIdentifierPool(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIdentifierPool", arg0)
+}
+
+func (_m *MockAdminOptions) IdentifierPool() ts.IdentifierPool {
+	ret := _m.ctrl.Call(_m, "IdentifierPool")
+	ret0, _ := ret[0].(ts.IdentifierPool)
+	return ret0
+}
+
+func (_mr *_MockAdminOptionsRecorder) IdentifierPool() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifierPool")
 }
 
 func (_m *MockAdminOptions) SetHostQueueOpsArrayPoolSize(value int) Options {

--- a/client/fetch_attempt.go
+++ b/client/fetch_attempt.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"time"
+
+	"github.com/m3db/m3db/encoding"
+	"github.com/m3db/m3x/pool"
+	xretry "github.com/m3db/m3x/retry"
+)
+
+var fetchAttemptArgsZeroed fetchAttemptArgs
+
+type fetchAttempt struct {
+	args fetchAttemptArgs
+
+	result encoding.SeriesIterators
+
+	session *session
+
+	attemptFn xretry.Fn
+}
+
+type fetchAttemptArgs struct {
+	namespace string
+	ids       []string
+	start     time.Time
+	end       time.Time
+}
+
+func (f *fetchAttempt) reset() {
+	f.args = fetchAttemptArgsZeroed
+	f.result = nil
+}
+
+func (f *fetchAttempt) perform() error {
+	result, err := f.session.fetchAllAttempt(f.args.namespace,
+		f.args.ids, f.args.start, f.args.end)
+	f.result = result
+	return err
+}
+
+type fetchAttemptPool struct {
+	initialized bool
+	pool        pool.ObjectPool
+	session     *session
+}
+
+func newFetchAttemptPool(
+	session *session,
+	opts pool.ObjectPoolOptions,
+) *fetchAttemptPool {
+	p := pool.NewObjectPool(opts)
+	return &fetchAttemptPool{pool: p, session: session}
+}
+
+func (p *fetchAttemptPool) Init() {
+	p.pool.Init(func() interface{} {
+		w := &fetchAttempt{session: p.session}
+		// NB(r): Bind attemptFn once to avoid creating receiver
+		// and function method pointer over and over again
+		w.attemptFn = w.perform
+		w.reset()
+		return w
+	})
+	p.initialized = true
+}
+
+func (p *fetchAttemptPool) Get() *fetchAttempt {
+	return p.pool.Get().(*fetchAttempt)
+}
+
+func (p *fetchAttemptPool) Put(f *fetchAttempt) {
+	f.reset()
+	p.pool.Put(f)
+}

--- a/client/fetch_attempt.go
+++ b/client/fetch_attempt.go
@@ -60,9 +60,8 @@ func (f *fetchAttempt) perform() error {
 }
 
 type fetchAttemptPool struct {
-	initialized bool
-	pool        pool.ObjectPool
-	session     *session
+	pool    pool.ObjectPool
+	session *session
 }
 
 func newFetchAttemptPool(
@@ -82,7 +81,6 @@ func (p *fetchAttemptPool) Init() {
 		w.reset()
 		return w
 	})
-	p.initialized = true
 }
 
 func (p *fetchAttemptPool) Get() *fetchAttempt {

--- a/client/fetch_batch.go
+++ b/client/fetch_batch.go
@@ -69,9 +69,8 @@ func (f *fetchBatchOp) complete(idx int, result interface{}, err error) {
 }
 
 type fetchBatchOpPool struct {
-	initialized bool
-	pool        pool.ObjectPool
-	capacity    int
+	pool     pool.ObjectPool
+	capacity int
 }
 
 func newFetchBatchOpPool(opts pool.ObjectPoolOptions, capacity int) *fetchBatchOpPool {
@@ -87,7 +86,6 @@ func (p *fetchBatchOpPool) Init() {
 		f.reset()
 		return f
 	})
-	p.initialized = true
 }
 
 func (p *fetchBatchOpPool) Get() *fetchBatchOp {

--- a/client/op_array_pool.go
+++ b/client/op_array_pool.go
@@ -64,10 +64,9 @@ func (p *poolOfOpArray) Put(ops []op) {
 }
 
 type fetchBatchOpArrayArrayPool struct {
-	initialized bool
-	pool        pool.ObjectPool
-	entries     int
-	capacity    int
+	pool     pool.ObjectPool
+	entries  int
+	capacity int
 }
 
 func newFetchBatchOpArrayArrayPool(
@@ -90,7 +89,6 @@ func (p *fetchBatchOpArrayArrayPool) Init() {
 		}
 		return arr
 	})
-	p.initialized = true
 }
 
 func (p *fetchBatchOpArrayArrayPool) Get() [][]*fetchBatchOp {

--- a/client/reader_slice_of_slices_iterator.go
+++ b/client/reader_slice_of_slices_iterator.go
@@ -34,12 +34,12 @@ type readerSliceOfSlicesIterator struct {
 	segmentReaders []xio.SegmentReader
 	idx            int
 	closed         bool
-	pool           readerSliceOfSlicesIteratorPool
+	pool           *readerSliceOfSlicesIteratorPool
 }
 
 func newReaderSliceOfSlicesIterator(
 	segments []*rpc.Segments,
-	pool readerSliceOfSlicesIteratorPool,
+	pool *readerSliceOfSlicesIteratorPool,
 ) *readerSliceOfSlicesIterator {
 	it := &readerSliceOfSlicesIterator{pool: pool}
 	it.Reset(segments)

--- a/client/reader_slice_of_slices_iterator_pool.go
+++ b/client/reader_slice_of_slices_iterator_pool.go
@@ -23,8 +23,7 @@ package client
 import "github.com/m3db/m3x/pool"
 
 type readerSliceOfSlicesIteratorPool struct {
-	initialized bool
-	pool        pool.ObjectPool
+	pool pool.ObjectPool
 }
 
 func newReaderSliceOfSlicesIteratorPool(
@@ -38,7 +37,6 @@ func (p *readerSliceOfSlicesIteratorPool) Init() {
 	p.pool.Init(func() interface{} {
 		return newReaderSliceOfSlicesIterator(nil, p)
 	})
-	p.initialized = true
 }
 
 func (p *readerSliceOfSlicesIteratorPool) Get() *readerSliceOfSlicesIterator {

--- a/client/types.go
+++ b/client/types.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+	xretry "github.com/m3db/m3x/retry"
 	xtime "github.com/m3db/m3x/time"
 
 	tchannel "github.com/uber/tchannel-go"
@@ -300,6 +301,9 @@ type Options interface {
 	// Validate validates the options
 	Validate() error
 
+	// SetEncodingM3TSZ sets m3tsz encoding
+	SetEncodingM3TSZ() Options
+
 	// SetClockOptions sets the clock options
 	SetClockOptions(value clock.Options) Options
 
@@ -311,9 +315,6 @@ type Options interface {
 
 	// InstrumentOptions returns the instrumentation options
 	InstrumentOptions() instrument.Options
-
-	// SetEncodingM3TSZ sets m3tsz encoding
-	SetEncodingM3TSZ() Options
 
 	// SetTopologyInitializer sets the TopologyInitializer
 	SetTopologyInitializer(value topology.Initializer) Options
@@ -431,23 +432,21 @@ type Options interface {
 	// timeout to produce a throttle sleep value.
 	BackgroundHealthCheckFailThrottleFactor() float64
 
-	// SetWriteOpPoolSize sets the writeOpPoolSize
-	SetWriteOpPoolSize(value int) Options
+	// SetWriteRetrier sets the write retrier when performing a write for
+	// a write operation. Only retryable errors are retried.
+	SetWriteRetrier(value xretry.Retrier) Options
 
-	// WriteOpPoolSize returns the writeOpPoolSize
-	WriteOpPoolSize() int
+	// WriteRetrier returns the write retrier when perform a write for
+	// a write operation. Only retryable errors are retried.
+	WriteRetrier() xretry.Retrier
 
-	// SetFetchBatchOpPoolSize sets the fetchBatchOpPoolSize
-	SetFetchBatchOpPoolSize(value int) Options
+	// SetFetchRetrier sets the fetch retrier when performing a write for
+	// a fetch operation. Only retryable errors are retried.
+	SetFetchRetrier(value xretry.Retrier) Options
 
-	// FetchBatchOpPoolSize returns the fetchBatchOpPoolSize
-	FetchBatchOpPoolSize() int
-
-	// SetContextPool sets the contextPool
-	SetContextPool(value context.Pool) Options
-
-	// ContextPool returns the contextPool
-	ContextPool() context.Pool
+	// FetchRetrier returns the fetch retrier when perform a write for
+	// a fetch operation. Only retryable errors are retried.
+	FetchRetrier() xretry.Retrier
 
 	// SetWriteBatchSize sets the writeBatchSize
 	// NB(r): for a write only application load this should match the host
@@ -467,11 +466,17 @@ type Options interface {
 	// FetchBatchSize returns the fetchBatchSize
 	FetchBatchSize() int
 
-	// SetIdentifierPool sets the identifier pool
-	SetIdentifierPool(value ts.IdentifierPool) Options
+	// SetWriteOpPoolSize sets the writeOpPoolSize
+	SetWriteOpPoolSize(value int) Options
 
-	// IdentifierPool returns the identifier pool
-	IdentifierPool() ts.IdentifierPool
+	// WriteOpPoolSize returns the writeOpPoolSize
+	WriteOpPoolSize() int
+
+	// SetFetchBatchOpPoolSize sets the fetchBatchOpPoolSize
+	SetFetchBatchOpPoolSize(value int) Options
+
+	// FetchBatchOpPoolSize returns the fetchBatchOpPoolSize
+	FetchBatchOpPoolSize() int
 
 	// SetHostQueueOpsFlushSize sets the hostQueueOpsFlushSize
 	SetHostQueueOpsFlushSize(value int) Options
@@ -484,6 +489,18 @@ type Options interface {
 
 	// HostQueueOpsFlushInterval returns the hostQueueOpsFlushInterval
 	HostQueueOpsFlushInterval() time.Duration
+
+	// SetContextPool sets the contextPool
+	SetContextPool(value context.Pool) Options
+
+	// ContextPool returns the contextPool
+	ContextPool() context.Pool
+
+	// SetIdentifierPool sets the identifier pool
+	SetIdentifierPool(value ts.IdentifierPool) Options
+
+	// IdentifierPool returns the identifier pool
+	IdentifierPool() ts.IdentifierPool
 
 	// HostQueueOpsArrayPoolSize sets the hostQueueOpsArrayPoolSize
 	SetHostQueueOpsArrayPoolSize(value int) Options

--- a/client/write.go
+++ b/client/write.go
@@ -62,8 +62,7 @@ func (w *writeOp) CompletionFn() completionFn {
 }
 
 type writeOpPool struct {
-	initialized bool
-	pool        pool.ObjectPool
+	pool pool.ObjectPool
 }
 
 func newWriteOpPool(opts pool.ObjectPoolOptions) *writeOpPool {
@@ -77,7 +76,6 @@ func (p *writeOpPool) Init() {
 		w.reset()
 		return w
 	})
-	p.initialized = true
 }
 
 func (p *writeOpPool) Get() *writeOp {
@@ -195,9 +193,8 @@ func (w *writeState) completionFn(result interface{}, err error) {
 }
 
 type writeStatePool struct {
-	initialized bool
-	pool        pool.ObjectPool
-	session     *session
+	pool    pool.ObjectPool
+	session *session
 }
 
 func newWriteStatePool(
@@ -214,7 +211,6 @@ func (p *writeStatePool) Init() {
 		w.reset()
 		return w
 	})
-	p.initialized = true
 }
 
 func (p *writeStatePool) Get() *writeState {

--- a/client/write_attempt.go
+++ b/client/write_attempt.go
@@ -57,9 +57,8 @@ func (w *writeAttempt) perform() error {
 }
 
 type writeAttemptPool struct {
-	initialized bool
-	pool        pool.ObjectPool
-	session     *session
+	pool    pool.ObjectPool
+	session *session
 }
 
 func newWriteAttemptPool(
@@ -79,7 +78,6 @@ func (p *writeAttemptPool) Init() {
 		w.reset()
 		return w
 	})
-	p.initialized = true
 }
 
 func (p *writeAttemptPool) Get() *writeAttempt {

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -126,7 +126,7 @@ func TestShardNotAvailable(t *testing.T) {
 // utils
 
 func getWriteState(s *session) *writeState {
-	wState := s.writeStatePool.Get().(*writeState)
+	wState := s.writeStatePool.Get()
 	wState.ctx = context.NewContext()
 	wState.topoMap = s.topoMap
 	wState.op = s.writeOpPool.Get()

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -26,11 +26,11 @@ package encoding
 import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
-	io0 "github.com/m3db/m3db/x/io"
+	io "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
 	time "github.com/m3db/m3x/time"
-	io "io"
+	io0 "io"
 	time0 "time"
 )
 
@@ -65,9 +65,9 @@ func (_mr *_MockEncoderRecorder) Encode(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0, arg1, arg2)
 }
 
-func (_m *MockEncoder) Stream() io0.SegmentReader {
+func (_m *MockEncoder) Stream() io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "Stream")
-	ret0, _ := ret[0].(io0.SegmentReader)
+	ret0, _ := ret[0].(io.SegmentReader)
 	return ret0
 }
 
@@ -262,7 +262,7 @@ func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }
 
-func (_m *MockOptions) SetSegmentReaderPool(value io0.SegmentReaderPool) Options {
+func (_m *MockOptions) SetSegmentReaderPool(value io.SegmentReaderPool) Options {
 	ret := _m.ctrl.Call(_m, "SetSegmentReaderPool", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -272,9 +272,9 @@ func (_mr *_MockOptionsRecorder) SetSegmentReaderPool(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSegmentReaderPool", arg0)
 }
 
-func (_m *MockOptions) SegmentReaderPool() io0.SegmentReaderPool {
+func (_m *MockOptions) SegmentReaderPool() io.SegmentReaderPool {
 	ret := _m.ctrl.Call(_m, "SegmentReaderPool")
-	ret0, _ := ret[0].(io0.SegmentReaderPool)
+	ret0, _ := ret[0].(io.SegmentReaderPool)
 	return ret0
 }
 
@@ -404,7 +404,7 @@ func (_mr *_MockReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockReaderIterator) Reset(reader io.Reader) {
+func (_m *MockReaderIterator) Reset(reader io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", reader)
 }
 
@@ -473,7 +473,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockMultiReaderIterator) Reset(readers []io.Reader) {
+func (_m *MockMultiReaderIterator) Reset(readers []io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", readers)
 }
 
@@ -481,7 +481,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Reset(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0)
 }
 
-func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io0.ReaderSliceOfSlicesIterator) {
+func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io.ReaderSliceOfSlicesIterator) {
 	_m.ctrl.Call(_m, "ResetSliceOfSlices", readers)
 }
 
@@ -733,7 +733,7 @@ func (_m *MockDecoder) EXPECT() *_MockDecoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDecoder) Decode(reader io.Reader) ReaderIterator {
+func (_m *MockDecoder) Decode(reader io0.Reader) ReaderIterator {
 	ret := _m.ctrl.Call(_m, "Decode", reader)
 	ret0, _ := ret[0].(ReaderIterator)
 	return ret0
@@ -808,7 +808,7 @@ func (_mr *_MockIStreamRecorder) PeekBits(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PeekBits", arg0)
 }
 
-func (_m *MockIStream) Reset(r io.Reader) {
+func (_m *MockIStream) Reset(r io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", r)
 }
 

--- a/persist/fs/commitlog/commit_log_mock.go
+++ b/persist/fs/commitlog/commit_log_mock.go
@@ -32,8 +32,8 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of CommitLog interface
@@ -67,7 +67,7 @@ func (_mr *_MockCommitLogRecorder) Open() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open")
 }
 
-func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -77,7 +77,7 @@ func (_mr *_MockCommitLogRecorder) Write(arg0, arg1, arg2, arg3, arg4 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "WriteBehind", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -139,11 +139,11 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (Series, ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (Series, ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(Series)
 	ret1, _ := ret[1].(ts.Datapoint)
-	ret2, _ := ret[2].(time0.Unit)
+	ret2, _ := ret[2].(time.Unit)
 	ret3, _ := ret[3].(ts.Annotation)
 	return ret0, ret1, ret2, ret3
 }
@@ -311,7 +311,7 @@ func (_mr *_MockOptionsRecorder) Strategy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Strategy")
 }
 
-func (_m *MockOptions) SetFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -321,9 +321,9 @@ func (_mr *_MockOptionsRecorder) SetFlushInterval(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFlushInterval", arg0)
 }
 
-func (_m *MockOptions) FlushInterval() time.Duration {
+func (_m *MockOptions) FlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -692,27 +692,24 @@ func (n *dbNamespace) readableShardAt(shardID uint32) (databaseShard, error) {
 }
 
 func (n *dbNamespace) shardAtWithRLock(shardID uint32) (databaseShard, error) {
+	// NB(r): These errors are retryable as they will occur
+	// during a topology change and must be retried by the client.
 	if int(shardID) >= len(n.shards) {
-		return nil, xerrors.NewInvalidParamsError(
+		return nil, xerrors.NewRetryableError(
 			fmt.Errorf("not responsible for shard %d", shardID))
 	}
 	shard := n.shards[shardID]
 	if shard == nil {
-		return nil, xerrors.NewInvalidParamsError(
+		return nil, xerrors.NewRetryableError(
 			fmt.Errorf("not responsible for shard %d", shardID))
 	}
 	return shard, nil
 }
 
 func (n *dbNamespace) readableShardAtWithRLock(shardID uint32) (databaseShard, error) {
-	if int(shardID) >= len(n.shards) {
-		return nil, xerrors.NewInvalidParamsError(
-			fmt.Errorf("not responsible for shard %d", shardID))
-	}
-	shard := n.shards[shardID]
-	if shard == nil {
-		return nil, xerrors.NewInvalidParamsError(
-			fmt.Errorf("not responsible for shard %d", shardID))
+	shard, err := n.shardAtWithRLock(shardID)
+	if err != nil {
+		return nil, err
 	}
 	if !shard.IsBootstrapped() {
 		return nil, xerrors.NewRetryableError(errShardNotBootstrappedToRead)

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -471,9 +471,11 @@ func TestNamespaceShardAt(t *testing.T) {
 	_, err = ns.readableShardAt(1)
 	require.Error(t, err)
 	require.True(t, xerrors.IsRetryableError(err))
+	require.Equal(t, errShardNotBootstrappedToRead.Error(), err.Error())
 	_, err = ns.readableShardAt(2)
 	require.Error(t, err)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsRetryableError(err))
+	require.Equal(t, "not responsible for shard 2", err.Error())
 }
 
 func TestNamespaceAssignShardSet(t *testing.T) {

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -91,7 +91,8 @@ func TestNamespaceWriteShardNotOwned(t *testing.T) {
 	}
 	err := ns.Write(ctx, ts.StringID("foo"), time.Now(), 0.0, xtime.Second, nil)
 	require.Error(t, err)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsRetryableError(err))
+	require.Equal(t, "not responsible for shard 0", err.Error())
 }
 
 func TestNamespaceWriteShardOwned(t *testing.T) {
@@ -163,7 +164,8 @@ func TestNamespaceFetchBlocksShardNotOwned(t *testing.T) {
 		ns.shards[i] = nil
 	}
 	_, err := ns.FetchBlocks(ctx, testShardIDs[0].ID(), ts.StringID("foo"), nil)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsRetryableError(err))
+	require.Equal(t, "not responsible for shard 0", err.Error())
 }
 
 func TestNamespaceFetchBlocksShardOwned(t *testing.T) {
@@ -201,7 +203,8 @@ func TestNamespaceFetchBlocksMetadataShardNotOwned(t *testing.T) {
 	start := time.Now()
 	end := start.Add(time.Hour)
 	_, _, err := ns.FetchBlocksMetadata(ctx, testShardIDs[0].ID(), start, end, 100, 0, true, true)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsRetryableError(err))
+	require.Equal(t, "not responsible for shard 0", err.Error())
 }
 
 func TestNamespaceFetchBlocksMetadataShardOwned(t *testing.T) {

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -1432,6 +1432,26 @@ func (_mr *_MockOptionsRecorder) CommitLogOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CommitLogOptions")
 }
 
+func (_m *MockOptions) SetRepairEnabled(b bool) Options {
+	ret := _m.ctrl.Call(_m, "SetRepairEnabled", b)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetRepairEnabled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRepairEnabled", arg0)
+}
+
+func (_m *MockOptions) RepairEnabled() bool {
+	ret := _m.ctrl.Call(_m, "RepairEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) RepairEnabled() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RepairEnabled")
+}
+
 func (_m *MockOptions) SetRepairOptions(value repair.Options) Options {
 	ret := _m.ctrl.Call(_m, "SetRepairOptions", value)
 	ret0, _ := ret[0].(Options)


### PR DESCRIPTION
This change adds the ability to set a retrier for writes and fetches.  It allows for anyone to use an out of the box retrier from the `github.com/m3db/m3x/retry` package.  It also let's them create their own custom retrier that fits the `Retrier` interface and specify that instead.

cc @xichen2020 @cw9 @prateek @ben-lerner 