### PR TITLE
Open only the delta set of connections on topology change

### DIFF
--- a/client/session_topology_test.go
+++ b/client/session_topology_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/integration/fake"
+	"github.com/m3db/m3db/topology"
+	"github.com/uber-go/tally"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testHostQueues struct {
+	sync.RWMutex
+	queues map[string]*MockhostQueue
+}
+
+func newTestHostQueues() *testHostQueues {
+	return &testHostQueues{
+		queues: make(map[string]*MockhostQueue),
+	}
+}
+
+func (q *testHostQueues) set(id string, value *MockhostQueue) {
+	q.Lock()
+	defer q.Unlock()
+	q.queues[id] = value
+}
+
+func (q *testHostQueues) get(id string) *MockhostQueue {
+	q.RLock()
+	defer q.RUnlock()
+	return q.queues[id]
+}
+
+func (q *testHostQueues) len() int {
+	q.RLock()
+	defer q.RUnlock()
+	return len(q.queues)
+}
+
+func TestSessionTopologyChangeCreatesNewClosesOldHostQueues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	avail := shard.Available
+
+	node := func(id string, shards []uint32) services.ServiceInstance {
+		result := services.NewServiceInstance().SetInstanceID(id)
+		resultShards := make([]shard.Shard, len(shards))
+		for i, id := range shards {
+			resultShards[i] = shard.NewShard(id).SetState(avail)
+		}
+		return result.SetShards(shard.NewShards(resultShards))
+	}
+
+	svc := fake.NewM3ClusterService().
+		SetInstances([]services.ServiceInstance{
+			node("testhost0", []uint32{0, 1}),
+			node("testhost1", []uint32{2, 3}),
+		}).
+		SetReplication(services.NewServiceReplication().SetReplicas(1)).
+		SetSharding(services.NewServiceSharding().SetNumShards(4))
+
+	svcs := fake.NewM3ClusterServices()
+	svcs.RegisterService("m3db", svc)
+
+	topoOpts := topology.NewDynamicOptions().
+		SetConfigServiceClient(fake.NewM3ClusterClient(svcs, nil))
+	topoInit := topology.NewDynamicInitializer(topoOpts)
+
+	scope := tally.NewTestScope("", nil)
+
+	opts := newSessionTestOptions().
+		SetTopologyInitializer(topoInit)
+	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().
+		SetMetricsScope(scope))
+
+	s, err := newSession(opts)
+	require.NoError(t, err)
+
+	createdQueues := newTestHostQueues()
+	closedQueues := newTestHostQueues()
+
+	session := s.(*session)
+	session.newHostQueueFn = func(
+		host topology.Host,
+		_ writeBatchRawRequestPool,
+		_ writeBatchRawRequestElementArrayPool,
+		opts Options,
+	) hostQueue {
+		queue := NewMockhostQueue(ctrl)
+		createdQueues.set(host.ID(), queue)
+
+		queue.EXPECT().Open()
+		queue.EXPECT().Host().Return(host).AnyTimes()
+		queue.EXPECT().ConnectionCount().Return(opts.MinConnectionCount()).AnyTimes()
+		queue.EXPECT().Close().Do(func() {
+			closedQueues.set(host.ID(), queue)
+		})
+		return queue
+	}
+
+	require.NoError(t, session.Open())
+	defer func() {
+		assert.NoError(t, session.Close())
+	}()
+
+	// Assert created two
+	require.Equal(t, 2, createdQueues.len())
+	require.Equal(t, 0, closedQueues.len())
+	require.NotNil(t, createdQueues.get("testhost0"))
+	require.NotNil(t, createdQueues.get("testhost1"))
+
+	// Change topology with one new instance and close one instance
+	svc.SetInstances([]services.ServiceInstance{
+		node("testhost1", []uint32{2, 3}),
+		node("testhost2", []uint32{0, 1}),
+	})
+	svcs.NotifyServiceUpdate("m3db")
+
+	// Wait for topology to be processed
+	for {
+		updated, ok := scope.Snapshot().Counters()["topology.updated-success"]
+		if ok && updated.Value() > 0 {
+			break
+		}
+	}
+
+	// Assert create third and closed first
+	require.Equal(t, 3, createdQueues.len())
+	require.Equal(t, 1, closedQueues.len())
+	require.NotNil(t, createdQueues.get("testhost0"))
+	require.NotNil(t, createdQueues.get("testhost1"))
+	require.NotNil(t, createdQueues.get("testhost2"))
+	require.NotNil(t, closedQueues.get("testhost0"))
+}

--- a/integration/cluster_add_one_node_test.go
+++ b/integration/cluster_add_one_node_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3db/integration/fake"
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
@@ -71,16 +72,16 @@ func TestClusterAddOneNode(t *testing.T) {
 		},
 	}
 
-	svc := NewFakeM3ClusterService().
+	svc := fake.NewM3ClusterService().
 		SetInstances(instances.start).
 		SetReplication(services.NewServiceReplication().SetReplicas(1)).
 		SetSharding(services.NewServiceSharding().SetNumShards(1024))
 
-	svcs := NewFakeM3ClusterServices()
+	svcs := fake.NewM3ClusterServices()
 	svcs.RegisterService("m3db", svc)
 
 	topoOpts := topology.NewDynamicOptions().
-		SetConfigServiceClient(NewM3FakeClusterClient(svcs, nil))
+		SetConfigServiceClient(fake.NewM3ClusterClient(svcs, nil))
 	topoInit := topology.NewDynamicInitializer(topoOpts)
 	retentionOpts := retention.NewOptions().
 		SetRetentionPeriod(6 * time.Hour).
@@ -184,7 +185,7 @@ func TestClusterAddOneNode(t *testing.T) {
 
 	log.Debug("waiting for shards to be marked initialized")
 	allMarkedAvailable := func(
-		fakePlacementService FakeM3ClusterPlacementService,
+		fakePlacementService fake.M3ClusterPlacementService,
 		instanceID string,
 		shards []shard.Shard,
 	) bool {

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3db/client"
 	"github.com/m3db/m3db/clock"
 	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/integration/fake"
 	"github.com/m3db/m3db/persist"
 	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/retention"
@@ -400,16 +401,16 @@ func newNodes(
 
 	// NB(bl): We set replication to 3 to mimic production. This can be made
 	// into a variable if needed.
-	svc := NewFakeM3ClusterService().
+	svc := fake.NewM3ClusterService().
 		SetInstances(instances).
 		SetReplication(services.NewServiceReplication().SetReplicas(3)).
 		SetSharding(services.NewServiceSharding().SetNumShards(1024))
 
-	svcs := NewFakeM3ClusterServices()
+	svcs := fake.NewM3ClusterServices()
 	svcs.RegisterService("m3db", svc)
 
 	topoOpts := topology.NewDynamicOptions().
-		SetConfigServiceClient(NewM3FakeClusterClient(svcs, nil))
+		SetConfigServiceClient(fake.NewM3ClusterClient(svcs, nil))
 	topoInit := topology.NewDynamicInitializer(topoOpts)
 	retentionOpts := retention.NewOptions().
 		SetRetentionPeriod(6 * time.Hour).


### PR DESCRIPTION
This change only connects to new sets of hosts on a topology change and only closes the host queues belonging to hosts no longer in the topology.

This will reduce the large double connection count required for a topology change.  Since the topology can change a lot during shards becoming available one by one this should reduce a lot of overhead.

cc @xichen2020 @cw9 @prateek @ben-lerner 