### PR TITLE
Reuse the bootstrap process

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -36,9 +36,9 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time "time"
+	time0 "time"
 )
 
 // Mock of Client interface
@@ -105,7 +105,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,7 +115,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -126,7 +126,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -349,7 +349,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,7 +359,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -370,7 +370,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -433,7 +433,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -444,7 +444,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -487,7 +487,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -497,7 +497,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -508,7 +508,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -571,7 +571,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -582,7 +582,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1083,7 +1083,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1093,9 +1093,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time.Duration {
+func (_m *MockOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1103,7 +1103,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1113,9 +1113,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1143,7 +1143,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1153,9 +1153,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1163,7 +1163,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1173,9 +1173,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1183,7 +1183,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1193,9 +1193,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1203,7 +1203,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1213,9 +1213,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1223,7 +1223,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1233,9 +1233,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1243,7 +1243,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1253,9 +1253,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1263,7 +1263,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1273,9 +1273,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1463,7 +1463,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1473,9 +1473,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1804,7 +1804,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1814,9 +1814,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1824,7 +1824,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1834,9 +1834,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1864,7 +1864,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1874,9 +1874,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1884,7 +1884,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1894,9 +1894,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1904,7 +1904,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1914,9 +1914,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1924,7 +1924,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1934,9 +1934,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1944,7 +1944,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1954,9 +1954,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1964,7 +1964,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1974,9 +1974,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1984,7 +1984,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1994,9 +1994,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2184,7 +2184,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2194,9 +2194,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2384,7 +2384,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2394,9 +2394,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2404,7 +2404,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2414,9 +2414,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -26,12 +26,12 @@ package encoding
 import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
-	io "github.com/m3db/m3db/x/io"
+	io0 "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
-	time "github.com/m3db/m3x/time"
-	io0 "io"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	io "io"
+	time "time"
 )
 
 // Mock of Encoder interface
@@ -55,7 +55,7 @@ func (_m *MockEncoder) EXPECT() *_MockEncoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
+func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Encode", dp, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -65,9 +65,9 @@ func (_mr *_MockEncoderRecorder) Encode(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0, arg1, arg2)
 }
 
-func (_m *MockEncoder) Stream() io.SegmentReader {
+func (_m *MockEncoder) Stream() io0.SegmentReader {
 	ret := _m.ctrl.Call(_m, "Stream")
-	ret0, _ := ret[0].(io.SegmentReader)
+	ret0, _ := ret[0].(io0.SegmentReader)
 	return ret0
 }
 
@@ -85,7 +85,7 @@ func (_mr *_MockEncoderRecorder) StreamLen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StreamLen")
 }
 
-func (_m *MockEncoder) Reset(t time0.Time, capacity int) {
+func (_m *MockEncoder) Reset(t time.Time, capacity int) {
 	_m.ctrl.Call(_m, "Reset", t, capacity)
 }
 
@@ -111,7 +111,7 @@ func (_mr *_MockEncoderRecorder) Discard() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Discard")
 }
 
-func (_m *MockEncoder) DiscardReset(t time0.Time, capacity int) ts.Segment {
+func (_m *MockEncoder) DiscardReset(t time.Time, capacity int) ts.Segment {
 	ret := _m.ctrl.Call(_m, "DiscardReset", t, capacity)
 	ret0, _ := ret[0].(ts.Segment)
 	return ret0
@@ -142,7 +142,7 @@ func (_m *MockOptions) EXPECT() *_MockOptionsRecorder {
 	return _m.recorder
 }
 
-func (_m *MockOptions) SetDefaultTimeUnit(tu time.Unit) Options {
+func (_m *MockOptions) SetDefaultTimeUnit(tu time0.Unit) Options {
 	ret := _m.ctrl.Call(_m, "SetDefaultTimeUnit", tu)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -152,9 +152,9 @@ func (_mr *_MockOptionsRecorder) SetDefaultTimeUnit(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultTimeUnit", arg0)
 }
 
-func (_m *MockOptions) DefaultTimeUnit() time.Unit {
+func (_m *MockOptions) DefaultTimeUnit() time0.Unit {
 	ret := _m.ctrl.Call(_m, "DefaultTimeUnit")
-	ret0, _ := ret[0].(time.Unit)
+	ret0, _ := ret[0].(time0.Unit)
 	return ret0
 }
 
@@ -262,7 +262,7 @@ func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }
 
-func (_m *MockOptions) SetSegmentReaderPool(value io.SegmentReaderPool) Options {
+func (_m *MockOptions) SetSegmentReaderPool(value io0.SegmentReaderPool) Options {
 	ret := _m.ctrl.Call(_m, "SetSegmentReaderPool", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -272,9 +272,9 @@ func (_mr *_MockOptionsRecorder) SetSegmentReaderPool(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSegmentReaderPool", arg0)
 }
 
-func (_m *MockOptions) SegmentReaderPool() io.SegmentReaderPool {
+func (_m *MockOptions) SegmentReaderPool() io0.SegmentReaderPool {
 	ret := _m.ctrl.Call(_m, "SegmentReaderPool")
-	ret0, _ := ret[0].(io.SegmentReaderPool)
+	ret0, _ := ret[0].(io0.SegmentReaderPool)
 	return ret0
 }
 
@@ -313,10 +313,10 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time.Unit)
+	ret1, _ := ret[1].(time0.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -374,10 +374,10 @@ func (_mr *_MockReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
+func (_m *MockReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time.Unit)
+	ret1, _ := ret[1].(time0.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -404,7 +404,7 @@ func (_mr *_MockReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockReaderIterator) Reset(reader io0.Reader) {
+func (_m *MockReaderIterator) Reset(reader io.Reader) {
 	_m.ctrl.Call(_m, "Reset", reader)
 }
 
@@ -443,10 +443,10 @@ func (_mr *_MockMultiReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
+func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time.Unit)
+	ret1, _ := ret[1].(time0.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -473,7 +473,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockMultiReaderIterator) Reset(readers []io0.Reader) {
+func (_m *MockMultiReaderIterator) Reset(readers []io.Reader) {
 	_m.ctrl.Call(_m, "Reset", readers)
 }
 
@@ -481,7 +481,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Reset(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0)
 }
 
-func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io.ReaderSliceOfSlicesIterator) {
+func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io0.ReaderSliceOfSlicesIterator) {
 	_m.ctrl.Call(_m, "ResetSliceOfSlices", readers)
 }
 
@@ -520,10 +520,10 @@ func (_mr *_MockSeriesIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockSeriesIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
+func (_m *MockSeriesIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time.Unit)
+	ret1, _ := ret[1].(time0.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -560,9 +560,9 @@ func (_mr *_MockSeriesIteratorRecorder) ID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ID")
 }
 
-func (_m *MockSeriesIterator) Start() time0.Time {
+func (_m *MockSeriesIterator) Start() time.Time {
 	ret := _m.ctrl.Call(_m, "Start")
-	ret0, _ := ret[0].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 
@@ -570,9 +570,9 @@ func (_mr *_MockSeriesIteratorRecorder) Start() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Start")
 }
 
-func (_m *MockSeriesIterator) End() time0.Time {
+func (_m *MockSeriesIterator) End() time.Time {
 	ret := _m.ctrl.Call(_m, "End")
-	ret0, _ := ret[0].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 
@@ -580,7 +580,7 @@ func (_mr *_MockSeriesIteratorRecorder) End() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "End")
 }
 
-func (_m *MockSeriesIterator) Reset(id string, startInclusive time0.Time, endExclusive time0.Time, replicas []Iterator) {
+func (_m *MockSeriesIterator) Reset(id string, startInclusive time.Time, endExclusive time.Time, replicas []Iterator) {
 	_m.ctrl.Call(_m, "Reset", id, startInclusive, endExclusive, replicas)
 }
 
@@ -733,7 +733,7 @@ func (_m *MockDecoder) EXPECT() *_MockDecoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDecoder) Decode(reader io0.Reader) ReaderIterator {
+func (_m *MockDecoder) Decode(reader io.Reader) ReaderIterator {
 	ret := _m.ctrl.Call(_m, "Decode", reader)
 	ret0, _ := ret[0].(ReaderIterator)
 	return ret0
@@ -808,7 +808,7 @@ func (_mr *_MockIStreamRecorder) PeekBits(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PeekBits", arg0)
 }
 
-func (_m *MockIStream) Reset(r io0.Reader) {
+func (_m *MockIStream) Reset(r io.Reader) {
 	_m.ctrl.Call(_m, "Reset", r)
 }
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -194,7 +194,7 @@ func newDefaultBootstrappableTestSetups(
 				SetClusterDatabaseTopologyInitializer(topologyInitializer)
 		}
 
-		setup, err := newTestSetup(opts)
+		setup, err := newTestSetup(instanceOpts)
 		require.NoError(t, err)
 
 		setup.storageOpts = setup.storageOpts.

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -140,21 +140,6 @@ func newMultiAddrAdminClient(
 	return adminClient
 }
 
-func newBootstrappableTestSetup(
-	t *testing.T,
-	opts testOptions,
-	retentionOpts retention.Options,
-	newBootstrapFn storage.NewBootstrapFn,
-) *testSetup {
-	setup, err := newTestSetup(opts)
-	require.NoError(t, err)
-
-	setup.storageOpts = setup.storageOpts.
-		SetRetentionOptions(retentionOpts).
-		SetNewBootstrapFn(newBootstrapFn)
-	return setup
-}
-
 type bootstrappableTestSetupOptions struct {
 	disablePeersBootstrapper   bool
 	bootstrapBlocksBatchSize   int
@@ -202,53 +187,60 @@ func newDefaultBootstrappableTestSetups(
 			topologyInitializer        = setupOpts[i].topologyInitializer
 			testStatsReporter          = setupOpts[i].testStatsReporter
 			instanceOpts               = newMultiAddrTestOptions(opts, instance)
-			setup                      *testSetup
 		)
+
 		if topologyInitializer != nil {
 			instanceOpts = instanceOpts.
 				SetClusterDatabaseTopologyInitializer(topologyInitializer)
 		}
-		setup = newBootstrappableTestSetup(t, instanceOpts, retentionOpts, func() bootstrap.Bootstrap {
-			instrumentOpts := setup.storageOpts.InstrumentOptions()
 
-			bsOpts := newDefaulTestResultOptions(setup.storageOpts, instrumentOpts)
-			noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+		setup, err := newTestSetup(opts)
+		require.NoError(t, err)
 
-			var adminClient client.AdminClient
-			if usingPeersBoostrapper {
-				adminOpts := client.NewAdminOptions()
-				if bootstrapBlocksBatchSize > 0 {
-					adminOpts = adminOpts.SetFetchSeriesBlocksBatchSize(bootstrapBlocksBatchSize)
-				}
-				if bootstrapBlocksConcurrency > 0 {
-					adminOpts = adminOpts.SetFetchSeriesBlocksBatchConcurrency(bootstrapBlocksConcurrency)
-				}
-				adminClient = newMultiAddrAdminClient(
-					t, adminOpts, instrumentOpts, setup.shardSet, replicas, instance)
+		setup.storageOpts = setup.storageOpts.
+			SetRetentionOptions(retentionOpts)
+
+		instrumentOpts := setup.storageOpts.InstrumentOptions()
+
+		bsOpts := newDefaulTestResultOptions(setup.storageOpts, instrumentOpts)
+		noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+
+		var adminClient client.AdminClient
+		if usingPeersBoostrapper {
+			adminOpts := client.NewAdminOptions()
+			if bootstrapBlocksBatchSize > 0 {
+				adminOpts = adminOpts.SetFetchSeriesBlocksBatchSize(bootstrapBlocksBatchSize)
 			}
-
-			peersOpts := peers.NewOptions().
-				SetResultOptions(bsOpts).
-				SetAdminClient(adminClient)
-
-			peersBootstrapper := peers.NewPeersBootstrapper(peersOpts, noOpAll)
-
-			fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-			filePathPrefix := fsOpts.FilePathPrefix()
-
-			bfsOpts := bfs.NewOptions().
-				SetResultOptions(bsOpts).
-				SetFilesystemOptions(fsOpts)
-
-			var fsBootstrapper bootstrap.Bootstrapper
-			if usingPeersBoostrapper {
-				fsBootstrapper = bfs.NewFileSystemBootstrapper(filePathPrefix, bfsOpts, peersBootstrapper)
-			} else {
-				fsBootstrapper = bfs.NewFileSystemBootstrapper(filePathPrefix, bfsOpts, noOpAll)
+			if bootstrapBlocksConcurrency > 0 {
+				adminOpts = adminOpts.SetFetchSeriesBlocksBatchConcurrency(bootstrapBlocksConcurrency)
 			}
+			adminClient = newMultiAddrAdminClient(
+				t, adminOpts, instrumentOpts, setup.shardSet, replicas, instance)
+		}
 
-			return bootstrap.NewBootstrapProcess(bsOpts, fsBootstrapper)
-		})
+		peersOpts := peers.NewOptions().
+			SetResultOptions(bsOpts).
+			SetAdminClient(adminClient)
+
+		peersBootstrapper := peers.NewPeersBootstrapper(peersOpts, noOpAll)
+
+		fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
+		filePathPrefix := fsOpts.FilePathPrefix()
+
+		bfsOpts := bfs.NewOptions().
+			SetResultOptions(bsOpts).
+			SetFilesystemOptions(fsOpts)
+
+		var fsBootstrapper bootstrap.Bootstrapper
+		if usingPeersBoostrapper {
+			fsBootstrapper = bfs.NewFileSystemBootstrapper(filePathPrefix, bfsOpts, peersBootstrapper)
+		} else {
+			fsBootstrapper = bfs.NewFileSystemBootstrapper(filePathPrefix, bfsOpts, noOpAll)
+		}
+
+		setup.storageOpts = setup.storageOpts.
+			SetBootstrapProcess(bootstrap.NewProcess(fsBootstrapper, bsOpts))
+
 		logger := setup.storageOpts.InstrumentOptions().Logger()
 		logger = logger.WithFields(xlog.NewLogField("instance", instance))
 		iopts := setup.storageOpts.InstrumentOptions().SetLogger(logger)

--- a/persist/fs/fs_mock.go
+++ b/persist/fs/fs_mock.go
@@ -27,8 +27,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
 	checked "github.com/m3db/m3x/checked"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of FileSetWriter interface
@@ -62,7 +62,7 @@ func (_mr *_MockFileSetWriterRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
+func (_m *MockFileSetWriter) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -143,7 +143,7 @@ func (_mr *_MockFileSetReaderRecorder) EntriesRead() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EntriesRead")
 }
 
-func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time0.Time) error {
+func (_m *MockFileSetReader) Open(_param0 ts.ID, _param1 uint32, _param2 time.Time) error {
 	ret := _m.ctrl.Call(_m, "Open", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -153,9 +153,9 @@ func (_mr *_MockFileSetReaderRecorder) Open(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Open", arg0, arg1, arg2)
 }
 
-func (_m *MockFileSetReader) Range() time.Range {
+func (_m *MockFileSetReader) Range() time0.Range {
 	ret := _m.ctrl.Call(_m, "Range")
-	ret0, _ := ret[0].(time.Range)
+	ret0, _ := ret[0].(time0.Range)
 	return ret0
 }
 

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -29,35 +29,53 @@ import (
 	ts "github.com/m3db/m3db/ts"
 )
 
-// Mock of Bootstrap interface
-type MockBootstrap struct {
+// Mock of Process interface
+type MockProcess struct {
 	ctrl     *gomock.Controller
-	recorder *_MockBootstrapRecorder
+	recorder *_MockProcessRecorder
 }
 
-// Recorder for MockBootstrap (not exported)
-type _MockBootstrapRecorder struct {
-	mock *MockBootstrap
+// Recorder for MockProcess (not exported)
+type _MockProcessRecorder struct {
+	mock *MockProcess
 }
 
-func NewMockBootstrap(ctrl *gomock.Controller) *MockBootstrap {
-	mock := &MockBootstrap{ctrl: ctrl}
-	mock.recorder = &_MockBootstrapRecorder{mock}
+func NewMockProcess(ctrl *gomock.Controller) *MockProcess {
+	mock := &MockProcess{ctrl: ctrl}
+	mock.recorder = &_MockProcessRecorder{mock}
 	return mock
 }
 
-func (_m *MockBootstrap) EXPECT() *_MockBootstrapRecorder {
+func (_m *MockProcess) EXPECT() *_MockProcessRecorder {
 	return _m.recorder
 }
 
-func (_m *MockBootstrap) Run(namespace ts.ID, shards []uint32, targetRanges []TargetRange) (result.BootstrapResult, error) {
+func (_m *MockProcess) SetBootstrapper(bootstrapper Bootstrapper) {
+	_m.ctrl.Call(_m, "SetBootstrapper", bootstrapper)
+}
+
+func (_mr *_MockProcessRecorder) SetBootstrapper(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBootstrapper", arg0)
+}
+
+func (_m *MockProcess) Bootstrapper() Bootstrapper {
+	ret := _m.ctrl.Call(_m, "Bootstrapper")
+	ret0, _ := ret[0].(Bootstrapper)
+	return ret0
+}
+
+func (_mr *_MockProcessRecorder) Bootstrapper() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrapper")
+}
+
+func (_m *MockProcess) Run(namespace ts.ID, shards []uint32, targetRanges []TargetRange) (result.BootstrapResult, error) {
 	ret := _m.ctrl.Call(_m, "Run", namespace, shards, targetRanges)
 	ret0, _ := ret[0].(result.BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBootstrapRecorder) Run(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (_mr *_MockProcessRecorder) Run(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0, arg1, arg2)
 }
 

--- a/storage/bootstrap/noop.go
+++ b/storage/bootstrap/noop.go
@@ -27,9 +27,16 @@ import (
 
 type noOpBootstrapProcess struct{}
 
-// NewNoOpBootstrapProcess creates a no-op bootstrap process.
-func NewNoOpBootstrapProcess() Bootstrap {
+// NewNoOpProcess creates a no-op bootstrap process.
+func NewNoOpProcess() Process {
 	return &noOpBootstrapProcess{}
+}
+
+func (b *noOpBootstrapProcess) SetBootstrapper(bootstrapper Bootstrapper) {
+}
+
+func (b *noOpBootstrapProcess) Bootstrapper() Bootstrapper {
+	return nil
 }
 
 func (b *noOpBootstrapProcess) Run(

--- a/storage/bootstrap/types.go
+++ b/storage/bootstrap/types.go
@@ -26,11 +26,16 @@ import (
 	xtime "github.com/m3db/m3x/time"
 )
 
-// NewBootstrapFn creates a new bootstrap processor.
-type NewBootstrapFn func() Bootstrap
+// Process represents the bootstrap process. Note that a bootstrap process can and will
+// be resused so it is important to not rely on state stored in the bootstrap itself
+// with the mindset that it will always be set to default values from the constructor.
+type Process interface {
+	// SetBootstrapper sets the bootstrapper to use when running the process.
+	SetBootstrapper(bootstrapper Bootstrapper)
 
-// Bootstrap represents the bootstrap process.
-type Bootstrap interface {
+	// Bootstrapper returns the current bootstrapper to use when running the process.
+	Bootstrapper() Bootstrapper
+
 	// Run runs the bootstrap process, returning the bootstrap result and any error encountered.
 	Run(
 		namespace ts.ID,
@@ -69,7 +74,9 @@ const (
 	BootstrapParallel
 )
 
-// Bootstrapper is the interface for different bootstrapping mechanisms.
+// Bootstrapper is the interface for different bootstrapping mechanisms.  Note that a bootstrapper
+// can and will be resused so it is important to not rely on state stored in the bootstrapper itself
+// with the mindset that it will always be set to default values from the constructor.
 type Bootstrapper interface {
 	// String returns the name of the bootstrapper
 	String() string
@@ -88,7 +95,9 @@ type Bootstrapper interface {
 	) (result.BootstrapResult, error)
 }
 
-// Source represents a bootstrap source.
+// Source represents a bootstrap source. Note that a source can and will be resused so
+// it is important to not rely on state stored in the source itself with the mindset
+// that it will always be set to default values from the constructor.
 type Source interface {
 	// Can returns whether a specific bootstrapper strategy can be applied.
 	Can(strategy Strategy) bool

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/ts"
 
 	"github.com/golang/mock/gomock"
@@ -39,11 +38,11 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 
 	opts := testDatabaseOptions()
 	now := time.Now()
-	opts = opts.SetNewBootstrapFn(func() bootstrap.Bootstrap {
-		return nil
-	}).SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
-		return now
-	}))
+	opts = opts.
+		SetBootstrapProcess(nil).
+		SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+			return now
+		}))
 
 	namespace := NewMockdatabaseNamespace(ctrl)
 	namespace.EXPECT().Bootstrap(nil, gomock.Any()).Return(fmt.Errorf("an error"))
@@ -77,11 +76,11 @@ func TestDatabaseBootstrapTargetRanges(t *testing.T) {
 		SetRetentionPeriod(2 * 24 * time.Hour))
 	ropts := opts.RetentionOptions()
 	now := time.Now().Truncate(ropts.BlockSize()).Add(8 * time.Minute)
-	opts = opts.SetNewBootstrapFn(func() bootstrap.Bootstrap {
-		return nil
-	}).SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
-		return now
-	}))
+	opts = opts.
+		SetBootstrapProcess(nil).
+		SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+			return now
+		}))
 
 	db := &mockDatabase{opts: opts}
 	bsm := newBootstrapManager(db, nil, opts).(*bootstrapManager)

--- a/storage/mediator_test.go
+++ b/storage/mediator_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3db/storage/bootstrap"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -33,11 +31,11 @@ import (
 func TestDatabaseMediatorOpenClose(t *testing.T) {
 	opts := testDatabaseOptions().SetRepairEnabled(false)
 	now := time.Now()
-	opts = opts.SetNewBootstrapFn(func() bootstrap.Bootstrap {
-		return nil
-	}).SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
-		return now
-	}))
+	opts = opts.
+		SetBootstrapProcess(nil).
+		SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+			return now
+		}))
 
 	db := &mockDatabase{opts: opts}
 	m, err := newMediator(db, opts)
@@ -58,11 +56,11 @@ func TestDatabaseMediatorDisableFileOps(t *testing.T) {
 
 	opts := testDatabaseOptions().SetRepairEnabled(false)
 	now := time.Now()
-	opts = opts.SetNewBootstrapFn(func() bootstrap.Bootstrap {
-		return nil
-	}).SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
-		return now
-	}))
+	opts = opts.
+		SetBootstrapProcess(nil).
+		SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+			return now
+		}))
 
 	db := &mockDatabase{opts: opts}
 	med, err := newMediator(db, opts)

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -362,7 +362,7 @@ func (n *dbNamespace) FetchBlocksMetadata(
 }
 
 func (n *dbNamespace) Bootstrap(
-	bs bootstrap.Bootstrap,
+	process bootstrap.Process,
 	targetRanges []bootstrap.TargetRange,
 ) error {
 	callStart := n.nowFn()
@@ -409,7 +409,7 @@ func (n *dbNamespace) Bootstrap(
 		shardIDs[i] = shard.ID()
 	}
 
-	bootstrapResult, err := bs.Run(n.id, shardIDs, targetRanges)
+	bootstrapResult, err := process.Run(n.id, shardIDs, targetRanges)
 	if err != nil {
 		n.log.Errorf("bootstrap for namespace %s aborted due to error: %v",
 			n.id.String(), err)

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -278,7 +278,7 @@ func TestNamespaceBootstrapAllShards(t *testing.T) {
 
 	ns := newTestNamespace(t)
 	errs := []error{nil, errors.New("foo")}
-	bs := bootstrap.NewMockBootstrap(ctrl)
+	bs := bootstrap.NewMockProcess(ctrl)
 	bs.EXPECT().
 		Run(ns.ID(), sharding.IDs(testShardIDs), ranges).
 		Return(result.NewBootstrapResult(), nil)
@@ -323,7 +323,7 @@ func TestNamespaceBootstrapOnlyNonBootstrappedShards(t *testing.T) {
 	require.True(t, len(alreadyBootstrapped) > 0)
 
 	ns := newTestNamespace(t)
-	bs := bootstrap.NewMockBootstrap(ctrl)
+	bs := bootstrap.NewMockProcess(ctrl)
 	bs.EXPECT().
 		Run(ns.ID(), sharding.IDs(needsBootstrap), ranges).
 		Return(result.NewBootstrapResult(), nil)

--- a/storage/options.go
+++ b/storage/options.go
@@ -67,10 +67,8 @@ const (
 )
 
 var (
-	// defaultNewBootstrapFn is the default function for creating a new bootstrap
-	defaultNewBootstrapFn = func() bootstrap.Bootstrap {
-		return bootstrap.NewNoOpBootstrapProcess()
-	}
+	// defaultBootstrapProcess is the default bootstrap for the database
+	defaultBootstrapProcess = bootstrap.NewNoOpProcess()
 
 	timeZero time.Time
 )
@@ -102,7 +100,7 @@ type options struct {
 	fileOpOpts                     FileOpOptions
 	newEncoderFn                   encoding.NewEncoderFn
 	newDecoderFn                   encoding.NewDecoderFn
-	newBootstrapFn                 NewBootstrapFn
+	bootstrapProcess               bootstrap.Process
 	persistManager                 persist.Manager
 	maxFlushRetries                int
 	blockRetrieverManager          block.DatabaseBlockRetrieverManager
@@ -138,7 +136,7 @@ func NewOptions() Options {
 		repairEnabled:                  defaultRepairEnabled,
 		repairOpts:                     repair.NewOptions(),
 		fileOpOpts:                     NewFileOpOptions(),
-		newBootstrapFn:                 defaultNewBootstrapFn,
+		bootstrapProcess:               defaultBootstrapProcess,
 		persistManager:                 fs.NewPersistManager(fs.NewOptions()),
 		maxFlushRetries:                defaultMaxFlushRetries,
 		contextPool:                    context.NewPool(nil, nil),
@@ -352,14 +350,14 @@ func (o *options) NewDecoderFn() encoding.NewDecoderFn {
 	return o.newDecoderFn
 }
 
-func (o *options) SetNewBootstrapFn(value NewBootstrapFn) Options {
+func (o *options) SetBootstrapProcess(value bootstrap.Process) Options {
 	opts := *o
-	opts.newBootstrapFn = value
+	opts.bootstrapProcess = value
 	return &opts
 }
 
-func (o *options) NewBootstrapFn() NewBootstrapFn {
-	return o.newBootstrapFn
+func (o *options) BootstrapProcess() bootstrap.Process {
+	return o.bootstrapProcess
 }
 
 func (o *options) SetPersistManager(value persist.Manager) Options {

--- a/storage/series/buffer_mock.go
+++ b/storage/series/buffer_mock.go
@@ -28,8 +28,8 @@ import (
 	context "github.com/m3db/m3db/context"
 	block "github.com/m3db/m3db/storage/block"
 	io "github.com/m3db/m3db/x/io"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of databaseBuffer interface
@@ -53,7 +53,7 @@ func (_m *MockdatabaseBuffer) EXPECT() *_MockdatabaseBufferRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -63,7 +63,7 @@ func (_mr *_MockdatabaseBufferRecorder) Write(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time0.Time, end time0.Time) [][]io.SegmentReader {
+func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time.Time, end time.Time) [][]io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	return ret0
@@ -73,7 +73,7 @@ func (_mr *_MockdatabaseBufferRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time0.Time) []block.FetchBlockResult {
+func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -83,7 +83,7 @@ func (_mr *_MockdatabaseBufferRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
+func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlockMetadataResults)
 	return ret0
@@ -103,10 +103,10 @@ func (_mr *_MockdatabaseBufferRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockdatabaseBuffer) MinMax() (time0.Time, time0.Time) {
+func (_m *MockdatabaseBuffer) MinMax() (time.Time, time.Time) {
 	ret := _m.ctrl.Call(_m, "MinMax")
-	ret0, _ := ret[0].(time0.Time)
-	ret1, _ := ret[1].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(time.Time)
 	return ret0, ret1
 }
 

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -24,6 +24,8 @@
 package series
 
 import (
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
@@ -31,7 +33,6 @@ import (
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
 	time0 "github.com/m3db/m3x/time"
-	time "time"
 )
 
 // Mock of DatabaseSeries interface

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -43,8 +43,8 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of Database interface
@@ -116,7 +116,7 @@ func (_mr *_MockDatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -126,7 +126,7 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -137,7 +137,7 @@ func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -148,7 +148,7 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -280,7 +280,7 @@ func (_mr *_MockdatabaseRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -290,7 +290,7 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -301,7 +301,7 @@ func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -312,7 +312,7 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -495,7 +495,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) AssignShardSet(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignShardSet", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time0.Duration) {
+func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time.Duration) {
 	_m.ctrl.Call(_m, "Tick", c, softDeadline)
 }
 
@@ -503,7 +503,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Tick(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -513,7 +513,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -524,7 +524,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, shardID, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -535,7 +535,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -547,8 +547,8 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocksMetadata(arg0, arg1, arg2,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
-func (_m *MockdatabaseNamespace) Bootstrap(bs bootstrap.Bootstrap, targetRanges []bootstrap.TargetRange) error {
-	ret := _m.ctrl.Call(_m, "Bootstrap", bs, targetRanges)
+func (_m *MockdatabaseNamespace) Bootstrap(process bootstrap.Process, targetRanges []bootstrap.TargetRange) error {
+	ret := _m.ctrl.Call(_m, "Bootstrap", process, targetRanges)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -557,7 +557,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Bootstrap(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Flush(blockStart time0.Time, flush persist.Flush) error {
+func (_m *MockdatabaseNamespace) Flush(blockStart time.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -567,7 +567,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time0.Time) bool {
+func (_m *MockdatabaseNamespace) NeedsFlush(blockStart time.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", blockStart)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -577,7 +577,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) NeedsFlush(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time0.Time) error {
+func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -598,7 +598,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Truncate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate")
 }
 
-func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time.Range) error {
+func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time0.Range) error {
 	ret := _m.ctrl.Call(_m, "Repair", repairer, tr)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -720,7 +720,7 @@ func (_mr *_MockdatabaseShardRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time0.Duration) tickResult {
+func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time.Duration) tickResult {
 	ret := _m.ctrl.Call(_m, "Tick", c, softDeadline)
 	ret0, _ := ret[0].(tickResult)
 	return ret0
@@ -730,7 +730,7 @@ func (_mr *_MockdatabaseShardRecorder) Tick(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -740,7 +740,7 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -751,7 +751,7 @@ func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -762,7 +762,7 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -783,7 +783,7 @@ func (_mr *_MockdatabaseShardRecorder) Bootstrap(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0)
 }
 
-func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time0.Time, flush persist.Flush) error {
+func (_m *MockdatabaseShard) Flush(namespace ts.ID, blockStart time.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", namespace, blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -793,7 +793,7 @@ func (_mr *_MockdatabaseShardRecorder) Flush(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FlushState(blockStart time0.Time) fileOpState {
+func (_m *MockdatabaseShard) FlushState(blockStart time.Time) fileOpState {
 	ret := _m.ctrl.Call(_m, "FlushState", blockStart)
 	ret0, _ := ret[0].(fileOpState)
 	return ret0
@@ -803,7 +803,7 @@ func (_mr *_MockdatabaseShardRecorder) FlushState(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushState", arg0)
 }
 
-func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time0.Time) error {
+func (_m *MockdatabaseShard) CleanupFileset(namespace ts.ID, earliestToRetain time.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", namespace, earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -813,7 +813,7 @@ func (_mr *_MockdatabaseShardRecorder) CleanupFileset(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupFileset", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShard) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -894,7 +894,7 @@ func (_m *MockdatabaseFlushManager) EXPECT() *_MockdatabaseFlushManagerRecorder 
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFlushManager) NeedsFlush(t time0.Time) bool {
+func (_m *MockdatabaseFlushManager) NeedsFlush(t time.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", t)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -904,9 +904,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) NeedsFlush(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeStart(t time0.Time) time0.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeStart(t time.Time) time.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeStart", t)
-	ret0, _ := ret[0].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 
@@ -914,9 +914,9 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeStart(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeStart", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time0.Time) time0.Time {
+func (_m *MockdatabaseFlushManager) FlushTimeEnd(t time.Time) time.Time {
 	ret := _m.ctrl.Call(_m, "FlushTimeEnd", t)
-	ret0, _ := ret[0].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 
@@ -924,7 +924,7 @@ func (_mr *_MockdatabaseFlushManagerRecorder) FlushTimeEnd(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushTimeEnd", arg0)
 }
 
-func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {
+func (_m *MockdatabaseFlushManager) Flush(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -981,7 +981,7 @@ func (_m *MockdatabaseCleanupManager) EXPECT() *_MockdatabaseCleanupManagerRecor
 	return _m.recorder
 }
 
-func (_m *MockdatabaseCleanupManager) Cleanup(t time0.Time) error {
+func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1040,7 +1040,7 @@ func (_mr *_MockFileOpOptionsRecorder) RetentionOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RetentionOptions")
 }
 
-func (_m *MockFileOpOptions) SetJitter(value time0.Duration) FileOpOptions {
+func (_m *MockFileOpOptions) SetJitter(value time.Duration) FileOpOptions {
 	ret := _m.ctrl.Call(_m, "SetJitter", value)
 	ret0, _ := ret[0].(FileOpOptions)
 	return ret0
@@ -1050,9 +1050,9 @@ func (_mr *_MockFileOpOptionsRecorder) SetJitter(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetJitter", arg0)
 }
 
-func (_m *MockFileOpOptions) Jitter() time0.Duration {
+func (_m *MockFileOpOptions) Jitter() time.Duration {
 	ret := _m.ctrl.Call(_m, "Jitter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1091,7 +1091,7 @@ func (_m *MockdatabaseFileSystemManager) EXPECT() *_MockdatabaseFileSystemManage
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFileSystemManager) Cleanup(t time0.Time) error {
+func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1101,7 +1101,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Cleanup(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) Flush(t time0.Time) error {
+func (_m *MockdatabaseFileSystemManager) Flush(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1141,7 +1141,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
-func (_m *MockdatabaseFileSystemManager) Run(t time0.Time, runType runType, forceType forceType) bool {
+func (_m *MockdatabaseFileSystemManager) Run(t time.Time, runType runType, forceType forceType) bool {
 	ret := _m.ctrl.Call(_m, "Run", t, runType, forceType)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1190,7 +1190,7 @@ func (_mr *_MockdatabaseShardRepairerRecorder) Options() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
-func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -1277,7 +1277,7 @@ func (_m *MockdatabaseTickManager) EXPECT() *_MockdatabaseTickManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseTickManager) Tick(softDeadline time0.Duration, forceType forceType) error {
+func (_m *MockdatabaseTickManager) Tick(softDeadline time.Duration, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1354,7 +1354,7 @@ func (_mr *_MockdatabaseMediatorRecorder) EnableFileOps() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableFileOps")
 }
 
-func (_m *MockdatabaseMediator) Tick(softDeadline time0.Duration, runType runType, forceType forceType) error {
+func (_m *MockdatabaseMediator) Tick(softDeadline time.Duration, runType runType, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, runType, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1543,7 +1543,7 @@ func (_mr *_MockOptionsRecorder) ErrorCounterOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ErrorCounterOptions")
 }
 
-func (_m *MockOptions) SetErrorWindowForLoad(value time0.Duration) Options {
+func (_m *MockOptions) SetErrorWindowForLoad(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetErrorWindowForLoad", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1553,9 +1553,9 @@ func (_mr *_MockOptionsRecorder) SetErrorWindowForLoad(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetErrorWindowForLoad", arg0)
 }
 
-func (_m *MockOptions) ErrorWindowForLoad() time0.Duration {
+func (_m *MockOptions) ErrorWindowForLoad() time.Duration {
 	ret := _m.ctrl.Call(_m, "ErrorWindowForLoad")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1643,24 +1643,24 @@ func (_mr *_MockOptionsRecorder) FileOpOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FileOpOptions")
 }
 
-func (_m *MockOptions) SetNewBootstrapFn(value NewBootstrapFn) Options {
-	ret := _m.ctrl.Call(_m, "SetNewBootstrapFn", value)
+func (_m *MockOptions) SetBootstrapProcess(value bootstrap.Process) Options {
+	ret := _m.ctrl.Call(_m, "SetBootstrapProcess", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) SetNewBootstrapFn(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetNewBootstrapFn", arg0)
+func (_mr *_MockOptionsRecorder) SetBootstrapProcess(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBootstrapProcess", arg0)
 }
 
-func (_m *MockOptions) NewBootstrapFn() NewBootstrapFn {
-	ret := _m.ctrl.Call(_m, "NewBootstrapFn")
-	ret0, _ := ret[0].(NewBootstrapFn)
+func (_m *MockOptions) BootstrapProcess() bootstrap.Process {
+	ret := _m.ctrl.Call(_m, "BootstrapProcess")
+	ret0, _ := ret[0].(bootstrap.Process)
 	return ret0
 }
 
-func (_mr *_MockOptionsRecorder) NewBootstrapFn() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewBootstrapFn")
+func (_mr *_MockOptionsRecorder) BootstrapProcess() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BootstrapProcess")
 }
 
 func (_m *MockOptions) SetPersistManager(value persist.Manager) Options {
@@ -1721,26 +1721,6 @@ func (_m *MockOptions) DatabaseBlockRetrieverManager() block.DatabaseBlockRetrie
 
 func (_mr *_MockOptionsRecorder) DatabaseBlockRetrieverManager() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockRetrieverManager")
-}
-
-func (_m *MockOptions) SetShardCloseDeadline(value time0.Duration) Options {
-	ret := _m.ctrl.Call(_m, "SetShardCloseDeadline", value)
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockOptionsRecorder) SetShardCloseDeadline(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetShardCloseDeadline", arg0)
-}
-
-func (_m *MockOptions) ShardCloseDeadline() time0.Duration {
-	ret := _m.ctrl.Call(_m, "ShardCloseDeadline")
-	ret0, _ := ret[0].(time0.Duration)
-	return ret0
-}
-
-func (_mr *_MockOptionsRecorder) ShardCloseDeadline() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShardCloseDeadline")
 }
 
 func (_m *MockOptions) SetContextPool(value context.Pool) Options {

--- a/storage/types.go
+++ b/storage/types.go
@@ -196,7 +196,7 @@ type databaseNamespace interface {
 
 	// Bootstrap performs bootstrapping
 	Bootstrap(
-		bs bootstrap.Bootstrap,
+		process bootstrap.Process,
 		targetRanges []bootstrap.TargetRange,
 	) error
 
@@ -451,9 +451,6 @@ type databaseMediator interface {
 	Report()
 }
 
-// NewBootstrapFn creates a new bootstrap
-type NewBootstrapFn func() bootstrap.Bootstrap
-
 // Options represents the options for storage
 type Options interface {
 	// SetEncodingM3TSZPooled sets m3tsz encoding with pooling
@@ -525,11 +522,11 @@ type Options interface {
 	// FileOpOptions returns the repair options
 	FileOpOptions() FileOpOptions
 
-	// SetNewBootstrapFn sets the newBootstrapFn
-	SetNewBootstrapFn(value NewBootstrapFn) Options
+	// SetBootstrapProcess sets the bootstrap process for the database
+	SetBootstrapProcess(value bootstrap.Process) Options
 
-	// NewBootstrapFn returns the newBootstrapFn
-	NewBootstrapFn() NewBootstrapFn
+	// BootstrapProcess returns the bootstrap process for the database
+	BootstrapProcess() bootstrap.Process
 
 	// SetPersistManager sets the persistence manager
 	SetPersistManager(value persist.Manager) Options


### PR DESCRIPTION
This change reuses the bootstrap process to avoid creating a new process every bootstrap.  During a topology change each shard that changes states causes a bootstrap, this creates churn creating the bootstrap process over and over again for small and sometimes no-op bootstraps (depending if the node is affected by the topology change or not).  This avoids that overhead.

cc @xichen2020 @kobolog @prateek @ben-lerner 