### PR TITLE
Report timing breakdowns during persistence

### DIFF
--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -26,11 +26,11 @@ package encoding
 import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
-	io0 "github.com/m3db/m3db/x/io"
+	io "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
 	time "github.com/m3db/m3x/time"
-	io "io"
+	io0 "io"
 	time0 "time"
 )
 
@@ -65,9 +65,9 @@ func (_mr *_MockEncoderRecorder) Encode(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0, arg1, arg2)
 }
 
-func (_m *MockEncoder) Stream() io0.SegmentReader {
+func (_m *MockEncoder) Stream() io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "Stream")
-	ret0, _ := ret[0].(io0.SegmentReader)
+	ret0, _ := ret[0].(io.SegmentReader)
 	return ret0
 }
 
@@ -262,7 +262,7 @@ func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }
 
-func (_m *MockOptions) SetSegmentReaderPool(value io0.SegmentReaderPool) Options {
+func (_m *MockOptions) SetSegmentReaderPool(value io.SegmentReaderPool) Options {
 	ret := _m.ctrl.Call(_m, "SetSegmentReaderPool", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -272,9 +272,9 @@ func (_mr *_MockOptionsRecorder) SetSegmentReaderPool(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSegmentReaderPool", arg0)
 }
 
-func (_m *MockOptions) SegmentReaderPool() io0.SegmentReaderPool {
+func (_m *MockOptions) SegmentReaderPool() io.SegmentReaderPool {
 	ret := _m.ctrl.Call(_m, "SegmentReaderPool")
-	ret0, _ := ret[0].(io0.SegmentReaderPool)
+	ret0, _ := ret[0].(io.SegmentReaderPool)
 	return ret0
 }
 
@@ -404,7 +404,7 @@ func (_mr *_MockReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockReaderIterator) Reset(reader io.Reader) {
+func (_m *MockReaderIterator) Reset(reader io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", reader)
 }
 
@@ -473,7 +473,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockMultiReaderIterator) Reset(readers []io.Reader) {
+func (_m *MockMultiReaderIterator) Reset(readers []io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", readers)
 }
 
@@ -481,7 +481,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Reset(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0)
 }
 
-func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io0.ReaderSliceOfSlicesIterator) {
+func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io.ReaderSliceOfSlicesIterator) {
 	_m.ctrl.Call(_m, "ResetSliceOfSlices", readers)
 }
 
@@ -733,7 +733,7 @@ func (_m *MockDecoder) EXPECT() *_MockDecoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDecoder) Decode(reader io.Reader) ReaderIterator {
+func (_m *MockDecoder) Decode(reader io0.Reader) ReaderIterator {
 	ret := _m.ctrl.Call(_m, "Decode", reader)
 	ret0, _ := ret[0].(ReaderIterator)
 	return ret0
@@ -808,7 +808,7 @@ func (_mr *_MockIStreamRecorder) PeekBits(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PeekBits", arg0)
 }
 
-func (_m *MockIStream) Reset(r io.Reader) {
+func (_m *MockIStream) Reset(r io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", r)
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 98c9d561d6973239192e7513952576e14adb11e0e04132dd9fcb500aa91bc9ef
-updated: 2017-02-20T09:11:06.175357095-05:00
+hash: 6d155e34454932674b0773ad9668f14d4d0f58cc74a1a56f0bd8efa364a158ce
+updated: 2017-02-20T17:31:51.03659332-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -28,7 +28,7 @@ imports:
   - services/placement
   - shard
 - name: github.com/m3db/m3x
-  version: 3a8328d65b7880b034b8515177921023b41e4399
+  version: 2adc966acde14c9f0cc04c3eaeb338c5f9673a74
   vcs: git
   subpackages:
   - checked

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,7 +45,7 @@ import:
   - services
 
 - package: github.com/m3db/m3x
-  version: 3a8328d65b7880b034b8515177921023b41e4399
+  version: 2adc966acde14c9f0cc04c3eaeb338c5f9673a74
   vcs: git
   subpackages:
   - checked

--- a/persist/fs/persist_manager.go
+++ b/persist/fs/persist_manager.go
@@ -163,10 +163,8 @@ func (pm *persistManager) persist(
 
 	end := pm.nowFn()
 	worked := end.Sub(start) - slept
-	if currMetrics != nil {
-		currMetrics.recordWorked(worked)
-		currMetrics.recordSlept(slept)
-	}
+	currMetrics.recordWorked(worked)
+	currMetrics.recordSlept(slept)
 
 	return err
 }

--- a/persist/fs/persist_manager.go
+++ b/persist/fs/persist_manager.go
@@ -21,6 +21,9 @@
 package fs
 
 import (
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/m3db/m3db/clock"
@@ -28,18 +31,61 @@ import (
 	"github.com/m3db/m3db/ratelimit"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/checked"
+
+	"github.com/uber-go/tally"
 )
 
 const (
-	bytesPerMegabit = 1024 * 1024 / 8
+	bytesPerMegabit  = 1024 * 1024 / 8
+	nsPerMillisecond = int64(time.Millisecond / time.Nanosecond)
 )
 
 type sleepFn func(time.Duration)
 
+type shardMetrics struct {
+	worked     tally.Gauge
+	slept      tally.Gauge
+	workedInNs int64
+	sleptInNs  int64
+}
+
+func newShardMetrics(scope tally.Scope, shard uint32) *shardMetrics {
+	s := scope.Tagged(
+		map[string]string{
+			"shard": strconv.Itoa(int(shard)),
+		},
+	)
+	return &shardMetrics{
+		worked: s.Gauge("worked"),
+		slept:  s.Gauge("slept"),
+	}
+}
+
+func (m *shardMetrics) reset() {
+	atomic.StoreInt64(&m.workedInNs, 0)
+	atomic.StoreInt64(&m.sleptInNs, 0)
+}
+
+func (m *shardMetrics) recordWorked(d time.Duration) {
+	atomic.AddInt64(&m.workedInNs, int64(d))
+}
+
+func (m *shardMetrics) recordSlept(d time.Duration) {
+	atomic.AddInt64(&m.sleptInNs, int64(d))
+}
+
+func (m *shardMetrics) report() {
+	m.worked.Update(float64(atomic.LoadInt64(&m.workedInNs) / nsPerMillisecond))
+	m.slept.Update(float64(atomic.LoadInt64(&m.sleptInNs) / nsPerMillisecond))
+}
+
 // persistManager is responsible for persisting series segments onto local filesystem.
 // It is not thread-safe.
 type persistManager struct {
+	sync.RWMutex
+
 	opts           Options
+	scope          tally.Scope
 	filePathPrefix string
 	rateLimitOpts  ratelimit.Options
 	nowFn          clock.NowFn
@@ -48,6 +94,8 @@ type persistManager struct {
 	start          time.Time
 	count          int
 	bytesWritten   int64
+	metrics        map[uint32]*shardMetrics
+	currMetrics    *shardMetrics
 
 	// segmentHolder is a two-item slice that's reused to hold pointers to the
 	// head and the tail of each segment so we don't need to allocate memory
@@ -57,21 +105,27 @@ type persistManager struct {
 
 // NewPersistManager creates a new filesystem persist manager
 func NewPersistManager(opts Options) persist.Manager {
+	scope := opts.InstrumentOptions().MetricsScope().SubScope("persist")
 	filePathPrefix := opts.FilePathPrefix()
 	writerBufferSize := opts.WriterBufferSize()
 	blockSize := opts.RetentionOptions().BlockSize()
 	newFileMode := opts.NewFileMode()
 	newDirectoryMode := opts.NewDirectoryMode()
 	writer := NewWriter(blockSize, filePathPrefix, writerBufferSize, newFileMode, newDirectoryMode)
-	return &persistManager{
+	pm := &persistManager{
 		opts:           opts,
+		scope:          scope,
 		filePathPrefix: filePathPrefix,
 		rateLimitOpts:  opts.RateLimitOptions(),
 		nowFn:          opts.ClockOptions().NowFn(),
 		sleepFn:        time.Sleep,
 		writer:         writer,
+		metrics:        make(map[uint32]*shardMetrics),
 		segmentHolder:  make([]checked.Bytes, 2),
 	}
+
+	go pm.reportLoop()
+	return pm
 }
 
 func (pm *persistManager) persist(
@@ -79,15 +133,23 @@ func (pm *persistManager) persist(
 	segment ts.Segment,
 	checksum uint32,
 ) error {
+	pm.RLock()
+	currMetrics := pm.currMetrics
+	pm.RUnlock()
+
+	var (
+		start = pm.nowFn()
+		slept time.Duration
+	)
 	rateLimitMbps := pm.rateLimitOpts.LimitMbps()
 	if pm.rateLimitOpts.LimitEnabled() && rateLimitMbps > 0.0 {
-		now := pm.nowFn()
 		if pm.start.IsZero() {
-			pm.start = now
+			pm.start = start
 		} else if pm.count >= pm.rateLimitOpts.LimitCheckEvery() {
 			target := time.Duration(float64(time.Second) * float64(pm.bytesWritten) / float64(rateLimitMbps*bytesPerMegabit))
-			if elapsed := now.Sub(pm.start); elapsed < target {
-				pm.sleepFn(target - elapsed)
+			if elapsed := start.Sub(pm.start); elapsed < target {
+				slept = target - elapsed
+				pm.sleepFn(slept)
 			}
 			pm.count = 0
 		}
@@ -98,6 +160,13 @@ func (pm *persistManager) persist(
 	err := pm.writer.WriteAll(id, pm.segmentHolder, checksum)
 	pm.count++
 	pm.bytesWritten += int64(segment.Len())
+
+	end := pm.nowFn()
+	worked := end.Sub(start) - slept
+	if currMetrics != nil {
+		currMetrics.recordWorked(worked)
+		currMetrics.recordSlept(slept)
+	}
 
 	return err
 }
@@ -115,20 +184,40 @@ func (pm *persistManager) reset() {
 }
 
 func (pm *persistManager) Prepare(namespace ts.ID, shard uint32, blockStart time.Time) (persist.PreparedPersist, error) {
+	pm.Lock()
+	currMetrics, exists := pm.metrics[shard]
+	if !exists {
+		currMetrics = newShardMetrics(pm.scope, shard)
+		pm.metrics[shard] = currMetrics
+	}
+	currMetrics.reset()
+	pm.currMetrics = currMetrics
+	pm.Unlock()
+
+	// NB(xichen): explicitly not using a defer to avoid creating lambdas on
+	// the heap and causing additional GC
+	start := pm.nowFn()
 	var prepared persist.PreparedPersist
 
 	// NB(xichen): if the checkpoint file for blockStart already exists, bail.
 	// This allows us to retry failed flushing attempts because they wouldn't
 	// have created the checkpoint file.
 	if FilesetExistsAt(pm.filePathPrefix, namespace, shard, blockStart) {
+		end := pm.nowFn()
+		currMetrics.recordWorked(end.Sub(start))
 		return prepared, nil
 	}
 	if err := pm.writer.Open(namespace, shard, blockStart); err != nil {
+		end := pm.nowFn()
+		currMetrics.recordWorked(end.Sub(start))
 		return prepared, err
 	}
 
 	prepared.Persist = pm.persist
 	prepared.Close = pm.close
+
+	end := pm.nowFn()
+	currMetrics.recordWorked(end.Sub(start))
 	return prepared, nil
 }
 
@@ -138,4 +227,17 @@ func (pm *persistManager) SetRateLimitOptions(value ratelimit.Options) {
 
 func (pm *persistManager) RateLimitOptions() ratelimit.Options {
 	return pm.rateLimitOpts
+}
+
+func (pm *persistManager) reportLoop() {
+	interval := pm.opts.InstrumentOptions().ReportInterval()
+	t := time.NewTimer(interval)
+	for range t.C {
+		pm.RLock()
+		currMetrics := pm.currMetrics
+		pm.RUnlock()
+		if currMetrics != nil {
+			currMetrics.report()
+		}
+	}
 }

--- a/persist/fs/persist_manager_test.go
+++ b/persist/fs/persist_manager_test.go
@@ -167,7 +167,11 @@ func TestPersistenceManagerNoRateLimit(t *testing.T) {
 
 	pm.nowFn = func() time.Time { return now }
 	pm.sleepFn = func(d time.Duration) { slept += d }
+
+	pm.Lock()
 	pm.currMetrics = newShardMetrics(tally.NoopScope, 0)
+	pm.Unlock()
+
 	writer.EXPECT().WriteAll(id, pm.segmentHolder, checksum).Return(nil).Times(2)
 
 	// Disable rate limiting
@@ -206,7 +210,11 @@ func TestPersistenceManagerWithRateLimit(t *testing.T) {
 
 	pm.nowFn = func() time.Time { return now }
 	pm.sleepFn = func(d time.Duration) { slept += d }
+
+	pm.Lock()
 	pm.currMetrics = newShardMetrics(tally.NoopScope, 0)
+	pm.Unlock()
+
 	writer.EXPECT().WriteAll(id, pm.segmentHolder, checksum).Return(nil).AnyTimes()
 	writer.EXPECT().Close().Times(iter)
 

--- a/persist/fs/persist_manager_test.go
+++ b/persist/fs/persist_manager_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func createShardDir(t *testing.T, prefix string, namespace ts.ID, shard uint32) string {
@@ -166,6 +167,7 @@ func TestPersistenceManagerNoRateLimit(t *testing.T) {
 
 	pm.nowFn = func() time.Time { return now }
 	pm.sleepFn = func(d time.Duration) { slept += d }
+	pm.currMetrics = newShardMetrics(tally.NoopScope, 0)
 	writer.EXPECT().WriteAll(id, pm.segmentHolder, checksum).Return(nil).Times(2)
 
 	// Disable rate limiting
@@ -204,6 +206,7 @@ func TestPersistenceManagerWithRateLimit(t *testing.T) {
 
 	pm.nowFn = func() time.Time { return now }
 	pm.sleepFn = func(d time.Duration) { slept += d }
+	pm.currMetrics = newShardMetrics(tally.NoopScope, 0)
 	writer.EXPECT().WriteAll(id, pm.segmentHolder, checksum).Return(nil).AnyTimes()
 	writer.EXPECT().Close().Times(iter)
 

--- a/persist/persist_mock.go
+++ b/persist/persist_mock.go
@@ -79,3 +79,11 @@ func (_m *MockManager) RateLimitOptions() ratelimit.Options {
 func (_mr *_MockManagerRecorder) RateLimitOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RateLimitOptions")
 }
+
+func (_m *MockManager) Report() {
+	_m.ctrl.Call(_m, "Report")
+}
+
+func (_mr *_MockManagerRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
+}

--- a/persist/types.go
+++ b/persist/types.go
@@ -52,4 +52,7 @@ type Manager interface {
 
 	// RateLimitOptions returns the rate limit options
 	RateLimitOptions() ratelimit.Options
+
+	// Report reports runtime information
+	Report()
 }

--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -82,8 +82,8 @@ type bootstrapManager struct {
 func newBootstrapManager(
 	database database,
 	mediator databaseMediator,
+	opts Options,
 ) databaseBootstrapManager {
-	opts := database.Options()
 	scope := opts.InstrumentOptions().MetricsScope()
 	return &bootstrapManager{
 		database:       database,

--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3x/errors"
 	"github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
+	"github.com/uber-go/tally"
 )
 
 type bootstrapState int
@@ -74,6 +75,7 @@ type bootstrapManager struct {
 	newBootstrapFn NewBootstrapFn
 	state          bootstrapState
 	hasPending     bool
+	status         tally.Gauge
 }
 
 func newBootstrapManager(
@@ -81,6 +83,7 @@ func newBootstrapManager(
 	mediator databaseMediator,
 ) databaseBootstrapManager {
 	opts := database.Options()
+	scope := opts.InstrumentOptions().MetricsScope()
 	return &bootstrapManager{
 		database:       database,
 		mediator:       mediator,
@@ -88,14 +91,8 @@ func newBootstrapManager(
 		log:            opts.InstrumentOptions().Logger(),
 		nowFn:          opts.ClockOptions().NowFn(),
 		newBootstrapFn: opts.NewBootstrapFn(),
+		status:         scope.Gauge("bootstrapped"),
 	}
-}
-
-func (m *bootstrapManager) IsBootstrapping() bool {
-	m.RLock()
-	state := m.state
-	m.RUnlock()
-	return state == bootstrapping
 }
 
 func (m *bootstrapManager) IsBootstrapped() bool {
@@ -103,37 +100,6 @@ func (m *bootstrapManager) IsBootstrapped() bool {
 	state := m.state
 	m.RUnlock()
 	return state == bootstrapped
-}
-
-func (m *bootstrapManager) targetRanges(at time.Time) []bootstrap.TargetRange {
-	ropts := m.opts.RetentionOptions()
-	start := at.Add(-ropts.RetentionPeriod()).
-		Truncate(ropts.BlockSize())
-	midPoint := at.
-		Add(-ropts.BlockSize()).
-		Add(-ropts.BufferPast()).
-		Truncate(ropts.BlockSize()).
-		// NB(r): Since "end" is exclusive we need to add a
-		// an extra block size when specifiying the end time.
-		Add(ropts.BlockSize())
-	cutover := at.Add(ropts.BufferFuture()).
-		Truncate(ropts.BlockSize()).
-		Add(ropts.BlockSize())
-
-	// NB(r): We want the large initial time range bootstrapped to
-	// bootstrap incrementally so we don't keep the full raw
-	// data in process until we finish bootstrapping which could
-	// cause the process to OOM.
-	return []bootstrap.TargetRange{
-		{
-			Range:      xtime.Range{Start: start, End: midPoint},
-			RunOptions: bootstrap.NewRunOptions().SetIncremental(true),
-		},
-		{
-			Range:      xtime.Range{Start: midPoint, End: cutover},
-			RunOptions: bootstrap.NewRunOptions().SetIncremental(false),
-		},
-	}
 }
 
 func (m *bootstrapManager) Bootstrap() error {
@@ -192,6 +158,46 @@ func (m *bootstrapManager) Bootstrap() error {
 	// across the cluster.
 
 	return multiErr.FinalError()
+}
+
+func (m *bootstrapManager) Report() {
+	if m.IsBootstrapped() {
+		m.status.Update(1)
+	} else {
+		m.status.Update(0)
+	}
+
+}
+
+func (m *bootstrapManager) targetRanges(at time.Time) []bootstrap.TargetRange {
+	ropts := m.opts.RetentionOptions()
+	start := at.Add(-ropts.RetentionPeriod()).
+		Truncate(ropts.BlockSize())
+	midPoint := at.
+		Add(-ropts.BlockSize()).
+		Add(-ropts.BufferPast()).
+		Truncate(ropts.BlockSize()).
+		// NB(r): Since "end" is exclusive we need to add a
+		// an extra block size when specifiying the end time.
+		Add(ropts.BlockSize())
+	cutover := at.Add(ropts.BufferFuture()).
+		Truncate(ropts.BlockSize()).
+		Add(ropts.BlockSize())
+
+	// NB(r): We want the large initial time range bootstrapped to
+	// bootstrap incrementally so we don't keep the full raw
+	// data in process until we finish bootstrapping which could
+	// cause the process to OOM.
+	return []bootstrap.TargetRange{
+		{
+			Range:      xtime.Range{Start: start, End: midPoint},
+			RunOptions: bootstrap.NewRunOptions().SetIncremental(true),
+		},
+		{
+			Range:      xtime.Range{Start: midPoint, End: cutover},
+			RunOptions: bootstrap.NewRunOptions().SetIncremental(false),
+		},
+	}
 }
 
 func (m *bootstrapManager) bootstrap() error {

--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3x/errors"
 	"github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
+
 	"github.com/uber-go/tally"
 )
 
@@ -166,7 +167,6 @@ func (m *bootstrapManager) Report() {
 	} else {
 		m.status.Update(0)
 	}
-
 }
 
 func (m *bootstrapManager) targetRanges(at time.Time) []bootstrap.TargetRange {

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -56,7 +56,7 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 	m := NewMockdatabaseMediator(ctrl)
 	m.EXPECT().DisableFileOps()
 	m.EXPECT().EnableFileOps().AnyTimes()
-	bsm := newBootstrapManager(db, m).(*bootstrapManager)
+	bsm := newBootstrapManager(db, m, opts).(*bootstrapManager)
 	err := bsm.Bootstrap()
 
 	require.NotNil(t, err)
@@ -84,7 +84,7 @@ func TestDatabaseBootstrapTargetRanges(t *testing.T) {
 	}))
 
 	db := &mockDatabase{opts: opts}
-	bsm := newBootstrapManager(db, nil).(*bootstrapManager)
+	bsm := newBootstrapManager(db, nil, opts).(*bootstrapManager)
 	ranges := bsm.targetRanges(now)
 
 	var all [][]time.Time

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -114,7 +114,7 @@ func newTestDatabase(t *testing.T, bs bootstrapState) *db {
 	require.NoError(t, err)
 	d := database.(*db)
 	m := d.mediator.(*mediator)
-	bsm := newBootstrapManager(d, m).(*bootstrapManager)
+	bsm := newBootstrapManager(d, m, opts).(*bootstrapManager)
 	bsm.state = bs
 	m.databaseBootstrapManager = bsm
 	return d

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -156,6 +156,11 @@ func (m *fileSystemManager) Run(t time.Time, runType runType, forceType forceTyp
 	return true
 }
 
+func (m *fileSystemManager) Report() {
+	m.databaseCleanupManager.Report()
+	m.databaseFlushManager.Report()
+}
+
 func (m *fileSystemManager) shouldRunWithLock() bool {
 	return m.enabled && m.status != fileOpInProgress && m.database.IsBootstrapped()
 }

--- a/storage/mediator.go
+++ b/storage/mediator.go
@@ -98,7 +98,7 @@ func newMediator(database database, opts Options) (databaseMediator, error) {
 	d.databaseRepairer = newNoopDatabaseRepairer()
 	if opts.RepairEnabled() {
 		var err error
-		d.databaseRepairer, err = newDatabaseRepairer(database)
+		d.databaseRepairer, err = newDatabaseRepairer(database, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -147,6 +147,12 @@ func (m *mediator) Tick(softDeadline time.Duration, runType runType, forceType f
 	return nil
 }
 
+func (m *mediator) Report() {
+	m.databaseBootstrapManager.Report()
+	m.databaseRepairer.Report()
+	m.databaseFileSystemManager.Report()
+}
+
 func (m *mediator) Close() error {
 	m.Lock()
 	defer m.Unlock()
@@ -187,26 +193,7 @@ func (m *mediator) reportLoop() {
 	for {
 		select {
 		case <-t.C:
-			if m.databaseBootstrapManager.IsBootstrapped() {
-				m.metrics.bootstrapStatus.Update(1)
-			} else {
-				m.metrics.bootstrapStatus.Update(0)
-			}
-			if m.databaseRepairer.IsRepairing() {
-				m.metrics.repairStatus.Update(1)
-			} else {
-				m.metrics.repairStatus.Update(0)
-			}
-			if m.databaseFileSystemManager.IsCleaningUp() {
-				m.metrics.cleanupStatus.Update(1)
-			} else {
-				m.metrics.cleanupStatus.Update(0)
-			}
-			if m.databaseFileSystemManager.IsFlushing() {
-				m.metrics.flushStatus.Update(1)
-			} else {
-				m.metrics.flushStatus.Update(0)
-			}
+			m.Report()
 		case <-m.closedCh:
 			t.Stop()
 			return

--- a/storage/mediator.go
+++ b/storage/mediator.go
@@ -105,7 +105,7 @@ func newMediator(database database, opts Options) (databaseMediator, error) {
 	}
 
 	d.databaseTickManager = newTickManager(database, opts)
-	d.databaseBootstrapManager = newBootstrapManager(database, d)
+	d.databaseBootstrapManager = newBootstrapManager(database, d, opts)
 	return d, nil
 }
 

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -426,7 +426,6 @@ func TestNamespaceTruncate(t *testing.T) {
 	require.Equal(t, int64(1), res)
 	require.NotNil(t, ns.shards[testShardIDs[0].ID()])
 	require.True(t, ns.shards[testShardIDs[0].ID()].IsBootstrapped())
-	require.False(t, ns.shards[testShardIDs[0].ID()].IsBootstrapping())
 }
 
 func TestNamespaceRepair(t *testing.T) {

--- a/storage/repair_test.go
+++ b/storage/repair_test.go
@@ -55,7 +55,7 @@ func TestDatabaseRepairerStartStop(t *testing.T) {
 	mockDatabase := newMockDatabase()
 	mockDatabase.opts = mockDatabase.opts.SetRepairOptions(testRepairOptions(ctrl))
 
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase)
+	databaseRepairer, err := newDatabaseRepairer(mockDatabase, mockDatabase.opts)
 	require.NoError(t, err)
 	repairer := databaseRepairer.(*dbRepairer)
 
@@ -119,7 +119,7 @@ func TestDatabaseRepairerHaveNotReachedOffset(t *testing.T) {
 		SetClockOptions(clockOpts.SetNowFn(nowFn)).
 		SetRepairOptions(repairOpts)
 
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase)
+	databaseRepairer, err := newDatabaseRepairer(mockDatabase, mockDatabase.opts)
 	require.NoError(t, err)
 	repairer := databaseRepairer.(*dbRepairer)
 
@@ -174,7 +174,7 @@ func TestDatabaseRepairerOnlyOncePerInterval(t *testing.T) {
 		SetClockOptions(clockOpts.SetNowFn(nowFn)).
 		SetRepairOptions(repairOpts)
 
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase)
+	databaseRepairer, err := newDatabaseRepairer(mockDatabase, mockDatabase.opts)
 	require.NoError(t, err)
 	repairer := databaseRepairer.(*dbRepairer)
 
@@ -202,7 +202,7 @@ func TestDatabaseRepairerRepairNotBootstrapped(t *testing.T) {
 	mockDatabase := newMockDatabase()
 	mockDatabase.opts = mockDatabase.opts.SetRepairOptions(testRepairOptions(ctrl))
 
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase)
+	databaseRepairer, err := newDatabaseRepairer(mockDatabase, mockDatabase.opts)
 	require.NoError(t, err)
 	repairer := databaseRepairer.(*dbRepairer)
 
@@ -341,7 +341,7 @@ func TestRepairerRepairTimes(t *testing.T) {
 		{time.Unix(36000, 0), repairState{repairNotStarted, 0}},
 		{time.Unix(43200, 0), repairState{repairSuccess, 1}},
 	}
-	repairer, err := newDatabaseRepairer(database)
+	repairer, err := newDatabaseRepairer(database, database.opts)
 	require.NoError(t, err)
 	r := repairer.(*dbRepairer)
 	for _, input := range inputTimes {
@@ -362,7 +362,7 @@ func TestRepairerRepairWithTime(t *testing.T) {
 	repairTimeRange := xtime.Range{Start: time.Unix(7200, 0), End: time.Unix(14400, 0)}
 	database := newMockDatabase()
 	database.opts = database.opts.SetRepairOptions(testRepairOptions(ctrl))
-	repairer, err := newDatabaseRepairer(database)
+	repairer, err := newDatabaseRepairer(database, database.opts)
 	require.NoError(t, err)
 	r := repairer.(*dbRepairer)
 

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -42,8 +42,8 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of Database interface
@@ -115,7 +115,7 @@ func (_mr *_MockDatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -125,7 +125,7 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -136,7 +136,7 @@ func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -147,7 +147,7 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -269,7 +269,7 @@ func (_mr *_MockdatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -279,7 +279,7 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -290,7 +290,7 @@ func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -301,7 +301,7 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -474,7 +474,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) AssignShardSet(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignShardSet", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time.Duration) {
+func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time0.Duration) {
 	_m.ctrl.Call(_m, "Tick", c, softDeadline)
 }
 
@@ -482,7 +482,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Tick(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -492,7 +492,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -503,7 +503,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, shardID, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -514,7 +514,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -536,7 +536,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Bootstrap(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Flush(blockStart time.Time, pm persist.Manager) error {
+func (_m *MockdatabaseNamespace) Flush(blockStart time0.Time, pm persist.Manager) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, pm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -546,7 +546,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time.Time) bool {
+func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", blockStart)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -556,7 +556,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) NeedsFlush(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time.Time) error {
+func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -577,7 +577,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Truncate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate")
 }
 
-func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time0.Range) error {
+func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time.Range) error {
 	ret := _m.ctrl.Call(_m, "Repair", repairer, tr)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -626,16 +626,6 @@ func (_m *MockShard) NumSeries() int64 {
 
 func (_mr *_MockShardRecorder) NumSeries() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NumSeries")
-}
-
-func (_m *MockShard) IsBootstrapping() bool {
-	ret := _m.ctrl.Call(_m, "IsBootstrapping")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockShardRecorder) IsBootstrapping() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsBootstrapping")
 }
 
 func (_m *MockShard) IsBootstrapped() bool {
@@ -689,16 +679,6 @@ func (_mr *_MockdatabaseShardRecorder) NumSeries() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NumSeries")
 }
 
-func (_m *MockdatabaseShard) IsBootstrapping() bool {
-	ret := _m.ctrl.Call(_m, "IsBootstrapping")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseShardRecorder) IsBootstrapping() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsBootstrapping")
-}
-
 func (_m *MockdatabaseShard) IsBootstrapped() bool {
 	ret := _m.ctrl.Call(_m, "IsBootstrapped")
 	ret0, _ := ret[0].(bool)
@@ -719,7 +699,7 @@ func (_mr *_MockdatabaseShardRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time.Duration) tickResult {
+func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time0.Duration) tickResult {
 	ret := _m.ctrl.Call(_m, "Tick", c, softDeadline)
 	ret0, _ := ret[0].(tickResult)
 	return ret0
@@ -729,7 +709,7 @@ func (_mr *_MockdatabaseShardRecorder) Tick(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -739,7 +719,7 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -750,7 +730,7 @@ func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -761,7 +741,7 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -782,7 +762,7 @@ func (_mr *_MockdatabaseShardRecorder) Bootstrap(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0)
 }
 
-func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time.Time, pm persist.Manager) error {
+func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time0.Time, pm persist.Manager) error {
 	ret := _m.ctrl.Call(_m, "Flush", namespace, blockStart, pm)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -792,7 +772,7 @@ func (_mr *_MockdatabaseShardRecorder) Flush(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FlushState(blockStart time.Time) fileOpState {
+func (_m *MockdatabaseShard) FlushState(blockStart time0.Time) fileOpState {
 	ret := _m.ctrl.Call(_m, "FlushState", blockStart)
 	ret0, _ := ret[0].(fileOpState)
 	return ret0
@@ -802,7 +782,7 @@ func (_mr *_MockdatabaseShardRecorder) FlushState(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushState", arg0)
 }
 
-func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time.Time) error {
+func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", namespace, earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -812,7 +792,7 @@ func (_mr *_MockdatabaseShardRecorder) CleanupFileset(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupFileset", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -842,16 +822,6 @@ func NewMockdatabaseBootstrapManager(ctrl *gomock.Controller) *MockdatabaseBoots
 
 func (_m *MockdatabaseBootstrapManager) EXPECT() *_MockdatabaseBootstrapManagerRecorder {
 	return _m.recorder
-}
-
-func (_m *MockdatabaseBootstrapManager) IsBootstrapping() bool {
-	ret := _m.ctrl.Call(_m, "IsBootstrapping")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseBootstrapManagerRecorder) IsBootstrapping() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsBootstrapping")
 }
 
 func (_m *MockdatabaseBootstrapManager) IsBootstrapped() bool {
@@ -895,17 +865,7 @@ func (_m *MockdatabaseFlushManager) EXPECT() *_MockdatabaseFlushManagerRecorder 
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFlushManager) IsFlushing() bool {
-	ret := _m.ctrl.Call(_m, "IsFlushing")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFlushManagerRecorder) IsFlushing() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFlushing")
-}
-
-func (_m *MockdatabaseFlushManager) NeedsFlush(t time.Time) bool {
+func (_m *MockdatabaseFlushManager) NeedsFlush(t time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -915,9 +875,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) NeedsFlush(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeStart(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeStart(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -925,9 +885,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeStart(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -935,7 +895,7 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeEnd(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) Flush(t time.Time) error {
+func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -963,6 +923,14 @@ func (_mr *_MockdatabaseFlushManagerRecorder) RateLimitOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RateLimitOptions")
 }
 
+func (_m *MockdatabaseFlushManager) Report() {
+	_m.ctrl.Call(_m, "Report")
+}
+
+func (_mr *_MockdatabaseFlushManagerRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
+}
+
 // Mock of databaseCleanupManager interface
 type MockdatabaseCleanupManager struct {
 	ctrl     *gomock.Controller
@@ -984,17 +952,7 @@ func (_m *MockdatabaseCleanupManager) EXPECT() *_MockdatabaseCleanupManagerRecor
 	return _m.recorder
 }
 
-func (_m *MockdatabaseCleanupManager) IsCleaningUp() bool {
-	ret := _m.ctrl.Call(_m, "IsCleaningUp")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseCleanupManagerRecorder) IsCleaningUp() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsCleaningUp")
-}
-
-func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseCleanupManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1002,6 +960,14 @@ func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
 
 func (_mr *_MockdatabaseCleanupManagerRecorder) Cleanup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
+}
+
+func (_m *MockdatabaseCleanupManager) Report() {
+	_m.ctrl.Call(_m, "Report")
+}
+
+func (_mr *_MockdatabaseCleanupManagerRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
 }
 
 // Mock of FileOpOptions interface
@@ -1045,7 +1011,7 @@ func (_mr *_MockFileOpOptionsRecorder) RetentionOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RetentionOptions")
 }
 
-func (_m *MockFileOpOptions) SetJitter(value time.Duration) FileOpOptions {
+func (_m *MockFileOpOptions) SetJitter(value time0.Duration) FileOpOptions {
 	ret := _m.ctrl.Call(_m, "SetJitter", value)
 	ret0, _ := ret[0].(FileOpOptions)
 	return ret0
@@ -1055,9 +1021,9 @@ func (_mr *_MockFileOpOptionsRecorder) SetJitter(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetJitter", arg0)
 }
 
-func (_m *MockFileOpOptions) Jitter() time.Duration {
+func (_m *MockFileOpOptions) Jitter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "Jitter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1096,85 +1062,7 @@ func (_m *MockdatabaseFileSystemManager) EXPECT() *_MockdatabaseFileSystemManage
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFileSystemManager) IsFlushing() bool {
-	ret := _m.ctrl.Call(_m, "IsFlushing")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) IsFlushing() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFlushing")
-}
-
-func (_m *MockdatabaseFileSystemManager) NeedsFlush(t time.Time) bool {
-	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) NeedsFlush(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
-}
-
-func (_m *MockdatabaseFileSystemManager) FlushTimeStart(t time.Time) time.Time {
-	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) FlushTimeStart(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
-}
-
-func (_m *MockdatabaseFileSystemManager) FlushTimeEnd(t time.Time) time.Time {
-	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) FlushTimeEnd(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
-}
-
-func (_m *MockdatabaseFileSystemManager) Flush(t time.Time) error {
-	ret := _m.ctrl.Call(_m, "Flush", t)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) Flush(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0)
-}
-
-func (_m *MockdatabaseFileSystemManager) SetRateLimitOptions(value ratelimit.Options) {
-	_m.ctrl.Call(_m, "SetRateLimitOptions", value)
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) SetRateLimitOptions(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRateLimitOptions", arg0)
-}
-
-func (_m *MockdatabaseFileSystemManager) RateLimitOptions() ratelimit.Options {
-	ret := _m.ctrl.Call(_m, "RateLimitOptions")
-	ret0, _ := ret[0].(ratelimit.Options)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) RateLimitOptions() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RateLimitOptions")
-}
-
-func (_m *MockdatabaseFileSystemManager) IsCleaningUp() bool {
-	ret := _m.ctrl.Call(_m, "IsCleaningUp")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFileSystemManagerRecorder) IsCleaningUp() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsCleaningUp")
-}
-
-func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseFileSystemManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1182,6 +1070,16 @@ func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
 
 func (_mr *_MockdatabaseFileSystemManagerRecorder) Cleanup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
+}
+
+func (_m *MockdatabaseFileSystemManager) Flush(t time0.Time) error {
+	ret := _m.ctrl.Call(_m, "Flush", t)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockdatabaseFileSystemManagerRecorder) Flush(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0)
 }
 
 func (_m *MockdatabaseFileSystemManager) Disable() fileOpStatus {
@@ -1214,7 +1112,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
-func (_m *MockdatabaseFileSystemManager) Run(t time.Time, runType runType, forceType forceType) bool {
+func (_m *MockdatabaseFileSystemManager) Run(t time0.Time, runType runType, forceType forceType) bool {
 	ret := _m.ctrl.Call(_m, "Run", t, runType, forceType)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1222,6 +1120,14 @@ func (_m *MockdatabaseFileSystemManager) Run(t time.Time, runType runType, force
 
 func (_mr *_MockdatabaseFileSystemManagerRecorder) Run(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0, arg1, arg2)
+}
+
+func (_m *MockdatabaseFileSystemManager) Report() {
+	_m.ctrl.Call(_m, "Report")
+}
+
+func (_mr *_MockdatabaseFileSystemManagerRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
 }
 
 // Mock of databaseShardRepairer interface
@@ -1255,7 +1161,7 @@ func (_mr *_MockdatabaseShardRepairerRecorder) Options() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
-func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -1313,14 +1219,12 @@ func (_mr *_MockdatabaseRepairerRecorder) Repair() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Repair")
 }
 
-func (_m *MockdatabaseRepairer) IsRepairing() bool {
-	ret := _m.ctrl.Call(_m, "IsRepairing")
-	ret0, _ := ret[0].(bool)
-	return ret0
+func (_m *MockdatabaseRepairer) Report() {
+	_m.ctrl.Call(_m, "Report")
 }
 
-func (_mr *_MockdatabaseRepairerRecorder) IsRepairing() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsRepairing")
+func (_mr *_MockdatabaseRepairerRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
 }
 
 // Mock of databaseTickManager interface
@@ -1344,7 +1248,7 @@ func (_m *MockdatabaseTickManager) EXPECT() *_MockdatabaseTickManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseTickManager) Tick(softDeadline time.Duration, forceType forceType) error {
+func (_m *MockdatabaseTickManager) Tick(softDeadline time0.Duration, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1421,7 +1325,7 @@ func (_mr *_MockdatabaseMediatorRecorder) EnableFileOps() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableFileOps")
 }
 
-func (_m *MockdatabaseMediator) Tick(softDeadline time.Duration, runType runType, forceType forceType) error {
+func (_m *MockdatabaseMediator) Tick(softDeadline time0.Duration, runType runType, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, runType, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1449,6 +1353,14 @@ func (_m *MockdatabaseMediator) Close() error {
 
 func (_mr *_MockdatabaseMediatorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
+func (_m *MockdatabaseMediator) Report() {
+	_m.ctrl.Call(_m, "Report")
+}
+
+func (_mr *_MockdatabaseMediatorRecorder) Report() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Report")
 }
 
 // Mock of Options interface
@@ -1722,7 +1634,7 @@ func (_mr *_MockOptionsRecorder) DatabaseBlockRetrieverManager() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockRetrieverManager")
 }
 
-func (_m *MockOptions) SetShardCloseDeadline(value time.Duration) Options {
+func (_m *MockOptions) SetShardCloseDeadline(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetShardCloseDeadline", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1732,9 +1644,9 @@ func (_mr *_MockOptionsRecorder) SetShardCloseDeadline(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetShardCloseDeadline", arg0)
 }
 
-func (_m *MockOptions) ShardCloseDeadline() time.Duration {
+func (_m *MockOptions) ShardCloseDeadline() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ShardCloseDeadline")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -220,9 +220,6 @@ type Shard interface {
 	// NumSeries returns the number of series in the shard
 	NumSeries() int64
 
-	// IsBootstrapped returns whether the shard is bootstrapping
-	IsBootstrapping() bool
-
 	// IsBootstrapped returns whether the shard is already bootstrapped
 	IsBootstrapped() bool
 }
@@ -296,21 +293,18 @@ type databaseShard interface {
 
 // databaseBootstrapManager manages the bootstrap process.
 type databaseBootstrapManager interface {
-	// IsBootstrapped returns whether the database is bootstrapping.
-	IsBootstrapping() bool
-
 	// IsBootstrapped returns whether the database is already bootstrapped.
 	IsBootstrapped() bool
 
 	// Bootstrap performs bootstrapping for all namespaces and shards owned.
 	Bootstrap() error
+
+	// Report reports runtime information
+	Report()
 }
 
 // databaseFlushManager manages flushing in-memory data to persistent storage.
 type databaseFlushManager interface {
-	// IsFlushing returns whether flush is in progress
-	IsFlushing() bool
-
 	// NeedsFlush returns true if the data for a given time have been flushed.
 	NeedsFlush(t time.Time) bool
 
@@ -328,15 +322,18 @@ type databaseFlushManager interface {
 
 	// RateLimitOptions returns the rate limit options
 	RateLimitOptions() ratelimit.Options
+
+	// Report reports runtime information
+	Report()
 }
 
 // databaseCleanupManager manages cleaning up persistent storage space.
 type databaseCleanupManager interface {
-	// IsCleaningUp returns whether cleanup is in progress
-	IsCleaningUp() bool
-
 	// Cleanup cleans up data not needed in the persistent storage.
 	Cleanup(t time.Time) error
+
+	// Report reports runtime information
+	Report()
 }
 
 // FileOpOptions control the database file operations behavior
@@ -359,8 +356,11 @@ type FileOpOptions interface {
 
 // databaseFileSystemManager manages the database related filesystem activities.
 type databaseFileSystemManager interface {
-	databaseFlushManager
-	databaseCleanupManager
+	// Cleanup cleans up data not needed in the persistent storage.
+	Cleanup(t time.Time) error
+
+	// Flush flushes in-memory data to persistent storage.
+	Flush(t time.Time) error
 
 	// Disable disables the filesystem manager and prevents it from
 	// performing file operations, returns the current file operation status
@@ -375,6 +375,9 @@ type databaseFileSystemManager interface {
 	// Run attempts to perform all filesystem-related operations,
 	// returning true if those operations are performed, and false otherwise
 	Run(t time.Time, runType runType, forceType forceType) bool
+
+	// Report reports runtime information
+	Report()
 }
 
 // databaseShardRepairer repairs in-memory data for a shard
@@ -402,8 +405,8 @@ type databaseRepairer interface {
 	// Repair repairs in-memory data
 	Repair() error
 
-	// IsRepairing returns whether the repairer is running or not
-	IsRepairing() bool
+	// Report reports runtime information
+	Report()
 }
 
 // databaseTickManager performs periodic ticking
@@ -439,6 +442,9 @@ type databaseMediator interface {
 
 	// Close closes the mediator
 	Close() error
+
+	// Report reports runtime information
+	Report()
 }
 
 // NewBootstrapFn creates a new bootstrap


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @ben-lerner 

This PR adds logic to report how much time is spent on doing actual work vs. sleeping during flushing so we have better visibility into what's happening during filesystem persistence.