### PR TITLE
Disable ticking and flushing after bootstrapping

### DIFF
--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -182,9 +182,6 @@ func (m *bootstrapManager) Bootstrap() error {
 		}
 	}
 
-	// Forcing a tick to perform necessary file operations
-	m.mediator.Tick(m.opts.RetentionOptions().BufferDrain(), syncRun, force)
-
 	return multiErr.FinalError()
 }
 

--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -182,6 +182,15 @@ func (m *bootstrapManager) Bootstrap() error {
 		}
 	}
 
+	// NB(xichen): in order for bootstrapped data to be flushed to disk, a tick
+	// needs to happen to drain the in-memory buffers and a consequent flush will
+	// flush all the data onto disk. However, this has shown to be too intensive
+	// to do immediately after bootstrap due to bootstrapping nodes simultaneously
+	// attempting to tick through their series and flushing data, adding significant
+	// load to the cluster. It turns out to be better to let ticking happen naturally
+	// on its own course so that the load of ticking and flushing is more spread out
+	// across the cluster.
+
 	return multiErr.FinalError()
 }
 

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -52,12 +52,10 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 		"test": namespace,
 	}
 
-	deadline := opts.RetentionOptions().BufferDrain()
 	db := &mockDatabase{namespaces: namespaces, opts: opts}
 	m := NewMockdatabaseMediator(ctrl)
 	m.EXPECT().DisableFileOps()
 	m.EXPECT().EnableFileOps().AnyTimes()
-	m.EXPECT().Tick(deadline, syncRun, force).Return(nil)
 	bsm := newBootstrapManager(db, m).(*bootstrapManager)
 	err := bsm.Bootstrap()
 


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @ben-lerner 

This PR disables ticking and flushing after bootstrapping because we observed that it added large load on the cluster, causing commit log queues to back up. Instead we'll let the buffer draining and data flushing happen naturally to spread out the load across the cluster. This has shown to reduce the commit log queue spikes significantly.