### PR TITLE
Add wired, unwired, open, made unwired block stats

### DIFF
--- a/retention/options.go
+++ b/retention/options.go
@@ -40,9 +40,6 @@ const (
 	// defaultBufferDrain is the default buffer drain
 	defaultBufferDrain = 2 * time.Minute
 
-	// defaultShortExpiry is the default bool for whether short expiry is on
-	defaultShortExpiry = false
-
 	// defaultDataExpiry is the default bool for whether data expiry is on
 	defaultDataExpiry = true
 
@@ -51,15 +48,11 @@ const (
 )
 
 type options struct {
-	retentionPeriod time.Duration
-	blockSize       time.Duration
-	bufferFuture    time.Duration
-	bufferPast      time.Duration
-	bufferDrain     time.Duration
-
-	shortExpiry       bool
-	shortExpiryPeriod time.Duration
-
+	retentionPeriod                  time.Duration
+	blockSize                        time.Duration
+	bufferFuture                     time.Duration
+	bufferPast                       time.Duration
+	bufferDrain                      time.Duration
 	dataExpiry                       bool
 	dataExpiryAfterNotAccessedPeriod time.Duration
 }
@@ -72,7 +65,6 @@ func NewOptions() Options {
 		bufferFuture:                     defaultBufferFuture,
 		bufferPast:                       defaultBufferPast,
 		bufferDrain:                      defaultBufferDrain,
-		shortExpiry:                      defaultShortExpiry,
 		dataExpiry:                       defaultDataExpiry,
 		dataExpiryAfterNotAccessedPeriod: defaultDataExpiryAfterNotAccessedPeriod,
 	}
@@ -126,26 +118,6 @@ func (o *options) SetBufferDrain(value time.Duration) Options {
 
 func (o *options) BufferDrain() time.Duration {
 	return o.bufferDrain
-}
-
-func (o *options) SetShortExpiry(value bool) Options {
-	opts := *o
-	opts.shortExpiry = value
-	return &opts
-}
-
-func (o *options) ShortExpiry() bool {
-	return o.shortExpiry
-}
-
-func (o *options) SetShortExpiryPeriod(period time.Duration) Options {
-	opts := *o
-	opts.shortExpiryPeriod = period
-	return &opts
-}
-
-func (o *options) ShortExpiryPeriod() time.Duration {
-	return o.shortExpiryPeriod
 }
 
 func (o *options) SetBlockDataExpiry(value bool) Options {

--- a/retention/types.go
+++ b/retention/types.go
@@ -56,21 +56,6 @@ type Options interface {
 	// BufferDrain returns the bufferDrain
 	BufferDrain() time.Duration
 
-	// SetShortExpiry sets the short expiry mode
-	SetShortExpiry(on bool) Options
-
-	// ShortExpiry returns whether short expiry mode is turned on. If turned on,
-	// data is only stored in memory for part of the retention period
-	ShortExpiry() bool
-
-	// SetShortExpiryPeriod sets the period that blocks should be kept in memory
-	// when short expiry is turned on
-	SetShortExpiryPeriod(period time.Duration) Options
-
-	// ShortExpiryPeriod returns the period that blocks should be kep in memory
-	// when short expiry is turned on
-	ShortExpiryPeriod() time.Duration
-
 	// SetBlockDataExpiry sets the block data expiry mode
 	SetBlockDataExpiry(on bool) Options
 

--- a/storage/block/block_mock.go
+++ b/storage/block/block_mock.go
@@ -31,6 +31,7 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	clock "github.com/m3db/m3x/clock"
 	pool "github.com/m3db/m3x/pool"
+	sync "github.com/m3db/m3x/sync"
 	time "time"
 )
 
@@ -841,6 +842,26 @@ func (_m *MockOptions) DatabaseBlockAllocSize() int {
 
 func (_mr *_MockOptionsRecorder) DatabaseBlockAllocSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DatabaseBlockAllocSize")
+}
+
+func (_m *MockOptions) SetCloseContextWorkers(value sync.WorkerPool) Options {
+	ret := _m.ctrl.Call(_m, "SetCloseContextWorkers", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) SetCloseContextWorkers(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetCloseContextWorkers", arg0)
+}
+
+func (_m *MockOptions) CloseContextWorkers() sync.WorkerPool {
+	ret := _m.ctrl.Call(_m, "CloseContextWorkers")
+	ret0, _ := ret[0].(sync.WorkerPool)
+	return ret0
+}
+
+func (_mr *_MockOptionsRecorder) CloseContextWorkers() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CloseContextWorkers")
 }
 
 func (_m *MockOptions) SetDatabaseBlockPool(value DatabaseBlockPool) Options {

--- a/storage/block/types.go
+++ b/storage/block/types.go
@@ -30,7 +30,7 @@ import (
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/pool"
-	"github.com/m3db/m3x/sync"
+	xsync "github.com/m3db/m3x/sync"
 )
 
 // Metadata captures block metadata

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -102,8 +102,12 @@ type databaseNamespaceTickMetrics struct {
 	activeSeries           tally.Gauge
 	expiredSeries          tally.Counter
 	activeBlocks           tally.Gauge
-	resetRetrievableBlocks tally.Counter
-	expiredBlocks          tally.Counter
+	openBlocks             tally.Gauge
+	wiredBlocks            tally.Gauge
+	unwiredBlocks          tally.Gauge
+	madeUnwiredBlocks      tally.Counter
+	madeExpiredBlocks      tally.Counter
+	mergedOutOfOrderBlocks tally.Counter
 	errors                 tally.Counter
 }
 
@@ -125,8 +129,12 @@ func newDatabaseNamespaceMetrics(scope tally.Scope, samplingRate float64) databa
 			activeSeries:           tickScope.Gauge("active-series"),
 			expiredSeries:          tickScope.Counter("expired-series"),
 			activeBlocks:           tickScope.Gauge("active-blocks"),
-			resetRetrievableBlocks: tickScope.Counter("reset-retrievable-blocks"),
-			expiredBlocks:          tickScope.Counter("expired-blocks"),
+			openBlocks:             tickScope.Gauge("open-blocks"),
+			wiredBlocks:            tickScope.Gauge("wired-blocks"),
+			unwiredBlocks:          tickScope.Gauge("unwired-blocks"),
+			madeUnwiredBlocks:      tickScope.Counter("made-unwired-blocks"),
+			madeExpiredBlocks:      tickScope.Counter("made-expired-blocks"),
+			mergedOutOfOrderBlocks: tickScope.Counter("merged-out-of-order-blocks"),
 			errors:                 tickScope.Counter("errors"),
 		},
 	}
@@ -298,8 +306,12 @@ func (n *dbNamespace) Tick(c context.Cancellable, softDeadline time.Duration) {
 	n.metrics.tick.activeSeries.Update(float64(r.activeSeries))
 	n.metrics.tick.expiredSeries.Inc(int64(r.expiredSeries))
 	n.metrics.tick.activeBlocks.Update(float64(r.activeBlocks))
-	n.metrics.tick.resetRetrievableBlocks.Inc(int64(r.resetRetrievableBlocks))
-	n.metrics.tick.expiredBlocks.Inc(int64(r.expiredBlocks))
+	n.metrics.tick.openBlocks.Update(float64(r.openBlocks))
+	n.metrics.tick.wiredBlocks.Update(float64(r.wiredBlocks))
+	n.metrics.tick.unwiredBlocks.Update(float64(r.unwiredBlocks))
+	n.metrics.tick.madeExpiredBlocks.Inc(int64(r.madeExpiredBlocks))
+	n.metrics.tick.madeUnwiredBlocks.Inc(int64(r.madeUnwiredBlocks))
+	n.metrics.tick.mergedOutOfOrderBlocks.Inc(int64(r.mergedOutOfOrderBlocks))
 	n.metrics.tick.errors.Inc(int64(r.errors))
 }
 

--- a/storage/result.go
+++ b/storage/result.go
@@ -24,8 +24,12 @@ type tickResult struct {
 	activeSeries           int
 	expiredSeries          int
 	activeBlocks           int
-	resetRetrievableBlocks int
-	expiredBlocks          int
+	openBlocks             int
+	wiredBlocks            int
+	unwiredBlocks          int
+	madeExpiredBlocks      int
+	madeUnwiredBlocks      int
+	mergedOutOfOrderBlocks int
 	errors                 int
 }
 
@@ -34,8 +38,12 @@ func (r tickResult) merge(other tickResult) tickResult {
 		activeSeries:           r.activeSeries + other.activeSeries,
 		expiredSeries:          r.expiredSeries + other.expiredSeries,
 		activeBlocks:           r.activeBlocks + other.activeBlocks,
-		resetRetrievableBlocks: r.resetRetrievableBlocks + other.resetRetrievableBlocks,
-		expiredBlocks:          r.expiredBlocks + other.expiredBlocks,
+		openBlocks:             r.openBlocks + other.openBlocks,
+		wiredBlocks:            r.wiredBlocks + other.wiredBlocks,
+		unwiredBlocks:          r.unwiredBlocks + other.unwiredBlocks,
+		madeExpiredBlocks:      r.madeExpiredBlocks + other.madeExpiredBlocks,
+		madeUnwiredBlocks:      r.madeUnwiredBlocks + other.madeUnwiredBlocks,
+		mergedOutOfOrderBlocks: r.mergedOutOfOrderBlocks + other.mergedOutOfOrderBlocks,
 		errors:                 r.errors + other.errors,
 	}
 }

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -138,6 +138,7 @@ func (b *dbBuffer) Reset() {
 	// Avoid capturing any variables with callback
 	b.computedForEachBucketAsc(computeAndResetBucketIdx, bucketResetStart)
 }
+
 func bucketResetStart(now time.Time, b *dbBuffer, idx int, start time.Time) int {
 	b.buckets[idx].opts = b.opts
 	b.buckets[idx].resetTo(start)
@@ -215,6 +216,7 @@ func (b *dbBuffer) NeedsDrain() bool {
 	// Avoid capturing any variables with callback
 	return b.computedForEachBucketAsc(computeBucketIdx, bucketNeedsDrain) > 0
 }
+
 func bucketNeedsDrain(now time.Time, b *dbBuffer, idx int, start time.Time) int {
 	if b.buckets[idx].needsDrain(now, start) {
 		return 1
@@ -229,6 +231,7 @@ func (b *dbBuffer) DrainAndReset() drainAndResetResult {
 		mergedOutOfOrderBlocks: mergedOutOfOrder,
 	}
 }
+
 func bucketDrainAndReset(now time.Time, b *dbBuffer, idx int, start time.Time) int {
 	mergedOutOfOrderBlocks := 0
 	if b.buckets[idx].needsDrain(now, start) {
@@ -280,7 +283,7 @@ func (b *dbBuffer) forEachBucketAsc(fn func(*dbBufferBucket)) {
 	}
 }
 
-// computedForEachBucketAscAny performs a fn on the buckets in time ascending order
+// computedForEachBucketAsc performs a fn on the buckets in time ascending order
 // and returns the sum of the number returned by each fn
 func (b *dbBuffer) computedForEachBucketAsc(
 	op computeBucketIdxOp,

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -86,15 +86,26 @@ type databaseBuffer interface {
 
 	IsEmpty() bool
 
+	Stats() bufferStats
+
 	MinMax() (time.Time, time.Time)
 
 	NeedsDrain() bool
 
-	DrainAndReset()
+	DrainAndReset() drainAndResetResult
 
 	Bootstrap(bl block.DatabaseBlock) error
 
 	Reset()
+}
+
+type bufferStats struct {
+	openBlocks  int
+	wiredBlocks int
+}
+
+type drainAndResetResult struct {
+	mergedOutOfOrderBlocks int
 }
 
 type dbBuffer struct {
@@ -124,23 +135,25 @@ func newDatabaseBuffer(drainFn databaseBufferDrainFn, opts Options) databaseBuff
 }
 
 func (b *dbBuffer) Reset() {
-	idx := computeAndResetBucketIdx
-	b.computedForEachBucketAsc(b.nowFn(), idx, func(bucket *dbBufferBucket, t time.Time) {
-		bucket.opts = b.opts
-		bucket.resetTo(t)
-	})
+	// Avoid capturing any variables with callback
+	b.computedForEachBucketAsc(computeAndResetBucketIdx, bucketResetStart)
+}
+func bucketResetStart(now time.Time, b *dbBuffer, idx int, start time.Time) int {
+	b.buckets[idx].opts = b.opts
+	b.buckets[idx].resetTo(start)
+	return 1
 }
 
 func (b *dbBuffer) MinMax() (time.Time, time.Time) {
 	var min, max time.Time
-	b.forEachBucketAsc(func(bucket *dbBufferBucket) {
-		if min.IsZero() || bucket.start.Before(min) {
-			min = bucket.start
+	for i := range b.buckets {
+		if min.IsZero() || b.buckets[i].start.Before(min) {
+			min = b.buckets[i].start
 		}
-		if max.IsZero() || bucket.start.After(max) {
-			max = bucket.start
+		if max.IsZero() || b.buckets[i].start.After(max) {
+			max = b.buckets[i].start
 		}
-	})
+	}
 	return min, max
 }
 
@@ -162,68 +175,96 @@ func (b *dbBuffer) Write(
 	}
 
 	bucketStart := timestamp.Truncate(b.blockSize)
-	bucketIdx := (timestamp.UnixNano() / int64(b.blockSize)) % bucketsLen
-
-	bucket := &b.buckets[bucketIdx]
-	if bucket.needsReset(bucketStart) {
+	idx := b.writableBucketIdx(timestamp)
+	if b.buckets[idx].needsReset(bucketStart) {
 		// Needs reset
 		b.DrainAndReset()
 	}
 
-	return bucket.write(timestamp, value, unit, annotation)
+	return b.buckets[idx].write(timestamp, value, unit, annotation)
+}
+
+func (b *dbBuffer) writableBucketIdx(t time.Time) int {
+	return int((t.UnixNano() / int64(b.blockSize)) % bucketsLen)
 }
 
 func (b *dbBuffer) IsEmpty() bool {
 	canReadAny := false
-	b.forEachBucketAsc(func(bucket *dbBufferBucket) {
-		canReadAny = canReadAny || bucket.canRead()
-	})
-	return !canReadAny
+	for i := range b.buckets {
+		canReadAny = canReadAny || b.buckets[i].canRead()
+	}
+	return canReadAny
+}
+
+func (b *dbBuffer) Stats() bufferStats {
+	var stats bufferStats
+	writableIdx := b.writableBucketIdx(b.nowFn())
+	for i := range b.buckets {
+		if !b.buckets[i].canRead() {
+			continue
+		}
+		if i == writableIdx {
+			stats.openBlocks++
+		}
+		stats.wiredBlocks++
+	}
+	return stats
 }
 
 func (b *dbBuffer) NeedsDrain() bool {
-	now := b.nowFn()
-	idx := computeBucketIdx
-	needsDrainAny := false
-	b.computedForEachBucketAsc(now, idx, func(bucket *dbBufferBucket, current time.Time) {
-		needsDrainAny = needsDrainAny || bucket.needsDrain(now, current)
-	})
-	return needsDrainAny
+	// Avoid capturing any variables with callback
+	return b.computedForEachBucketAsc(computeBucketIdx, bucketNeedsDrain) > 0
+}
+func bucketNeedsDrain(now time.Time, b *dbBuffer, idx int, start time.Time) int {
+	if b.buckets[idx].needsDrain(now, start) {
+		return 1
+	}
+	return 0
 }
 
-func (b *dbBuffer) DrainAndReset() {
-	now := b.nowFn()
-	idx := computeAndResetBucketIdx
-	b.computedForEachBucketAsc(now, idx, func(bucket *dbBufferBucket, current time.Time) {
-		if bucket.needsDrain(now, current) {
-			mergedBlock := bucket.discardMerged()
-			if mergedBlock.Len() > 0 {
-				b.drainFn(mergedBlock)
-			} else {
-				log := b.opts.InstrumentOptions().Logger()
-				log.Errorf("buffer drain tried to drain empty stream for bucket: %v",
-					current.String())
-			}
-
-			bucket.drained = true
+func (b *dbBuffer) DrainAndReset() drainAndResetResult {
+	// Avoid capturing any variables with callback
+	mergedOutOfOrder := b.computedForEachBucketAsc(computeAndResetBucketIdx, bucketDrainAndReset)
+	return drainAndResetResult{
+		mergedOutOfOrderBlocks: mergedOutOfOrder,
+	}
+}
+func bucketDrainAndReset(now time.Time, b *dbBuffer, idx int, start time.Time) int {
+	mergedOutOfOrderBlocks := 0
+	if b.buckets[idx].needsDrain(now, start) {
+		merged := b.buckets[idx].discardMerged()
+		if merged.merges > 0 {
+			mergedOutOfOrderBlocks = 1
+		}
+		if merged.block.Len() > 0 {
+			b.drainFn(merged.block)
+		} else {
+			log := b.opts.InstrumentOptions().Logger()
+			log.Errorf("buffer drain tried to drain empty stream for bucket: %v",
+				start.String())
 		}
 
-		if bucket.needsReset(current) {
-			// Reset bucket
-			bucket.resetTo(current)
-		}
-	})
+		b.buckets[idx].drained = true
+	}
+
+	if b.buckets[idx].needsReset(start) {
+		// Reset bucket
+		b.buckets[idx].resetTo(start)
+	}
+
+	return mergedOutOfOrderBlocks
 }
 
 func (b *dbBuffer) Bootstrap(bl block.DatabaseBlock) error {
 	blockStart := bl.StartTime()
 	bootstrapped := false
-	b.forEachBucketAsc(func(bucket *dbBufferBucket) {
-		if bucket.start.Equal(blockStart) {
-			bucket.bootstrap(bl)
+	for i := range b.buckets {
+		if b.buckets[i].start.Equal(blockStart) {
+			b.buckets[i].bootstrap(bl)
 			bootstrapped = true
+			break
 		}
-	})
+	}
 	if !bootstrapped {
 		return fmt.Errorf("block at %s not contained by buffer", blockStart.String())
 	}
@@ -239,21 +280,25 @@ func (b *dbBuffer) forEachBucketAsc(fn func(*dbBufferBucket)) {
 	}
 }
 
-// computedForEachBucketAsc performs computation on the buckets in time ascending order
+// computedForEachBucketAscAny performs a fn on the buckets in time ascending order
+// and returns the sum of the number returned by each fn
 func (b *dbBuffer) computedForEachBucketAsc(
-	now time.Time,
 	op computeBucketIdxOp,
-	fn func(*dbBufferBucket, time.Time),
-) {
+	fn func(now time.Time, b *dbBuffer, idx int, bucketStart time.Time) int,
+) int {
+	now := b.nowFn()
 	pastMostBucketStart := now.Truncate(b.blockSize).Add(-1 * b.blockSize)
 	bucketNum := (pastMostBucketStart.UnixNano() / int64(b.blockSize)) % bucketsLen
+	result := 0
 	for i := int64(0); i < bucketsLen; i++ {
 		idx := int((bucketNum + i) % bucketsLen)
-		fn(&b.buckets[idx], pastMostBucketStart.Add(time.Duration(i)*b.blockSize))
+		curr := pastMostBucketStart.Add(time.Duration(i) * b.blockSize)
+		result += fn(now, b, idx, curr)
 	}
 	if op == computeAndResetBucketIdx {
 		b.pastMostBucketIdx = int(bucketNum)
 	}
+	return result
 }
 
 func (b *dbBuffer) ReadEncoded(ctx context.Context, start, end time.Time) [][]xio.SegmentReader {
@@ -515,7 +560,12 @@ func (b *dbBufferBucket) resetBootstrapped() {
 	b.bootstrapped = nil
 }
 
-func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
+type discardMergedResult struct {
+	block  block.DatabaseBlock
+	merges int
+}
+
+func (b *dbBufferBucket) discardMerged() discardMergedResult {
 	defer func() {
 		b.resetEncoders()
 		b.resetBootstrapped()
@@ -528,7 +578,7 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 		newBlock := b.opts.DatabaseBlockOptions().DatabaseBlockPool().Get()
 		newBlock.Reset(b.start, encoder.Discard())
 		b.encoders = b.encoders[:0]
-		return newBlock
+		return discardMergedResult{newBlock, 0}
 	}
 
 	if (len(b.encoders) == 0 ||
@@ -538,7 +588,7 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 		// Already merged just a single bootstrapped block
 		existingBlock := b.bootstrapped[0]
 		b.bootstrapped = b.bootstrapped[:0]
-		return existingBlock
+		return discardMergedResult{existingBlock, 0}
 	}
 
 	// If we have to merge bootstrapped from disk during a block rotation
@@ -556,6 +606,7 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 		}
 	}
 
+	merges := 0
 	bopts := b.opts.DatabaseBlockOptions()
 	encoder := bopts.EncoderPool().Get()
 	encoder.Reset(b.start, bopts.DatabaseBlockAllocSize())
@@ -563,6 +614,7 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 	readers := make([]io.Reader, 0, len(b.encoders)+len(b.bootstrapped))
 	for i := range b.encoders {
 		if stream := b.encoders[i].encoder.Stream(); stream != nil {
+			merges++
 			readers = append(readers, stream)
 			defer stream.Finalize()
 		}
@@ -571,6 +623,7 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 	for i := range b.bootstrapped {
 		stream, err := b.bootstrapped[i].Stream(b.ctx)
 		if err == nil && stream != nil {
+			merges++
 			readers = append(readers, stream)
 		}
 	}
@@ -590,5 +643,5 @@ func (b *dbBufferBucket) discardMerged() block.DatabaseBlock {
 	newBlock := b.opts.DatabaseBlockOptions().DatabaseBlockPool().Get()
 	newBlock.Reset(b.start, encoder.Discard())
 
-	return newBlock
+	return discardMergedResult{newBlock, merges}
 }

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -193,7 +193,7 @@ func (b *dbBuffer) IsEmpty() bool {
 	for i := range b.buckets {
 		canReadAny = canReadAny || b.buckets[i].canRead()
 	}
-	return canReadAny
+	return !canReadAny
 }
 
 func (b *dbBuffer) Stats() bufferStats {

--- a/storage/series/buffer_mock.go
+++ b/storage/series/buffer_mock.go
@@ -28,8 +28,8 @@ import (
 	context "github.com/m3db/m3db/context"
 	block "github.com/m3db/m3db/storage/block"
 	io "github.com/m3db/m3db/x/io"
-	time0 "github.com/m3db/m3x/time"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of databaseBuffer interface
@@ -53,7 +53,7 @@ func (_m *MockdatabaseBuffer) EXPECT() *_MockdatabaseBufferRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -63,7 +63,7 @@ func (_mr *_MockdatabaseBufferRecorder) Write(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time.Time, end time.Time) [][]io.SegmentReader {
+func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time0.Time, end time0.Time) [][]io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	return ret0
@@ -73,7 +73,7 @@ func (_mr *_MockdatabaseBufferRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
+func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time0.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -83,7 +83,7 @@ func (_mr *_MockdatabaseBufferRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
+func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, includeSizes, includeChecksums)
 	ret0, _ := ret[0].(block.FetchBlockMetadataResults)
 	return ret0
@@ -103,10 +103,20 @@ func (_mr *_MockdatabaseBufferRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockdatabaseBuffer) MinMax() (time.Time, time.Time) {
+func (_m *MockdatabaseBuffer) Stats() bufferStats {
+	ret := _m.ctrl.Call(_m, "Stats")
+	ret0, _ := ret[0].(bufferStats)
+	return ret0
+}
+
+func (_mr *_MockdatabaseBufferRecorder) Stats() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stats")
+}
+
+func (_m *MockdatabaseBuffer) MinMax() (time0.Time, time0.Time) {
 	ret := _m.ctrl.Call(_m, "MinMax")
-	ret0, _ := ret[0].(time.Time)
-	ret1, _ := ret[1].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
+	ret1, _ := ret[1].(time0.Time)
 	return ret0, ret1
 }
 
@@ -124,8 +134,10 @@ func (_mr *_MockdatabaseBufferRecorder) NeedsDrain() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsDrain")
 }
 
-func (_m *MockdatabaseBuffer) DrainAndReset() {
-	_m.ctrl.Call(_m, "DrainAndReset")
+func (_m *MockdatabaseBuffer) DrainAndReset() drainAndResetResult {
+	ret := _m.ctrl.Call(_m, "DrainAndReset")
+	ret0, _ := ret[0].(drainAndResetResult)
+	return ret0
 }
 
 func (_mr *_MockdatabaseBufferRecorder) DrainAndReset() *gomock.Call {

--- a/storage/series/buffer_test.go
+++ b/storage/series/buffer_test.go
@@ -309,7 +309,7 @@ func TestBufferWriteOutOfOrder(t *testing.T) {
 	// Explicitly merge
 	var mergedResults [][]xio.SegmentReader
 	for i := range buffer.buckets {
-		block := buffer.buckets[i].discardMerged()
+		block := buffer.buckets[i].discardMerged().block
 		require.NotNil(t, block)
 
 		if block.Len() > 0 {
@@ -376,7 +376,7 @@ func newTestBufferBucketWithData(t *testing.T) (*dbBufferBucket, Options, []valu
 func TestBufferBucketMerge(t *testing.T) {
 	b, opts, expected := newTestBufferBucketWithData(t)
 
-	bl := b.discardMerged()
+	bl := b.discardMerged().block
 	require.NotNil(t, bl)
 
 	assert.Equal(t, 0, len(b.encoders))
@@ -440,7 +440,7 @@ func TestBufferBucketWriteDuplicate(t *testing.T) {
 	require.NoError(t, b.write(curr, 1, xtime.Second, nil))
 	require.Equal(t, 1, len(b.encoders))
 
-	bl := b.discardMerged()
+	bl := b.discardMerged().block
 	require.NotNil(t, bl)
 
 	ctx := context.NewContext()

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -74,11 +74,6 @@ type dbSeries struct {
 	pool           DatabaseSeriesPool
 }
 
-type updateBlocksResult struct {
-	expired          int
-	resetRetrievable int
-}
-
 // NewDatabaseSeries creates a new database series
 func NewDatabaseSeries(id ts.ID, opts Options) DatabaseSeries {
 	return newDatabaseSeries(id, opts)
@@ -119,125 +114,61 @@ func (s *dbSeries) ID() ts.ID {
 
 func (s *dbSeries) Tick() (TickResult, error) {
 	var r TickResult
-	if s.IsEmpty() {
-		return r, ErrSeriesAllDatapointsExpired
-	}
-
-	// In best case when explicitly asked to drain may have no
-	// stale buckets, cheaply check this case first with a Rlock
-	s.RLock()
-
-	needsDrain := s.buffer.NeedsDrain()
-	needsBlockUpdate := s.needsBlockUpdateWithLock()
-	r.ActiveBlocks = s.blocks.Len()
-
-	s.RUnlock()
-
-	if !needsDrain && !needsBlockUpdate {
-		return r, nil
-	}
 
 	s.Lock()
 
 	// NB(r): don't bother to check if needs drain or needs
-	// block update still holds as running both these checks
+	// block update as running both these checks
 	// are relatively expensive and running these methods
-	// will be a no-op in case conditions no longer hold.
-	if needsDrain {
-		s.buffer.DrainAndReset()
-	}
+	// will be a no-op in case where work is not needed to be done.
+	drain := s.buffer.DrainAndReset()
+	r.MergedOutOfOrderBlocks = drain.mergedOutOfOrderBlocks
 
-	if needsBlockUpdate {
-		updateResult := s.updateBlocksWithLock()
-		r.ExpiredBlocks = updateResult.expired
-		r.ResetRetrievableBlocks = updateResult.resetRetrievable
-	}
-
-	r.ActiveBlocks = s.blocks.Len()
+	update := s.updateBlocksWithLock()
+	r.TickStatus = update.TickStatus
+	r.MadeExpiredBlocks, r.MadeUnwiredBlocks =
+		update.madeExpiredBlocks, update.madeUnwiredBlocks
 
 	s.Unlock()
 
 	return r, nil
 }
 
-func (s *dbSeries) needsBlockUpdateWithLock() bool {
-	if s.blocks.Len() == 0 {
-		return false
-	}
-
-	now := s.opts.ClockOptions().NowFn()()
-	if s.shouldExpireAnyBlockData(now) {
-		return true
-	}
-
-	// If the earliest block is not within the retention period,
-	// we should expire the blocks.
-	minBlockStart := s.blocks.MinTime()
-	return s.shouldExpireBlockAt(now, minBlockStart)
-}
-
-func (s *dbSeries) shouldExpireAnyBlockData(now time.Time) bool {
-	retriever := s.blockRetriever
-	if retriever == nil {
-		return false
-	}
-
-	ropts := s.opts.RetentionOptions()
-	if !ropts.BlockDataExpiry() {
-		return false
-	}
-
-	cutoff := ropts.BlockDataExpiryAfterNotAccessedPeriod()
-	for start, block := range s.blocks.AllBlocks() {
-		if !block.IsRetrieved() {
-			continue
-		}
-		sinceLastAccessed := now.Sub(block.LastAccessTime())
-		if sinceLastAccessed >= cutoff &&
-			retriever.IsBlockRetrievable(start) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (s *dbSeries) shouldExpireBlockAt(now, blockStart time.Time) bool {
-	var cutoff time.Time
-	rops := s.opts.RetentionOptions()
-	if rops.ShortExpiry() {
-		// Some blocks of series is stored in disk only
-		cutoff = now.Add(-rops.ShortExpiryPeriod() - rops.BlockSize()).Truncate(rops.BlockSize())
-	} else {
-		// Everything for the retention period is kept in mem
-		cutoff = now.Add(-rops.RetentionPeriod()).Truncate(rops.BlockSize())
-	}
-
-	return blockStart.Before(cutoff)
+type updateBlocksResult struct {
+	TickStatus
+	madeExpiredBlocks int
+	madeUnwiredBlocks int
 }
 
 func (s *dbSeries) updateBlocksWithLock() updateBlocksResult {
 	var (
-		r         updateBlocksResult
-		now       = s.opts.ClockOptions().NowFn()()
-		allBlocks = s.blocks.AllBlocks()
-
-		retriever       = s.blockRetriever
-		ropts           = s.opts.RetentionOptions()
-		dataExpiry      = ropts.BlockDataExpiry()
-		dataCutoff      = ropts.BlockDataExpiryAfterNotAccessedPeriod()
-		makeRetrievable = retriever != nil && dataExpiry
+		result       updateBlocksResult
+		now          = s.opts.ClockOptions().NowFn()()
+		ropts        = s.opts.RetentionOptions()
+		retriever    = s.blockRetriever
+		checkUnwire  = retriever != nil && ropts.BlockDataExpiry()
+		expireCutoff = now.Add(-ropts.RetentionPeriod()).Truncate(ropts.BlockSize())
+		wiredTimeout = ropts.BlockDataExpiryAfterNotAccessedPeriod()
 	)
-	for start, currBlock := range allBlocks {
-		if s.shouldExpireBlockAt(now, start) {
+	for start, currBlock := range s.blocks.AllBlocks() {
+		if start.Before(expireCutoff) {
 			s.blocks.RemoveBlockAt(start)
 			currBlock.Close()
-			r.expired++
+			result.madeExpiredBlocks++
 			continue
 		}
-		if makeRetrievable && currBlock.IsRetrieved() {
+
+		result.ActiveBlocks++
+
+		if !currBlock.IsRetrieved() {
+			result.UnwiredBlocks++
+			continue
+		}
+
+		var unwired bool
+		if checkUnwire {
 			sinceLastAccessed := now.Sub(currBlock.LastAccessTime())
-			if sinceLastAccessed >= dataCutoff &&
+			if sinceLastAccessed >= wiredTimeout &&
 				retriever.IsBlockRetrievable(start) {
 				// NB(r): Each block needs shared ref to the series ID
 				// or else each block needs to have a copy of the ID
@@ -248,11 +179,24 @@ func (s *dbSeries) updateBlocksWithLock() updateBlocksResult {
 					Checksum: currBlock.Checksum(),
 				}
 				currBlock.ResetRetrievable(start, retriever, metadata)
-				r.resetRetrievable++
+
+				unwired = true
+				result.madeUnwiredBlocks++
 			}
 		}
+		if unwired {
+			result.UnwiredBlocks++
+		} else {
+			result.WiredBlocks++
+		}
 	}
-	return r
+
+	bufferStats := s.buffer.Stats()
+	result.ActiveBlocks += bufferStats.wiredBlocks
+	result.WiredBlocks += bufferStats.wiredBlocks
+	result.OpenBlocks += bufferStats.openBlocks
+
+	return result
 }
 
 func (s *dbSeries) IsEmpty() bool {

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -131,6 +131,9 @@ func (s *dbSeries) Tick() (TickResult, error) {
 
 	s.Unlock()
 
+	if update.ActiveBlocks == 0 {
+		return r, ErrSeriesAllDatapointsExpired
+	}
 	return r, nil
 }
 

--- a/storage/series/types.go
+++ b/storage/series/types.go
@@ -102,11 +102,27 @@ type QueryableBlockRetriever interface {
 	IsBlockRetrievable(blockStart time.Time) bool
 }
 
+// TickStatus is the status of a series for a given tick
+type TickStatus struct {
+	// ActiveBlocks is the number of total active blocks
+	ActiveBlocks int
+	// OpenBlocks is the number of blocks actively mutable can be written to
+	OpenBlocks int
+	// WiredBlocks is the number of blocks wired in memory (all data kept)
+	WiredBlocks int
+	// UnwiredBlocks is the number of blocks unwired (data kept on disk)
+	UnwiredBlocks int
+}
+
 // TickResult is a set of results from a tick
 type TickResult struct {
-	ActiveBlocks           int
-	ExpiredBlocks          int
-	ResetRetrievableBlocks int
+	TickStatus
+	// MadeExpiredBlocks is count of blocks just expired
+	MadeExpiredBlocks int
+	// MadeUnwiredBlocks is count of blocks just unwired from memory
+	MadeUnwiredBlocks int
+	// MergedOutOfOrderBlocks is count of blocks merged from out of order streams
+	MergedOutOfOrderBlocks int
 }
 
 // DatabaseSeriesAllocate allocates a database series for a pool

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -381,8 +381,12 @@ func (s *dbShard) tickAndExpire(
 			}
 		}
 		r.activeBlocks += result.ActiveBlocks
-		r.resetRetrievableBlocks += result.ResetRetrievableBlocks
-		r.expiredBlocks += result.ExpiredBlocks
+		r.openBlocks += result.OpenBlocks
+		r.wiredBlocks += result.WiredBlocks
+		r.unwiredBlocks += result.UnwiredBlocks
+		r.madeExpiredBlocks += result.MadeExpiredBlocks
+		r.madeUnwiredBlocks += result.MadeUnwiredBlocks
+		r.mergedOutOfOrderBlocks += result.MergedOutOfOrderBlocks
 		i++
 		// Continue
 		return true

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -311,7 +311,9 @@ func (s *dbShard) Close() error {
 	// GC is not placed all at one time.  If the deadline is too low and still
 	// causes the GC to impact performance when closing shards the deadline
 	// should be increased.
-	s.tickAndExpire(context.NewNoOpCanncellable(), s.opts.RetentionOptions().BufferDrain(), tickPolicyForceExpiry)
+	cancellable := context.NewNoOpCanncellable()
+	softDeadline := s.opts.RetentionOptions().BufferDrain()
+	s.tickAndExpire(cancellable, softDeadline, tickPolicyForceExpiry)
 
 	return nil
 }


### PR DESCRIPTION
This change adds metrics for wired, unwired, open and made unwired blocks.  This will help us choose correct sizes for our wired blocks LRU list.

There is also a small amount of refactoring to reduce the number of loops when looping series blocks during a tick, and also some further allocation avoidance in the inner loops inside the buffer.

Short expiry is also being removed as it's not used in preference for block data expiry.

cc @xichen2020 @cw9 @kobolog @prateek 