### PR TITLE
Add load shedding when server is overloaded

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -36,9 +36,9 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
-	time "github.com/m3db/m3x/time"
+	time0 "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time0 "time"
+	time "time"
 )
 
 // Mock of Client interface
@@ -105,7 +105,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,7 +115,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -126,7 +126,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -349,7 +349,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,7 +359,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -370,7 +370,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -433,7 +433,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -444,7 +444,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -487,7 +487,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -497,7 +497,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -508,7 +508,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -571,7 +571,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -582,7 +582,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1083,7 +1083,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1093,9 +1093,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1103,7 +1103,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1113,9 +1113,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1143,7 +1143,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1153,9 +1153,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1163,7 +1163,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1173,9 +1173,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1183,7 +1183,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1193,9 +1193,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1203,7 +1203,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1213,9 +1213,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1223,7 +1223,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1233,9 +1233,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1243,7 +1243,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1253,9 +1253,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1263,7 +1263,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1273,9 +1273,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1463,7 +1463,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1473,9 +1473,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1804,7 +1804,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1814,9 +1814,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1824,7 +1824,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1834,9 +1834,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1864,7 +1864,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1874,9 +1874,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1884,7 +1884,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1894,9 +1894,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1904,7 +1904,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1914,9 +1914,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1924,7 +1924,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1934,9 +1934,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1944,7 +1944,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1954,9 +1954,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1964,7 +1964,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1974,9 +1974,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1984,7 +1984,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1994,9 +1994,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2184,7 +2184,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2194,9 +2194,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2384,7 +2384,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2394,9 +2394,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2404,7 +2404,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2414,9 +2414,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -36,9 +36,9 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time "time"
+	time0 "time"
 )
 
 // Mock of Client interface
@@ -105,7 +105,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,7 +115,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -126,7 +126,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -349,7 +349,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,7 +359,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -370,7 +370,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -433,7 +433,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -444,7 +444,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -487,7 +487,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -497,7 +497,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -508,7 +508,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -571,7 +571,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -582,7 +582,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1083,7 +1083,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1093,9 +1093,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time.Duration {
+func (_m *MockOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1103,7 +1103,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1113,9 +1113,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1143,7 +1143,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1153,9 +1153,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1163,7 +1163,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1173,9 +1173,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1183,7 +1183,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1193,9 +1193,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1203,7 +1203,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1213,9 +1213,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1223,7 +1223,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1233,9 +1233,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1243,7 +1243,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1253,9 +1253,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1263,7 +1263,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1273,9 +1273,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1463,7 +1463,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1473,9 +1473,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1804,7 +1804,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1814,9 +1814,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1824,7 +1824,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1834,9 +1834,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1864,7 +1864,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1874,9 +1874,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1884,7 +1884,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1894,9 +1894,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1904,7 +1904,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1914,9 +1914,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1924,7 +1924,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1934,9 +1934,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1944,7 +1944,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1954,9 +1954,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1964,7 +1964,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1974,9 +1974,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1984,7 +1984,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1994,9 +1994,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2184,7 +2184,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2194,9 +2194,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2384,7 +2384,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2394,9 +2394,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2404,7 +2404,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2414,9 +2414,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/network/server/tchannelthrift/node/service.go
+++ b/network/server/tchannelthrift/node/service.go
@@ -302,7 +302,7 @@ func (s *service) FetchBatchRaw(tctx thrift.Context, req *rpc.FetchBatchRawReque
 func (s *service) FetchBlocksRaw(tctx thrift.Context, req *rpc.FetchBlocksRawRequest) (*rpc.FetchBlocksRawResult_, error) {
 	if s.db.IsOverloaded() {
 		s.metrics.overloadRejected.Inc(1)
-		return nil, tterrors.NewInternalError(errDatabaseIsOverloaded)
+		return nil, tterrors.NewInternalError(errServerIsOverloaded)
 	}
 
 	callStart := s.nowFn()
@@ -371,7 +371,7 @@ func (s *service) FetchBlocksRaw(tctx thrift.Context, req *rpc.FetchBlocksRawReq
 func (s *service) FetchBlocksMetadataRaw(tctx thrift.Context, req *rpc.FetchBlocksMetadataRawRequest) (*rpc.FetchBlocksMetadataRawResult_, error) {
 	if s.db.IsOverloaded() {
 		s.metrics.overloadRejected.Inc(1)
-		return nil, tterrors.NewInternalError(errDatabaseIsOverloaded)
+		return nil, tterrors.NewInternalError(errServerIsOverloaded)
 	}
 
 	callStart := s.nowFn()

--- a/network/server/tchannelthrift/node/service_test.go
+++ b/network/server/tchannelthrift/node/service_test.go
@@ -233,6 +233,7 @@ func TestServiceFetchBlocksRaw(t *testing.T) {
 
 	mockDB := storage.NewMockDatabase(ctrl)
 	mockDB.EXPECT().Options().Return(testServiceOpts).AnyTimes()
+	mockDB.EXPECT().IsOverloaded().Return(false)
 
 	service := NewService(mockDB, nil).(*service)
 
@@ -339,6 +340,7 @@ func TestServiceFetchBlocksMetadataRaw(t *testing.T) {
 
 	mockDB := storage.NewMockDatabase(ctrl)
 	mockDB.EXPECT().Options().Return(testServiceOpts).AnyTimes()
+	mockDB.EXPECT().IsOverloaded().Return(false)
 
 	service := NewService(mockDB, nil).(*service)
 

--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -35,8 +35,11 @@ import (
 )
 
 var (
-	errCommitLogClosed    = errors.New("commit log is closed")
-	errCommitLogQueueFull = errors.New("commit log queue is full")
+	// ErrCommitLogQueueFull is raised when trying to write to the commit log
+	// when the queue is full
+	ErrCommitLogQueueFull = errors.New("commit log queue is full")
+
+	errCommitLogClosed = errors.New("commit log is closed")
 
 	timeZero = time.Time{}
 )
@@ -352,7 +355,7 @@ func (l *commitLog) Write(
 	l.RUnlock()
 
 	if !enqueued {
-		return errCommitLogQueueFull
+		return ErrCommitLogQueueFull
 	}
 
 	wg.Wait()
@@ -390,7 +393,7 @@ func (l *commitLog) WriteBehind(
 	l.RUnlock()
 
 	if !enqueued {
-		return errCommitLogQueueFull
+		return ErrCommitLogQueueFull
 	}
 
 	return nil

--- a/persist/fs/commitlog/commit_log_mock.go
+++ b/persist/fs/commitlog/commit_log_mock.go
@@ -32,8 +32,8 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of CommitLog interface
@@ -67,7 +67,7 @@ func (_mr *_MockCommitLogRecorder) Open() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open")
 }
 
-func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) Write(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -77,7 +77,7 @@ func (_mr *_MockCommitLogRecorder) Write(arg0, arg1, arg2, arg3, arg4 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
+func (_m *MockCommitLog) WriteBehind(ctx context.Context, series Series, datapoint ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "WriteBehind", ctx, series, datapoint, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -139,11 +139,11 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (Series, ts.Datapoint, time.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (Series, ts.Datapoint, time0.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(Series)
 	ret1, _ := ret[1].(ts.Datapoint)
-	ret2, _ := ret[2].(time.Unit)
+	ret2, _ := ret[2].(time0.Unit)
 	ret3, _ := ret[3].(ts.Annotation)
 	return ret0, ret1, ret2, ret3
 }
@@ -311,7 +311,7 @@ func (_mr *_MockOptionsRecorder) Strategy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Strategy")
 }
 
-func (_m *MockOptions) SetFlushInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -321,9 +321,9 @@ func (_mr *_MockOptionsRecorder) SetFlushInterval(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFlushInterval", arg0)
 }
 
-func (_m *MockOptions) FlushInterval() time0.Duration {
+func (_m *MockOptions) FlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "FlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -385,7 +385,7 @@ func TestCommitLogWriteErrorOnFull(t *testing.T) {
 	for {
 		if err := commitLog.WriteBehind(ctx, series, dp, unit, nil); err != nil {
 			// Ensure queue full error
-			assert.Equal(t, errCommitLogQueueFull, err)
+			assert.Equal(t, ErrCommitLogQueueFull, err)
 			break
 		}
 		writes = append(writes, testWrite{series, dp.Timestamp, dp.Value, unit, nil, nil})

--- a/persist/fs/fs_mock.go
+++ b/persist/fs/fs_mock.go
@@ -27,8 +27,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
 	checked "github.com/m3db/m3x/checked"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of FileSetWriter interface
@@ -62,7 +62,7 @@ func (_mr *_MockFileSetWriterRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
+func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -143,7 +143,7 @@ func (_mr *_MockFileSetReaderRecorder) EntriesRead() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EntriesRead")
 }
 
-func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
+func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -153,9 +153,9 @@ func (_mr *_MockFileSetReaderRecorder) Open(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open", arg0, arg1, arg2)
 }
 
-func (_m *MockFileSetReader) Range() time0.Range {
+func (_m *MockFileSetReader) Range() time.Range {
 	ret := _m.ctrl.Call(_m, "Range")
-	ret0, _ := ret[0].(time0.Range)
+	ret0, _ := ret[0].(time.Range)
 	return ret0
 }
 

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -58,6 +58,7 @@ func (d *mockDatabase) Open() error                               { return nil }
 func (d *mockDatabase) Close() error                              { return nil }
 func (d *mockDatabase) Bootstrap() error                          { return nil }
 func (d *mockDatabase) IsBootstrapped() bool                      { return d.bs == bootstrapped }
+func (d *mockDatabase) IsOverloaded() bool                        { return false }
 func (d *mockDatabase) Repair() error                             { return nil }
 func (d *mockDatabase) Truncate(namespace ts.ID) (int64, error)   { return 0, nil }
 func (d *mockDatabase) flush(t time.Time, async bool)             {}

--- a/storage/options.go
+++ b/storage/options.go
@@ -69,7 +69,7 @@ const (
 	defaultErrorWindowForLoad = 10 * time.Second
 
 	// defaultErrorThresholdForLoad is the default error threshold for considering server overloaded
-	defaultErrorThresholdForLoad = 100
+	defaultErrorThresholdForLoad = 1000
 )
 
 var (

--- a/storage/options.go
+++ b/storage/options.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3db/x/counter"
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
@@ -63,6 +64,12 @@ const (
 
 	// defaultRepairEnabled enables repair by default
 	defaultRepairEnabled = true
+
+	// defaultErrorWindowForLoad is the default error window for evaluating server load
+	defaultErrorWindowForLoad = 10 * time.Second
+
+	// defaultErrorThresholdForLoad is the default error threshold for considering server overloaded
+	defaultErrorThresholdForLoad = 100
 )
 
 var (
@@ -93,6 +100,9 @@ type options struct {
 	retentionOpts                  retention.Options
 	blockOpts                      block.Options
 	commitLogOpts                  commitlog.Options
+	errCounterOpts                 xcounter.Options
+	errWindowForLoad               time.Duration
+	errThresholdForLoad            int64
 	repairEnabled                  bool
 	repairOpts                     repair.Options
 	fileOpOpts                     FileOpOptions
@@ -129,6 +139,9 @@ func NewOptions() Options {
 		retentionOpts:                  retention.NewOptions(),
 		blockOpts:                      block.NewOptions(),
 		commitLogOpts:                  commitlog.NewOptions(),
+		errCounterOpts:                 xcounter.NewOptions(),
+		errWindowForLoad:               defaultErrorWindowForLoad,
+		errThresholdForLoad:            defaultErrorThresholdForLoad,
 		repairEnabled:                  defaultRepairEnabled,
 		repairOpts:                     repair.NewOptions(),
 		fileOpOpts:                     NewFileOpOptions(),
@@ -205,6 +218,36 @@ func (o *options) SetCommitLogOptions(value commitlog.Options) Options {
 
 func (o *options) CommitLogOptions() commitlog.Options {
 	return o.commitLogOpts
+}
+
+func (o *options) SetErrorCounterOptions(value xcounter.Options) Options {
+	opts := *o
+	opts.errCounterOpts = value
+	return &opts
+}
+
+func (o *options) ErrorCounterOptions() xcounter.Options {
+	return o.errCounterOpts
+}
+
+func (o *options) SetErrorWindowForLoad(value time.Duration) Options {
+	opts := *o
+	opts.errWindowForLoad = value
+	return &opts
+}
+
+func (o *options) ErrorWindowForLoad() time.Duration {
+	return o.errWindowForLoad
+}
+
+func (o *options) SetErrorThresholdForLoad(value int64) Options {
+	opts := *o
+	opts.errThresholdForLoad = value
+	return &opts
+}
+
+func (o *options) ErrorThresholdForLoad() int64 {
+	return o.errThresholdForLoad
 }
 
 func (o *options) SetRepairEnabled(b bool) Options {

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -43,8 +43,8 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of Database interface
@@ -116,7 +116,7 @@ func (_mr *_MockDatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -126,7 +126,7 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -137,7 +137,7 @@ func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -148,7 +148,7 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -280,7 +280,7 @@ func (_mr *_MockdatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -290,7 +290,7 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -301,7 +301,7 @@ func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -312,7 +312,7 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -495,7 +495,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) AssignShardSet(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignShardSet", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time.Duration) {
+func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time0.Duration) {
 	_m.ctrl.Call(_m, "Tick", c, softDeadline)
 }
 
@@ -503,7 +503,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Tick(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -513,7 +513,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -524,7 +524,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, shardID, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -535,7 +535,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -557,7 +557,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Bootstrap(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Flush(blockStart time.Time, flush persist.Flush) error {
+func (_m *MockdatabaseNamespace) Flush(blockStart time0.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -567,7 +567,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time.Time) bool {
+func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", blockStart)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -577,7 +577,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) NeedsFlush(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time.Time) error {
+func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -598,7 +598,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Truncate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate")
 }
 
-func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time0.Range) error {
+func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time.Range) error {
 	ret := _m.ctrl.Call(_m, "Repair", repairer, tr)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -720,7 +720,7 @@ func (_mr *_MockdatabaseShardRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time.Duration) tickResult {
+func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time0.Duration) tickResult {
 	ret := _m.ctrl.Call(_m, "Tick", c, softDeadline)
 	ret0, _ := ret[0].(tickResult)
 	return ret0
@@ -730,7 +730,7 @@ func (_mr *_MockdatabaseShardRecorder) Tick(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -740,7 +740,7 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -751,7 +751,7 @@ func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -762,7 +762,7 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -783,7 +783,7 @@ func (_mr *_MockdatabaseShardRecorder) Bootstrap(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0)
 }
 
-func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time.Time, flush persist.Flush) error {
+func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time0.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", namespace, blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -793,7 +793,7 @@ func (_mr *_MockdatabaseShardRecorder) Flush(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FlushState(blockStart time.Time) fileOpState {
+func (_m *MockdatabaseShard) FlushState(blockStart time0.Time) fileOpState {
 	ret := _m.ctrl.Call(_m, "FlushState", blockStart)
 	ret0, _ := ret[0].(fileOpState)
 	return ret0
@@ -803,7 +803,7 @@ func (_mr *_MockdatabaseShardRecorder) FlushState(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushState", arg0)
 }
 
-func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time.Time) error {
+func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time0.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", namespace, earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -813,7 +813,7 @@ func (_mr *_MockdatabaseShardRecorder) CleanupFileset(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupFileset", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -894,7 +894,7 @@ func (_m *MockdatabaseFlushManager) EXPECT() *_MockdatabaseFlushManagerRecorder 
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFlushManager) NeedsFlush(t time.Time) bool {
+func (_m *MockdatabaseFlushManager) NeedsFlush(t time0.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -904,9 +904,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) NeedsFlush(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeStart(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeStart(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -914,9 +914,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeStart(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time.Time) time.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time0.Time) time0.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -924,7 +924,7 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeEnd(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) Flush(t time.Time) error {
+func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -981,7 +981,7 @@ func (_m *MockdatabaseCleanupManager) EXPECT() *_MockdatabaseCleanupManagerRecor
 	return _m.recorder
 }
 
-func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseCleanupManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1040,7 +1040,7 @@ func (_mr *_MockFileOpOptionsRecorder) RetentionOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RetentionOptions")
 }
 
-func (_m *MockFileOpOptions) SetJitter(value time.Duration) FileOpOptions {
+func (_m *MockFileOpOptions) SetJitter(value time0.Duration) FileOpOptions {
 	ret := _m.ctrl.Call(_m, "SetJitter", value)
 	ret0, _ := ret[0].(FileOpOptions)
 	return ret0
@@ -1050,9 +1050,9 @@ func (_mr *_MockFileOpOptionsRecorder) SetJitter(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetJitter", arg0)
 }
 
-func (_m *MockFileOpOptions) Jitter() time.Duration {
+func (_m *MockFileOpOptions) Jitter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "Jitter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1091,7 +1091,7 @@ func (_m *MockdatabaseFileSystemManager) EXPECT() *_MockdatabaseFileSystemManage
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
+func (_m *MockdatabaseFileSystemManager) Cleanup(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1101,7 +1101,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Cleanup(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) Flush(t time.Time) error {
+func (_m *MockdatabaseFileSystemManager) Flush(t time0.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1141,7 +1141,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
-func (_m *MockdatabaseFileSystemManager) Run(t time.Time, runType runType, forceType forceType) bool {
+func (_m *MockdatabaseFileSystemManager) Run(t time0.Time, runType runType, forceType forceType) bool {
 	ret := _m.ctrl.Call(_m, "Run", t, runType, forceType)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1190,7 +1190,7 @@ func (_mr *_MockdatabaseShardRepairerRecorder) Options() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
-func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -1277,7 +1277,7 @@ func (_m *MockdatabaseTickManager) EXPECT() *_MockdatabaseTickManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseTickManager) Tick(softDeadline time.Duration, forceType forceType) error {
+func (_m *MockdatabaseTickManager) Tick(softDeadline time0.Duration, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1354,7 +1354,7 @@ func (_mr *_MockdatabaseMediatorRecorder) EnableFileOps() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableFileOps")
 }
 
-func (_m *MockdatabaseMediator) Tick(softDeadline time.Duration, runType runType, forceType forceType) error {
+func (_m *MockdatabaseMediator) Tick(softDeadline time0.Duration, runType runType, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, runType, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1723,7 +1723,7 @@ func (_mr *_MockOptionsRecorder) DatabaseBlockRetrieverManager() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockRetrieverManager")
 }
 
-func (_m *MockOptions) SetShardCloseDeadline(value time.Duration) Options {
+func (_m *MockOptions) SetShardCloseDeadline(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetShardCloseDeadline", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1733,9 +1733,9 @@ func (_mr *_MockOptionsRecorder) SetShardCloseDeadline(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetShardCloseDeadline", arg0)
 }
 
-func (_m *MockOptions) ShardCloseDeadline() time.Duration {
+func (_m *MockOptions) ShardCloseDeadline() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ShardCloseDeadline")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -39,6 +39,7 @@ import (
 	repair "github.com/m3db/m3db/storage/repair"
 	series "github.com/m3db/m3db/storage/series"
 	ts "github.com/m3db/m3db/ts"
+	counter "github.com/m3db/m3db/x/counter"
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
@@ -177,6 +178,16 @@ func (_m *MockDatabase) IsBootstrapped() bool {
 
 func (_mr *_MockDatabaseRecorder) IsBootstrapped() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsBootstrapped")
+}
+
+func (_m *MockDatabase) IsOverloaded() bool {
+	ret := _m.ctrl.Call(_m, "IsOverloaded")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockDatabaseRecorder) IsOverloaded() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOverloaded")
 }
 
 func (_m *MockDatabase) Repair() error {
@@ -331,6 +342,16 @@ func (_m *Mockdatabase) IsBootstrapped() bool {
 
 func (_mr *_MockdatabaseRecorder) IsBootstrapped() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsBootstrapped")
+}
+
+func (_m *Mockdatabase) IsOverloaded() bool {
+	ret := _m.ctrl.Call(_m, "IsOverloaded")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockdatabaseRecorder) IsOverloaded() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsOverloaded")
 }
 
 func (_m *Mockdatabase) Repair() error {
@@ -1500,6 +1521,66 @@ func (_m *MockOptions) CommitLogOptions() commitlog.Options {
 
 func (_mr *_MockOptionsRecorder) CommitLogOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CommitLogOptions")
+}
+
+func (_m *MockOptions) SetErrorCounterOptions(value counter.Options) Options {
+	ret := _m.ctrl.Call(_m, "SetErrorCounterOptions", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetErrorCounterOptions(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetErrorCounterOptions", arg0)
+}
+
+func (_m *MockOptions) ErrorCounterOptions() counter.Options {
+	ret := _m.ctrl.Call(_m, "ErrorCounterOptions")
+	ret0, _ := ret[0].(counter.Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) ErrorCounterOptions() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ErrorCounterOptions")
+}
+
+func (_m *MockOptions) SetErrorWindowForLoad(value time0.Duration) Options {
+	ret := _m.ctrl.Call(_m, "SetErrorWindowForLoad", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetErrorWindowForLoad(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetErrorWindowForLoad", arg0)
+}
+
+func (_m *MockOptions) ErrorWindowForLoad() time0.Duration {
+	ret := _m.ctrl.Call(_m, "ErrorWindowForLoad")
+	ret0, _ := ret[0].(time0.Duration)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) ErrorWindowForLoad() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ErrorWindowForLoad")
+}
+
+func (_m *MockOptions) SetErrorThresholdForLoad(value int64) Options {
+	ret := _m.ctrl.Call(_m, "SetErrorThresholdForLoad", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetErrorThresholdForLoad(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetErrorThresholdForLoad", arg0)
+}
+
+func (_m *MockOptions) ErrorThresholdForLoad() int64 {
+	ret := _m.ctrl.Call(_m, "ErrorThresholdForLoad")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) ErrorThresholdForLoad() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ErrorThresholdForLoad")
 }
 
 func (_m *MockOptions) SetRepairEnabled(b bool) Options {

--- a/storage/types.go
+++ b/storage/types.go
@@ -38,6 +38,7 @@ import (
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3db/x/counter"
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
@@ -484,6 +485,24 @@ type Options interface {
 
 	// CommitLogOptions returns the commit log options
 	CommitLogOptions() commitlog.Options
+
+	// SetErrorCounterOptions sets the error counter options
+	SetErrorCounterOptions(value xcounter.Options) Options
+
+	// ErrorCounterOptions returns the error counter options
+	ErrorCounterOptions() xcounter.Options
+
+	// SetErrorWindowForLoad sets the error window for load
+	SetErrorWindowForLoad(value time.Duration) Options
+
+	// ErrorWindowForLoad returns the error window for load
+	ErrorWindowForLoad() time.Duration
+
+	// SetErrorThresholdForLoad sets the error threshold for load
+	SetErrorThresholdForLoad(value int64) Options
+
+	// ErrorThresholdForLoad returns the error threshold for load
+	ErrorThresholdForLoad() int64
 
 	// SetRepairEnabled sets whether or not to enable the repair
 	SetRepairEnabled(b bool) Options

--- a/storage/types.go
+++ b/storage/types.go
@@ -38,7 +38,7 @@ import (
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
-	"github.com/m3db/m3db/x/counter"
+	xcounter "github.com/m3db/m3db/x/counter"
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
@@ -109,6 +109,9 @@ type Database interface {
 
 	// IsBootstrapped determines whether the database is bootstrapped.
 	IsBootstrapped() bool
+
+	// IsOverloaded determines whether the database is overloaded
+	IsOverloaded() bool
 
 	// Repair will issue a repair and return nil on success or error on error.
 	Repair() error

--- a/x/counter/frequency_counter.go
+++ b/x/counter/frequency_counter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/x/counter/frequency_counter.go
+++ b/x/counter/frequency_counter.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xcounter
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+)
+
+type frequencyBucket struct {
+	sync.RWMutex
+
+	timestamp time.Time
+	count     int64
+}
+
+// record records the frequency value n for a given time.
+// If the frequency value is too old, it's discarded.
+// Returns true if the value is processed, false if it
+// requires further processing.
+func (b *frequencyBucket) record(t time.Time, n int64) {
+	b.RLock()
+	if processed := b.recordWithLock(t, n); processed {
+		b.RUnlock()
+		return
+	}
+	b.RUnlock()
+
+	b.Lock()
+	if processed := b.recordWithLock(t, n); processed {
+		b.Unlock()
+		return
+	}
+	b.timestamp = t
+	b.count = n
+	b.Unlock()
+}
+
+// countFor returns the frequency value if the bucket
+// timestamp matches the given time, 0 otherwise
+func (b *frequencyBucket) countFor(t time.Time) int64 {
+	b.RLock()
+	if b.timestamp != t {
+		b.RUnlock()
+		return 0
+	}
+	count := b.count
+	b.RUnlock()
+
+	return count
+}
+
+func (b *frequencyBucket) recordWithLock(t time.Time, n int64) bool {
+	// The information is too old to keep
+	if t.Before(b.timestamp) {
+		return true
+	}
+	// The timestamp matches so it's safe to record
+	if t == b.timestamp {
+		// NB(xichen): use atomics here so multiple goroutines
+		// can record at the same time
+		atomic.AddInt64(&b.count, n)
+		return true
+	}
+	// Otherwise this bucket is stale, don't record
+	return false
+}
+
+// FrequencyCounter keeps track of the frequency counts for the
+// previous interval and the current interval
+type FrequencyCounter struct {
+	nowFn    clock.NowFn
+	interval time.Duration
+	buckets  []frequencyBucket
+}
+
+// NewFrequencyCounter creates a new frequency counter
+func NewFrequencyCounter(opts Options) FrequencyCounter {
+	return FrequencyCounter{
+		nowFn:    time.Now,
+		interval: opts.Interval(),
+		buckets:  make([]frequencyBucket, opts.NumBuckets()),
+	}
+}
+
+// Record records a frequency value in the corresponding bucket
+func (c *FrequencyCounter) Record(n int64) {
+	now := c.nowFn().Truncate(c.interval)
+	bucketIdx := c.bucketIdx(now)
+	c.buckets[bucketIdx].record(now, n)
+}
+
+// Count returns the frequency count between now - dur and now
+func (c *FrequencyCounter) Count(dur time.Duration) int64 {
+	if dur <= 0 {
+		return 0
+	}
+	var (
+		n        = int(math.Min(float64(dur/c.interval), float64(len(c.buckets))))
+		now      = c.nowFn().Truncate(c.interval)
+		currIdx  = c.bucketIdx(now)
+		currTime = now
+		total    int64
+	)
+	// NB(xichen): we discount the current bucket because it may be incomplete
+	for i := 0; i < n; i++ {
+		currTime = currTime.Add(-c.interval)
+		currIdx--
+		if currIdx < 0 {
+			currIdx += len(c.buckets)
+		}
+		total += c.buckets[currIdx].countFor(currTime)
+	}
+	return total
+}
+
+func (c *FrequencyCounter) bucketIdx(now time.Time) int {
+	return int((now.UnixNano() / int64(c.interval)) % int64(len(c.buckets)))
+}

--- a/x/counter/frequency_counter_test.go
+++ b/x/counter/frequency_counter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/x/counter/frequency_counter_test.go
+++ b/x/counter/frequency_counter_test.go
@@ -29,8 +29,10 @@ import (
 )
 
 func TestFrequencyCounterSequential(t *testing.T) {
+	numBuckets := 10
 	interval := time.Second
-	c := NewFrequencyCounter(10, interval)
+	opts := NewOptions().SetNumBuckets(numBuckets).SetInterval(interval)
+	c := NewFrequencyCounter(opts)
 	var now time.Time
 	c.nowFn = func() time.Time { return now }
 
@@ -59,8 +61,10 @@ func TestFrequencyCounterSequential(t *testing.T) {
 }
 
 func TestFrequencyCounterParallel(t *testing.T) {
+	numBuckets := 10
 	interval := time.Second
-	c := NewFrequencyCounter(10, interval)
+	opts := NewOptions().SetNumBuckets(numBuckets).SetInterval(interval)
+	c := NewFrequencyCounter(opts)
 	var now time.Time
 	c.nowFn = func() time.Time { return now }
 

--- a/x/counter/frequency_counter_test.go
+++ b/x/counter/frequency_counter_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xcounter
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrequencyCounterSequential(t *testing.T) {
+	interval := time.Second
+	c := NewFrequencyCounter(10, interval)
+	var now time.Time
+	c.nowFn = func() time.Time { return now }
+
+	// Record a value in each bucket
+	now = time.Now().Truncate(interval)
+	iter := 10
+	for i := 0; i < iter; i++ {
+		now = now.Add(interval)
+		c.Record(1)
+	}
+	require.Equal(t, int64(iter-1), c.Count(time.Duration(iter)*interval))
+
+	// Move time forward
+	now = now.Add(interval)
+	c.Record(2)
+	require.Equal(t, int64(iter-1), c.Count(time.Duration(iter)*interval))
+
+	// Move time forward again
+	now = now.Add(interval)
+	c.Record(2)
+	require.Equal(t, int64(iter), c.Count(time.Duration(iter)*interval))
+
+	// Move time forward far into future
+	now = now.Add(20 * interval)
+	require.Equal(t, int64(0), c.Count(time.Duration(iter)*interval))
+}
+
+func TestFrequencyCounterParallel(t *testing.T) {
+	interval := time.Second
+	c := NewFrequencyCounter(10, interval)
+	var now time.Time
+	c.nowFn = func() time.Time { return now }
+
+	var (
+		wg         sync.WaitGroup
+		numWorkers = 10
+		iter       = 10
+	)
+	now = time.Now().Truncate(interval)
+	for i := 0; i < iter; i++ {
+		now = now.Add(interval)
+		wg.Add(numWorkers)
+		for j := 0; j < numWorkers; j++ {
+			go func() {
+				defer wg.Done()
+
+				c.Record(1)
+			}()
+		}
+		wg.Wait()
+	}
+	require.Equal(t, int64(iter-1)*int64(numWorkers), c.Count(time.Duration(iter)*interval))
+}

--- a/x/counter/options.go
+++ b/x/counter/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/x/counter/options.go
+++ b/x/counter/options.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xcounter
+
+import "time"
+
+const (
+	defaultNumBuckets = 60
+	defaultInterval   = time.Second
+)
+
+// Options controls the parameters for frequency counters
+type Options struct {
+	numBuckets int
+	interval   time.Duration
+}
+
+// NewOptions creates new options
+func NewOptions() Options {
+	return Options{
+		numBuckets: defaultNumBuckets,
+		interval:   defaultInterval,
+	}
+}
+
+// NumBuckets returns the number of buckets
+func (o Options) NumBuckets() int { return o.numBuckets }
+
+// Interval returns the interval associated with each bucket
+func (o Options) Interval() time.Duration { return o.interval }
+
+// SetNumBuckets sets the number of buckets
+func (o Options) SetNumBuckets(value int) Options {
+	o.numBuckets = value
+	return o
+}
+
+// SetInterval sets the interval
+func (o Options) SetInterval(value time.Duration) Options {
+	o.interval = value
+	return o
+}


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @ben-lerner 

This PR adds load shedding when the server is overloaded. We use the number of "commit log queue full" errors as a proxy to measure whether the server is overwhelmed. In particular, if the number of such errors exceeds a given threshold, the server will return "database is overloaded" back to the client.

Load shedding is currently only applicable to `FetchBlocksMetadata` and `FetchBlocks` calls because they are less performance critical, but may be applied to other methods in the future.