### PR TITLE
Limit context closing concurrency to avoid goroutine explosion during topology changes

### DIFF
--- a/storage/block/types.go
+++ b/storage/block/types.go
@@ -30,6 +30,7 @@ import (
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/sync"
 )
 
 // Metadata captures block metadata
@@ -321,6 +322,12 @@ type Options interface {
 
 	// DatabaseBlockAllocSize returns the databaseBlockAllocSize
 	DatabaseBlockAllocSize() int
+
+	// SetCloseContextWorkers sets the workers for closing contexts
+	SetCloseContextWorkers(value xsync.WorkerPool) Options
+
+	// CloseContextWorkers returns the workers for closing contexts
+	CloseContextWorkers() xsync.WorkerPool
 
 	// SetDatabaseBlockPool sets the databaseBlockPool
 	SetDatabaseBlockPool(value DatabaseBlockPool) Options


### PR DESCRIPTION
cc @robskillington @cw9 @prateek @ben-lerner 

This PR uses a worker pool to limit the concurrency when closing contexts to avoid the goroutine explosion problem during topology changes.