### PR TITLE
Fix fetch batch op pooling misuse

### DIFF
--- a/client/connection_pool.go
+++ b/client/connection_pool.go
@@ -78,6 +78,9 @@ type healthCheckFn func(client rpc.TChanNode, opts Options) error
 
 type sleepFn func(t time.Duration)
 
+// Allow for test override
+var globalNewConn = newConn
+
 func newConnectionPool(host topology.Host, opts Options) connectionPool {
 	seed := int64(murmur3.Sum32([]byte(host.Address())))
 
@@ -88,7 +91,7 @@ func newConnectionPool(host topology.Host, opts Options) connectionPool {
 		poolLen:            0,
 		connectRand:        rand.NewSource(seed),
 		healthCheckRand:    rand.NewSource(seed + 1),
-		newConn:            newConn,
+		newConn:            globalNewConn,
 		healthCheckNewConn: healthCheck,
 		healthCheck:        healthCheck,
 		sleepConnect:       time.Sleep,

--- a/client/fetch_batch.go
+++ b/client/fetch_batch.go
@@ -124,6 +124,7 @@ func (p *fetchBatchOpPool) Put(f *fetchBatchOp) {
 	f.IncRef()
 	if cap(f.request.Ids) != p.capacity || cap(f.completionFns) != p.capacity {
 		// Grew outside capacity, do not return to pool
+		f.DecRef()
 		return
 	}
 	f.reset()

--- a/client/host_queue.go
+++ b/client/host_queue.go
@@ -49,7 +49,7 @@ type queue struct {
 	ops                                  []op
 	opsSumSize                           int
 	opsLastRotatedAt                     time.Time
-	opsArrayPool                         opArrayPool
+	opsArrayPool                         *opArrayPool
 	drainIn                              chan []op
 	state                                state
 }

--- a/client/host_queue.go
+++ b/client/host_queue.go
@@ -182,11 +182,7 @@ func (q *queue) drain() {
 		writeBatchSize               = q.opts.WriteBatchSize()
 	)
 
-	for {
-		ops, ok := <-q.drainIn
-		if !ok {
-			break
-		}
+	for ops := range q.drainIn {
 		var (
 			currWriteOps      []op
 			currBatchElements []*rpc.WriteBatchRawRequestElement
@@ -251,7 +247,6 @@ func (q *queue) asyncWrite(
 	ops []op,
 	elems []*rpc.WriteBatchRawRequestElement,
 ) {
-
 	q.Add(1)
 	// TODO(r): Use a worker pool to avoid creating new go routines for async writes
 	go func() {
@@ -317,7 +312,11 @@ func (q *queue) asyncFetch(op *fetchBatchOp) {
 	// TODO(r): Use a worker pool to avoid creating new go routines for async fetches
 	go func() {
 		// NB(r): Defer is slow in the hot path unfortunately
-		cleanup := q.Done
+		cleanup := func() {
+			op.DecRef()
+			op.Finalize()
+			q.Done()
+		}
 
 		client, err := q.connPool.NextClient()
 		if err != nil {
@@ -336,7 +335,8 @@ func (q *queue) asyncFetch(op *fetchBatchOp) {
 		}
 
 		resultLen := len(result.Elements)
-		for i := 0; i < op.Size(); i++ {
+		opLen := op.Size()
+		for i := 0; i < opLen; i++ {
 			if !(i < resultLen) {
 				// No results for this entry, in practice should never occur
 				op.complete(i, nil, errQueueFetchNoResponse(q.host.ID()))
@@ -385,6 +385,11 @@ func (q *queue) Len() int {
 }
 
 func (q *queue) Enqueue(o op) error {
+	if fetchOp, ok := o.(*fetchBatchOp); ok {
+		// Need to take ownership if its a fetch batch op
+		fetchOp.IncRef()
+	}
+
 	var needsDrain []op
 	q.Lock()
 	if q.state != stateOpen {

--- a/client/host_queue_test.go
+++ b/client/host_queue_test.go
@@ -628,7 +628,6 @@ func testHostQueueFetchBatches(
 			Ids:        rawIDs,
 		},
 	}
-	fetchBatch.IncRef()
 	for _ = range fetchBatch.request.Ids {
 		fetchBatch.completionFns = append(fetchBatch.completionFns, callback)
 	}

--- a/client/host_queue_test.go
+++ b/client/host_queue_test.go
@@ -628,6 +628,7 @@ func testHostQueueFetchBatches(
 			Ids:        rawIDs,
 		},
 	}
+	fetchBatch.IncRef()
 	for _ = range fetchBatch.request.Ids {
 		fetchBatch.completionFns = append(fetchBatch.completionFns, callback)
 	}

--- a/client/op_array_pool.go
+++ b/client/op_array_pool.go
@@ -24,38 +24,27 @@ import (
 	"github.com/m3db/m3x/pool"
 )
 
-type opArrayPool interface {
-	// Init pool
-	Init()
-
-	// Get an array of ops
-	Get() []op
-
-	// Put an array of ops
-	Put(ops []op)
-}
-
-type poolOfOpArray struct {
+type opArrayPool struct {
 	pool     pool.ObjectPool
 	capacity int
 }
 
-func newOpArrayPool(opts pool.ObjectPoolOptions, capacity int) opArrayPool {
+func newOpArrayPool(opts pool.ObjectPoolOptions, capacity int) *opArrayPool {
 	p := pool.NewObjectPool(opts)
-	return &poolOfOpArray{p, capacity}
+	return &opArrayPool{p, capacity}
 }
 
-func (p *poolOfOpArray) Init() {
+func (p *opArrayPool) Init() {
 	p.pool.Init(func() interface{} {
 		return make([]op, 0, p.capacity)
 	})
 }
 
-func (p *poolOfOpArray) Get() []op {
+func (p *opArrayPool) Get() []op {
 	return p.pool.Get().([]op)
 }
 
-func (p *poolOfOpArray) Put(ops []op) {
+func (p *opArrayPool) Put(ops []op) {
 	for i := range ops {
 		ops[i] = nil
 	}

--- a/client/session_fetch_high_concurrency_test.go
+++ b/client/session_fetch_high_concurrency_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/encoding/m3tsz"
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/sharding"
+	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3x/close"
+	"github.com/m3db/m3x/time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noopCloser struct{}
+
+func (noopCloser) Close() {}
+
+func TestSessionFetchAllHighConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	numShards := 1024
+	numReplicas := 3
+	numHosts := 8
+
+	concurrency := 4
+	fetchAllEach := 128
+
+	maxIDs := 0
+	fetchAllTypes := []struct {
+		numIDs int
+		ids    []string
+	}{
+		{numIDs: 16},
+		{numIDs: 32},
+	}
+	for i := range fetchAllTypes {
+		for j := 0; j < fetchAllTypes[i].numIDs; j++ {
+			fetchAllTypes[i].ids = append(fetchAllTypes[i].ids, fmt.Sprintf("foo.%d", j))
+		}
+		if fetchAllTypes[i].numIDs > maxIDs {
+			maxIDs = fetchAllTypes[i].numIDs
+		}
+	}
+
+	healthCheckResult := &rpc.NodeHealthResult_{Ok: true, Status: "ok", Bootstrapped: true}
+
+	start := time.Now().Truncate(time.Hour)
+	end := start.Add(2 * time.Hour)
+
+	encoder := m3tsz.NewEncoder(start, nil, true, nil)
+	for at := start; at.Before(end); at = at.Add(30 * time.Second) {
+		dp := ts.Datapoint{
+			Timestamp: at,
+			Value:     rand.Float64() * math.MaxFloat64,
+		}
+		encoder.Encode(dp, xtime.Second, nil)
+	}
+	seg := encoder.Discard()
+	respSegments := []*rpc.Segments{&rpc.Segments{
+		Merged: &rpc.Segment{Head: seg.Head.Get(), Tail: seg.Tail.Get()},
+	}}
+	respElements := make([]*rpc.FetchRawResult_, maxIDs)
+	for i := range respElements {
+		respElements[i] = &rpc.FetchRawResult_{Segments: respSegments}
+	}
+	respResult := &rpc.FetchBatchRawResult_{Elements: respElements}
+
+	// Override the new connection function for connection pools
+	// to be able to mock the entire end to end pipeline
+	prevGlobalNewConn := globalNewConn
+	globalNewConn = func(_ string, addr string, _ Options) (xclose.SimpleCloser, rpc.TChanNode, error) {
+		mockClient := rpc.NewMockTChanNode(ctrl)
+		mockClient.EXPECT().Health(gomock.Any()).
+			Return(healthCheckResult, nil).
+			AnyTimes()
+		mockClient.EXPECT().FetchBatchRaw(gomock.Any(), gomock.Any()).
+			Return(respResult, nil).
+			AnyTimes()
+		return noopCloser{}, mockClient, nil
+	}
+	defer func() { globalNewConn = prevGlobalNewConn }()
+
+	shards := make([]shard.Shard, numShards)
+	for i := range shards {
+		shards[i] = shard.NewShard(uint32(i)).SetState(shard.Available)
+	}
+
+	shardSet, err := sharding.NewShardSet(shards, sharding.DefaultHashGen(numShards))
+	require.NoError(t, err)
+
+	hosts := make([]topology.Host, numHosts)
+	for i := range hosts {
+		id := testHostName(i)
+		hosts[i] = topology.NewHost(id, fmt.Sprintf("%s:9000", id))
+	}
+
+	shardAssignments := make([][]shard.Shard, numHosts)
+	allShards := shardSet.All()
+	host := 0
+	for i := 0; i < numReplicas; i++ {
+		for shard := 0; shard < numShards; shard++ {
+			placed := false
+			for !placed {
+				unique := true
+				for _, existing := range shardAssignments[host] {
+					if existing.ID() == uint32(shard) {
+						unique = false
+						break
+					}
+				}
+				if unique {
+					placed = true
+					shardAssignments[host] = append(shardAssignments[host], allShards[shard])
+				}
+				host++
+				if host >= len(hosts) {
+					host = 0
+				}
+			}
+			if !placed {
+				assert.Fail(t, "could not place shard")
+			}
+		}
+	}
+
+	hostShardSets := make([]topology.HostShardSet, numHosts)
+	for hostIdx, shards := range shardAssignments {
+		shardsSubset, err := sharding.NewShardSet(shards, shardSet.HashFn())
+		require.NoError(t, err)
+		hostShardSets[hostIdx] = topology.NewHostShardSet(hosts[hostIdx], shardsSubset)
+	}
+
+	opts := applySessionTestOptions(NewOptions()).
+		SetFetchBatchSize(128).
+		SetTopologyInitializer(topology.NewStaticInitializer(
+			topology.NewStaticOptions().
+				SetReplicas(numReplicas).
+				SetShardSet(shardSet).
+				SetHostShardSets(sessionTestHostAndShards(shardSet))))
+
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+	session := s.(*session)
+
+	require.NoError(t, session.Open())
+
+	var wg, startWg sync.WaitGroup
+	startWg.Add(1)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			startWg.Wait()
+			defer wg.Done()
+
+			for j := 0; j < fetchAllEach; j++ {
+				ids := fetchAllTypes[j%len(fetchAllTypes)].ids
+				iters, err := session.FetchAll(testNamespaceName, ids, start, end)
+				if err != nil {
+					panic(err)
+				}
+				iters.Close()
+			}
+		}()
+	}
+
+	startWg.Done()
+
+	wg.Wait()
+
+	require.NoError(t, session.Close())
+}

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/m3db/m3db/x/metrics"
 	xerrors "github.com/m3db/m3x/errors"
 	"github.com/m3db/m3x/time"
-	"github.com/uber-go/tally"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 const (


### PR DESCRIPTION
This change fixes the use of the op length when calling the call backs for the operation.  This lead to newly enqueued callbacks in the double used operation to be called, causing more than once callback semantics for a given callback, leading to unexpected results.

It also introduces ownership semantics and checking for fetch batch operations for further safety going forward.

cc @xichen2020 @cw9 @prateek @ben-lerner @kobolog 