### PR TITLE
Fix minor disk block retrieve seeker 'accessed' race

### DIFF
--- a/persist/fs/seek_manager.go
+++ b/persist/fs/seek_manager.go
@@ -330,7 +330,10 @@ func (m *seekerManager) openCloseLoop() {
 		}
 
 		for _, byTime := range m.seekersByShardIdx {
-			if !byTime.accessed {
+			byTime.RLock()
+			accessed := byTime.accessed
+			byTime.RUnlock()
+			if !accessed {
 				continue
 			}
 			shouldTryOpen = append(shouldTryOpen, byTime)


### PR DESCRIPTION
This change fixes a minor race to read the 'accessed' field of a seeker by the seeker open/close loop that garbage collects open seekers and opens seekers ahead of time to newly flushed blocks.

cc @xichen2020 @cw9 @prateek @ben-lerner 