### PR TITLE
Add ability to read last read time from block

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -101,3 +101,9 @@ func (c *client) NewAdminSession() (AdminSession, error) {
 func (c *client) DefaultAdminSession() (AdminSession, error) {
 	return c.defaultSession()
 }
+
+func (c *client) DefaultSessionActive() bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.session != nil
+}

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -36,9 +36,9 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
-	time "github.com/m3db/m3x/time"
+	time0 "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time0 "time"
+	time "time"
 )
 
 // Mock of Client interface
@@ -105,7 +105,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,7 +115,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -126,7 +126,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -349,7 +349,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,7 +359,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -370,7 +370,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -433,7 +433,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -444,7 +444,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -487,7 +487,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -497,7 +497,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -508,7 +508,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -571,7 +571,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -582,7 +582,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1083,7 +1083,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1093,9 +1093,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1103,7 +1103,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1113,9 +1113,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1143,7 +1143,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1153,9 +1153,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1163,7 +1163,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1173,9 +1173,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1183,7 +1183,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1193,9 +1193,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1203,7 +1203,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1213,9 +1213,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1223,7 +1223,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1233,9 +1233,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1243,7 +1243,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1253,9 +1253,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1263,7 +1263,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1273,9 +1273,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1463,7 +1463,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1473,9 +1473,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1804,7 +1804,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1814,9 +1814,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1824,7 +1824,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1834,9 +1834,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1864,7 +1864,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1874,9 +1874,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1884,7 +1884,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1894,9 +1894,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1904,7 +1904,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1914,9 +1914,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1924,7 +1924,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1934,9 +1934,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1944,7 +1944,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1954,9 +1954,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1964,7 +1964,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1974,9 +1974,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1984,7 +1984,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1994,9 +1994,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2184,7 +2184,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2194,9 +2194,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2384,7 +2384,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2394,9 +2394,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -2404,7 +2404,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2414,9 +2414,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -36,9 +36,9 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
 	tchannel_go "github.com/uber/tchannel-go"
-	time "time"
+	time0 "time"
 )
 
 // Mock of Client interface
@@ -84,6 +84,16 @@ func (_mr *_MockClientRecorder) DefaultSession() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DefaultSession")
 }
 
+func (_m *MockClient) DefaultSessionActive() bool {
+	ret := _m.ctrl.Call(_m, "DefaultSessionActive")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) DefaultSessionActive() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DefaultSessionActive")
+}
+
 // Mock of Session interface
 type MockSession struct {
 	ctrl     *gomock.Controller
@@ -105,7 +115,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,7 +125,7 @@ func (_mr *_MockSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -126,7 +136,7 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -199,6 +209,16 @@ func (_m *MockAdminClient) DefaultSession() (Session, error) {
 
 func (_mr *_MockAdminClientRecorder) DefaultSession() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DefaultSession")
+}
+
+func (_m *MockAdminClient) DefaultSessionActive() bool {
+	ret := _m.ctrl.Call(_m, "DefaultSessionActive")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockAdminClientRecorder) DefaultSessionActive() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DefaultSessionActive")
 }
 
 func (_m *MockAdminClient) NewAdminSession() (AdminSession, error) {
@@ -349,7 +369,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,7 +379,7 @@ func (_mr *_MockAdminSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -370,7 +390,7 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -433,7 +453,7 @@ func (_mr *_MockAdminSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockAdminSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -444,7 +464,7 @@ func (_mr *_MockAdminSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockAdminSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -487,7 +507,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace string, id string, t time0.Time, value float64, unit time.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -497,7 +517,7 @@ func (_mr *_MockclientSessionRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -508,7 +528,7 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time0.Time, endExclusive time0.Time) (encoding.SeriesIterators, error) {
 	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
@@ -571,7 +591,7 @@ func (_mr *_MockclientSessionRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time) (PeerBlocksMetadataIter, error) {
+func (_m *MockclientSession) FetchBlocksMetadataFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time) (PeerBlocksMetadataIter, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadataFromPeers", namespace, shard, start, end)
 	ret0, _ := ret[0].(PeerBlocksMetadataIter)
 	ret1, _ := ret[1].(error)
@@ -582,7 +602,7 @@ func (_mr *_MockclientSessionRecorder) FetchBlocksMetadataFromPeers(arg0, arg1, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadataFromPeers", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time.Time, end time.Time, opts result.Options) (result.ShardResult, error) {
+func (_m *MockclientSession) FetchBootstrapBlocksFromPeers(namespace ts.ID, shard uint32, start time0.Time, end time0.Time, opts result.Options) (result.ShardResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBootstrapBlocksFromPeers", namespace, shard, start, end, opts)
 	ret0, _ := ret[0].(result.ShardResult)
 	ret1, _ := ret[1].(error)
@@ -1083,7 +1103,7 @@ func (_mr *_MockOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1093,9 +1113,9 @@ func (_mr *_MockOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) HostConnectTimeout() time.Duration {
+func (_m *MockOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1103,7 +1123,7 @@ func (_mr *_MockOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1113,9 +1133,9 @@ func (_mr *_MockOptionsRecorder) SetClusterConnectTimeout(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1143,7 +1163,7 @@ func (_mr *_MockOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1153,9 +1173,9 @@ func (_mr *_MockOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1163,7 +1183,7 @@ func (_mr *_MockOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1173,9 +1193,9 @@ func (_mr *_MockOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1183,7 +1203,7 @@ func (_mr *_MockOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1193,9 +1213,9 @@ func (_mr *_MockOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1203,7 +1223,7 @@ func (_mr *_MockOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1213,9 +1233,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1223,7 +1243,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1233,9 +1253,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundConnectStutter(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1243,7 +1263,7 @@ func (_mr *_MockOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1253,9 +1273,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1263,7 +1283,7 @@ func (_mr *_MockOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1273,9 +1293,9 @@ func (_mr *_MockOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1463,7 +1483,7 @@ func (_mr *_MockOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1473,9 +1493,9 @@ func (_mr *_MockOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1804,7 +1824,7 @@ func (_mr *_MockAdminOptionsRecorder) MinConnectionCount() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MinConnectionCount")
 }
 
-func (_m *MockAdminOptions) SetHostConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1814,9 +1834,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostConnectTimeout(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) HostConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) HostConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1824,7 +1844,7 @@ func (_mr *_MockAdminOptionsRecorder) HostConnectTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostConnectTimeout")
 }
 
-func (_m *MockAdminOptions) SetClusterConnectTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetClusterConnectTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetClusterConnectTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1834,9 +1854,9 @@ func (_mr *_MockAdminOptionsRecorder) SetClusterConnectTimeout(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetClusterConnectTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) ClusterConnectTimeout() time.Duration {
+func (_m *MockAdminOptions) ClusterConnectTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "ClusterConnectTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1864,7 +1884,7 @@ func (_mr *_MockAdminOptionsRecorder) ClusterConnectConsistencyLevel() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClusterConnectConsistencyLevel")
 }
 
-func (_m *MockAdminOptions) SetWriteRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetWriteRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetWriteRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1874,9 +1894,9 @@ func (_mr *_MockAdminOptionsRecorder) SetWriteRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriteRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) WriteRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) WriteRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "WriteRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1884,7 +1904,7 @@ func (_mr *_MockAdminOptionsRecorder) WriteRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetFetchRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetFetchRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1894,9 +1914,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchRequestTimeout(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1904,7 +1924,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time.Duration) Options {
+func (_m *MockAdminOptions) SetTruncateRequestTimeout(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTruncateRequestTimeout", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1914,9 +1934,9 @@ func (_mr *_MockAdminOptionsRecorder) SetTruncateRequestTimeout(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTruncateRequestTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) TruncateRequestTimeout() time.Duration {
+func (_m *MockAdminOptions) TruncateRequestTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "TruncateRequestTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1924,7 +1944,7 @@ func (_mr *_MockAdminOptionsRecorder) TruncateRequestTimeout() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateRequestTimeout")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1934,9 +1954,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1944,7 +1964,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectInterval() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundConnectStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundConnectStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1954,9 +1974,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundConnectStutter(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundConnectStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundConnectStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundConnectStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundConnectStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1964,7 +1984,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundConnectStutter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundConnectStutter")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1974,9 +1994,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckInterval(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckInterval", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -1984,7 +2004,7 @@ func (_mr *_MockAdminOptionsRecorder) BackgroundHealthCheckInterval() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BackgroundHealthCheckInterval")
 }
 
-func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time.Duration) Options {
+func (_m *MockAdminOptions) SetBackgroundHealthCheckStutter(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetBackgroundHealthCheckStutter", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1994,9 +2014,9 @@ func (_mr *_MockAdminOptionsRecorder) SetBackgroundHealthCheckStutter(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBackgroundHealthCheckStutter", arg0)
 }
 
-func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time.Duration {
+func (_m *MockAdminOptions) BackgroundHealthCheckStutter() time0.Duration {
 	ret := _m.ctrl.Call(_m, "BackgroundHealthCheckStutter")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2184,7 +2204,7 @@ func (_mr *_MockAdminOptionsRecorder) HostQueueOpsFlushSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HostQueueOpsFlushSize")
 }
 
-func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time.Duration) Options {
+func (_m *MockAdminOptions) SetHostQueueOpsFlushInterval(value time0.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetHostQueueOpsFlushInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -2194,9 +2214,9 @@ func (_mr *_MockAdminOptionsRecorder) SetHostQueueOpsFlushInterval(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetHostQueueOpsFlushInterval", arg0)
 }
 
-func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time.Duration {
+func (_m *MockAdminOptions) HostQueueOpsFlushInterval() time0.Duration {
 	ret := _m.ctrl.Call(_m, "HostQueueOpsFlushInterval")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2384,7 +2404,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksBatchSize() *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksBatchSize")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksMetadataBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksMetadataBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2394,9 +2414,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksMetadataBatchTimeout(a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksMetadataBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksMetadataBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksMetadataBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 
@@ -2404,7 +2424,7 @@ func (_mr *_MockAdminOptionsRecorder) FetchSeriesBlocksMetadataBatchTimeout() *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchSeriesBlocksMetadataBatchTimeout")
 }
 
-func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time.Duration) AdminOptions {
+func (_m *MockAdminOptions) SetFetchSeriesBlocksBatchTimeout(value time0.Duration) AdminOptions {
 	ret := _m.ctrl.Call(_m, "SetFetchSeriesBlocksBatchTimeout", value)
 	ret0, _ := ret[0].(AdminOptions)
 	return ret0
@@ -2414,9 +2434,9 @@ func (_mr *_MockAdminOptionsRecorder) SetFetchSeriesBlocksBatchTimeout(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFetchSeriesBlocksBatchTimeout", arg0)
 }
 
-func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time.Duration {
+func (_m *MockAdminOptions) FetchSeriesBlocksBatchTimeout() time0.Duration {
 	ret := _m.ctrl.Call(_m, "FetchSeriesBlocksBatchTimeout")
-	ret0, _ := ret[0].(time.Duration)
+	ret0, _ := ret[0].(time0.Duration)
 	return ret0
 }
 

--- a/client/host_queue_test.go
+++ b/client/host_queue_test.go
@@ -691,9 +691,9 @@ func testWriteOp(
 	w.namespace = ts.StringID(namespace)
 	w.request.ID = []byte(id)
 	w.request.Datapoint = &rpc.Datapoint{
-		Value:         value,
-		Timestamp:     timestamp,
-		TimestampType: timeType,
+		Value:             value,
+		Timestamp:         timestamp,
+		TimestampTimeType: timeType,
 	}
 	w.completionFn = completionFn
 	return w

--- a/client/session_fetch_metadata_test.go
+++ b/client/session_fetch_metadata_test.go
@@ -49,16 +49,17 @@ func TestPeerBlocksMetadataIter(t *testing.T) {
 	peer := newHostQueue(h, nil, nil, opts)
 	now := time.Now()
 	checksums := []uint32{1, 2, 3}
+	lastRead := now.Add(-100 * time.Millisecond)
 	inputs := []blocksMetadata{
 		{peer: peer, id: ts.StringID("foo"), blocks: []blockMetadata{
 			{start: now, size: int64(1), checksum: &checksums[0]},
-			{start: now.Add(time.Second), size: int64(2), checksum: &checksums[1]},
+			{start: now.Add(time.Second), size: int64(2), checksum: &checksums[1], lastRead: lastRead},
 		}},
 		{peer: peer, id: ts.StringID("bar"), blocks: []blockMetadata{
-			{start: now, size: int64(3), checksum: &checksums[2]},
+			{start: now, size: int64(3), checksum: &checksums[2], lastRead: lastRead},
 		}},
 		{peer: peer, id: ts.StringID("baz"), blocks: []blockMetadata{
-			{start: now, size: int64(4), checksum: nil},
+			{start: now, size: int64(4), checksum: nil, lastRead: lastRead},
 		}},
 	}
 
@@ -76,7 +77,7 @@ func TestPeerBlocksMetadataIter(t *testing.T) {
 		host, blocks := it.Current()
 		var m []block.Metadata
 		for _, b := range blocks.Blocks {
-			m = append(m, block.NewMetadata(b.Start, b.Size, b.Checksum))
+			m = append(m, block.NewMetadata(b.Start, b.Size, b.Checksum, b.LastRead))
 		}
 		actualBlocks := block.NewBlocksMetadata(blocks.ID, m)
 		actual = append(actual, testHostBlocks{host, actualBlocks})
@@ -84,14 +85,18 @@ func TestPeerBlocksMetadataIter(t *testing.T) {
 
 	expected := []testHostBlocks{
 		{h, block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{
-			block.NewMetadata(inputs[0].blocks[0].start, inputs[0].blocks[0].size, inputs[0].blocks[0].checksum),
-			block.NewMetadata(inputs[0].blocks[1].start, inputs[0].blocks[1].size, inputs[0].blocks[1].checksum),
+			block.NewMetadata(inputs[0].blocks[0].start, inputs[0].blocks[0].size,
+				inputs[0].blocks[0].checksum, inputs[0].blocks[0].lastRead),
+			block.NewMetadata(inputs[0].blocks[1].start, inputs[0].blocks[1].size,
+				inputs[0].blocks[1].checksum, inputs[0].blocks[1].lastRead),
 		})},
 		{h, block.NewBlocksMetadata(ts.StringID("bar"), []block.Metadata{
-			block.NewMetadata(inputs[1].blocks[0].start, inputs[1].blocks[0].size, inputs[1].blocks[0].checksum),
+			block.NewMetadata(inputs[1].blocks[0].start, inputs[1].blocks[0].size,
+				inputs[1].blocks[0].checksum, inputs[1].blocks[0].lastRead),
 		})},
 		{h, block.NewBlocksMetadata(ts.StringID("baz"), []block.Metadata{
-			block.NewMetadata(inputs[2].blocks[0].start, inputs[2].blocks[0].size, inputs[2].blocks[0].checksum),
+			block.NewMetadata(inputs[2].blocks[0].start, inputs[2].blocks[0].size,
+				inputs[2].blocks[0].checksum, inputs[2].blocks[0].lastRead),
 		})},
 	}
 

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -66,7 +66,7 @@ func TestSessionWrite(t *testing.T) {
 		assert.Equal(t, w.id, string(write.request.ID))
 		assert.Equal(t, w.value, write.request.Datapoint.Value)
 		assert.Equal(t, w.t.Unix(), write.request.Datapoint.Timestamp)
-		assert.Equal(t, rpc.TimeType_UNIX_SECONDS, write.request.Datapoint.TimestampType)
+		assert.Equal(t, rpc.TimeType_UNIX_SECONDS, write.request.Datapoint.TimestampTimeType)
 		assert.NotNil(t, write.completionFn)
 	}})
 

--- a/client/types.go
+++ b/client/types.go
@@ -118,6 +118,9 @@ type Client interface {
 
 	// DefaultSession creates a default session that gets reused
 	DefaultSession() (Session, error)
+
+	// DefaultSessionActive returns whether the default session is active
+	DefaultSessionActive() bool
 }
 
 // Session can write and read to a cluster

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -26,12 +26,12 @@ package encoding
 import (
 	gomock "github.com/golang/mock/gomock"
 	ts "github.com/m3db/m3db/ts"
-	io0 "github.com/m3db/m3db/x/io"
+	io "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
-	time0 "github.com/m3db/m3x/time"
-	io "io"
-	time "time"
+	time "github.com/m3db/m3x/time"
+	io0 "io"
+	time0 "time"
 )
 
 // Mock of Encoder interface
@@ -55,7 +55,7 @@ func (_m *MockEncoder) EXPECT() *_MockEncoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time0.Unit, annotation ts.Annotation) error {
+func (_m *MockEncoder) Encode(dp ts.Datapoint, unit time.Unit, annotation ts.Annotation) error {
 	ret := _m.ctrl.Call(_m, "Encode", dp, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -65,9 +65,9 @@ func (_mr *_MockEncoderRecorder) Encode(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Encode", arg0, arg1, arg2)
 }
 
-func (_m *MockEncoder) Stream() io0.SegmentReader {
+func (_m *MockEncoder) Stream() io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "Stream")
-	ret0, _ := ret[0].(io0.SegmentReader)
+	ret0, _ := ret[0].(io.SegmentReader)
 	return ret0
 }
 
@@ -85,7 +85,7 @@ func (_mr *_MockEncoderRecorder) StreamLen() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StreamLen")
 }
 
-func (_m *MockEncoder) Reset(t time.Time, capacity int) {
+func (_m *MockEncoder) Reset(t time0.Time, capacity int) {
 	_m.ctrl.Call(_m, "Reset", t, capacity)
 }
 
@@ -111,7 +111,7 @@ func (_mr *_MockEncoderRecorder) Discard() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Discard")
 }
 
-func (_m *MockEncoder) DiscardReset(t time.Time, capacity int) ts.Segment {
+func (_m *MockEncoder) DiscardReset(t time0.Time, capacity int) ts.Segment {
 	ret := _m.ctrl.Call(_m, "DiscardReset", t, capacity)
 	ret0, _ := ret[0].(ts.Segment)
 	return ret0
@@ -142,7 +142,7 @@ func (_m *MockOptions) EXPECT() *_MockOptionsRecorder {
 	return _m.recorder
 }
 
-func (_m *MockOptions) SetDefaultTimeUnit(tu time0.Unit) Options {
+func (_m *MockOptions) SetDefaultTimeUnit(tu time.Unit) Options {
 	ret := _m.ctrl.Call(_m, "SetDefaultTimeUnit", tu)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -152,9 +152,9 @@ func (_mr *_MockOptionsRecorder) SetDefaultTimeUnit(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultTimeUnit", arg0)
 }
 
-func (_m *MockOptions) DefaultTimeUnit() time0.Unit {
+func (_m *MockOptions) DefaultTimeUnit() time.Unit {
 	ret := _m.ctrl.Call(_m, "DefaultTimeUnit")
-	ret0, _ := ret[0].(time0.Unit)
+	ret0, _ := ret[0].(time.Unit)
 	return ret0
 }
 
@@ -262,7 +262,7 @@ func (_mr *_MockOptionsRecorder) BytesPool() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BytesPool")
 }
 
-func (_m *MockOptions) SetSegmentReaderPool(value io0.SegmentReaderPool) Options {
+func (_m *MockOptions) SetSegmentReaderPool(value io.SegmentReaderPool) Options {
 	ret := _m.ctrl.Call(_m, "SetSegmentReaderPool", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -272,9 +272,9 @@ func (_mr *_MockOptionsRecorder) SetSegmentReaderPool(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSegmentReaderPool", arg0)
 }
 
-func (_m *MockOptions) SegmentReaderPool() io0.SegmentReaderPool {
+func (_m *MockOptions) SegmentReaderPool() io.SegmentReaderPool {
 	ret := _m.ctrl.Call(_m, "SegmentReaderPool")
-	ret0, _ := ret[0].(io0.SegmentReaderPool)
+	ret0, _ := ret[0].(io.SegmentReaderPool)
 	return ret0
 }
 
@@ -313,10 +313,10 @@ func (_mr *_MockIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -374,10 +374,10 @@ func (_mr *_MockReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -404,7 +404,7 @@ func (_mr *_MockReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockReaderIterator) Reset(reader io.Reader) {
+func (_m *MockReaderIterator) Reset(reader io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", reader)
 }
 
@@ -443,10 +443,10 @@ func (_mr *_MockMultiReaderIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockMultiReaderIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -473,7 +473,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockMultiReaderIterator) Reset(readers []io.Reader) {
+func (_m *MockMultiReaderIterator) Reset(readers []io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", readers)
 }
 
@@ -481,7 +481,7 @@ func (_mr *_MockMultiReaderIteratorRecorder) Reset(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0)
 }
 
-func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io0.ReaderSliceOfSlicesIterator) {
+func (_m *MockMultiReaderIterator) ResetSliceOfSlices(readers io.ReaderSliceOfSlicesIterator) {
 	_m.ctrl.Call(_m, "ResetSliceOfSlices", readers)
 }
 
@@ -520,10 +520,10 @@ func (_mr *_MockSeriesIteratorRecorder) Next() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Next")
 }
 
-func (_m *MockSeriesIterator) Current() (ts.Datapoint, time0.Unit, ts.Annotation) {
+func (_m *MockSeriesIterator) Current() (ts.Datapoint, time.Unit, ts.Annotation) {
 	ret := _m.ctrl.Call(_m, "Current")
 	ret0, _ := ret[0].(ts.Datapoint)
-	ret1, _ := ret[1].(time0.Unit)
+	ret1, _ := ret[1].(time.Unit)
 	ret2, _ := ret[2].(ts.Annotation)
 	return ret0, ret1, ret2
 }
@@ -560,9 +560,9 @@ func (_mr *_MockSeriesIteratorRecorder) ID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ID")
 }
 
-func (_m *MockSeriesIterator) Start() time.Time {
+func (_m *MockSeriesIterator) Start() time0.Time {
 	ret := _m.ctrl.Call(_m, "Start")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -570,9 +570,9 @@ func (_mr *_MockSeriesIteratorRecorder) Start() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Start")
 }
 
-func (_m *MockSeriesIterator) End() time.Time {
+func (_m *MockSeriesIterator) End() time0.Time {
 	ret := _m.ctrl.Call(_m, "End")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(time0.Time)
 	return ret0
 }
 
@@ -580,7 +580,7 @@ func (_mr *_MockSeriesIteratorRecorder) End() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "End")
 }
 
-func (_m *MockSeriesIterator) Reset(id string, startInclusive time.Time, endExclusive time.Time, replicas []Iterator) {
+func (_m *MockSeriesIterator) Reset(id string, startInclusive time0.Time, endExclusive time0.Time, replicas []Iterator) {
 	_m.ctrl.Call(_m, "Reset", id, startInclusive, endExclusive, replicas)
 }
 
@@ -733,7 +733,7 @@ func (_m *MockDecoder) EXPECT() *_MockDecoderRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDecoder) Decode(reader io.Reader) ReaderIterator {
+func (_m *MockDecoder) Decode(reader io0.Reader) ReaderIterator {
 	ret := _m.ctrl.Call(_m, "Decode", reader)
 	ret0, _ := ret[0].(ReaderIterator)
 	return ret0
@@ -808,7 +808,7 @@ func (_mr *_MockIStreamRecorder) PeekBits(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PeekBits", arg0)
 }
 
-func (_m *MockIStream) Reset(r io.Reader) {
+func (_m *MockIStream) Reset(r io0.Reader) {
 	_m.ctrl.Call(_m, "Reset", r)
 }
 

--- a/generated/thrift/rpc.thrift
+++ b/generated/thrift/rpc.thrift
@@ -79,7 +79,7 @@ struct Datapoint {
 	1: required i64 timestamp
 	2: required double value
 	3: optional binary annotation
-	4: optional TimeType timestampType = TimeType.UNIX_SECONDS
+	4: optional TimeType timestampTimeType = TimeType.UNIX_SECONDS
 }
 
 struct WriteRequest {
@@ -93,7 +93,7 @@ struct FetchBatchRawRequest {
 	2: required i64 rangeEnd
 	3: required binary nameSpace
 	4: required list<binary> ids
-	5: optional TimeType rangeType = TimeType.UNIX_SECONDS
+	5: optional TimeType rangeTimeType = TimeType.UNIX_SECONDS
 }
 
 struct FetchBatchRawResult {
@@ -151,6 +151,7 @@ struct FetchBlocksMetadataRawRequest {
 	6: optional i64 pageToken
 	7: optional bool includeSizes
 	8: optional bool includeChecksums
+	9: optional bool includeLastRead
 }
 
 struct FetchBlocksMetadataRawResult {
@@ -168,6 +169,8 @@ struct BlockMetadata {
 	2: required i64 start
 	3: optional i64 size
 	4: optional i64 checksum
+	5: optional i64 lastRead
+	6: optional TimeType lastReadTimeType = TimeType.UNIX_SECONDS
 }
 
 struct WriteBatchRawRequest {

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -802,7 +802,7 @@ func (p *FetchResult_) ReadField1(iprot thrift.TProtocol) error {
 	p.Datapoints = tSlice
 	for i := 0; i < size; i++ {
 		_elem1 := &Datapoint{
-			TimestampType: 0,
+			TimestampTimeType: 0,
 		}
 		if err := _elem1.Read(iprot); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem1), err)
@@ -865,17 +865,17 @@ func (p *FetchResult_) String() string {
 //  - Timestamp
 //  - Value
 //  - Annotation
-//  - TimestampType
+//  - TimestampTimeType
 type Datapoint struct {
-	Timestamp     int64    `thrift:"timestamp,1,required" db:"timestamp" json:"timestamp"`
-	Value         float64  `thrift:"value,2,required" db:"value" json:"value"`
-	Annotation    []byte   `thrift:"annotation,3" db:"annotation" json:"annotation,omitempty"`
-	TimestampType TimeType `thrift:"timestampType,4" db:"timestampType" json:"timestampType,omitempty"`
+	Timestamp         int64    `thrift:"timestamp,1,required" db:"timestamp" json:"timestamp"`
+	Value             float64  `thrift:"value,2,required" db:"value" json:"value"`
+	Annotation        []byte   `thrift:"annotation,3" db:"annotation" json:"annotation,omitempty"`
+	TimestampTimeType TimeType `thrift:"timestampTimeType,4" db:"timestampTimeType" json:"timestampTimeType,omitempty"`
 }
 
 func NewDatapoint() *Datapoint {
 	return &Datapoint{
-		TimestampType: 0,
+		TimestampTimeType: 0,
 	}
 }
 
@@ -893,17 +893,17 @@ func (p *Datapoint) GetAnnotation() []byte {
 	return p.Annotation
 }
 
-var Datapoint_TimestampType_DEFAULT TimeType = 0
+var Datapoint_TimestampTimeType_DEFAULT TimeType = 0
 
-func (p *Datapoint) GetTimestampType() TimeType {
-	return p.TimestampType
+func (p *Datapoint) GetTimestampTimeType() TimeType {
+	return p.TimestampTimeType
 }
 func (p *Datapoint) IsSetAnnotation() bool {
 	return p.Annotation != nil
 }
 
-func (p *Datapoint) IsSetTimestampType() bool {
-	return p.TimestampType != Datapoint_TimestampType_DEFAULT
+func (p *Datapoint) IsSetTimestampTimeType() bool {
+	return p.TimestampTimeType != Datapoint_TimestampTimeType_DEFAULT
 }
 
 func (p *Datapoint) Read(iprot thrift.TProtocol) error {
@@ -994,7 +994,7 @@ func (p *Datapoint) ReadField4(iprot thrift.TProtocol) error {
 		return thrift.PrependError("error reading field 4: ", err)
 	} else {
 		temp := TimeType(v)
-		p.TimestampType = temp
+		p.TimestampTimeType = temp
 	}
 	return nil
 }
@@ -1068,15 +1068,15 @@ func (p *Datapoint) writeField3(oprot thrift.TProtocol) (err error) {
 }
 
 func (p *Datapoint) writeField4(oprot thrift.TProtocol) (err error) {
-	if p.IsSetTimestampType() {
-		if err := oprot.WriteFieldBegin("timestampType", thrift.I32, 4); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:timestampType: ", p), err)
+	if p.IsSetTimestampTimeType() {
+		if err := oprot.WriteFieldBegin("timestampTimeType", thrift.I32, 4); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:timestampTimeType: ", p), err)
 		}
-		if err := oprot.WriteI32(int32(p.TimestampType)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T.timestampType (4) field write error: ", p), err)
+		if err := oprot.WriteI32(int32(p.TimestampTimeType)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.timestampTimeType (4) field write error: ", p), err)
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:timestampType: ", p), err)
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:timestampTimeType: ", p), err)
 		}
 	}
 	return err
@@ -1200,7 +1200,7 @@ func (p *WriteRequest) ReadField2(iprot thrift.TProtocol) error {
 
 func (p *WriteRequest) ReadField3(iprot thrift.TProtocol) error {
 	p.Datapoint = &Datapoint{
-		TimestampType: 0,
+		TimestampTimeType: 0,
 	}
 	if err := p.Datapoint.Read(iprot); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Datapoint), err)
@@ -1283,18 +1283,18 @@ func (p *WriteRequest) String() string {
 //  - RangeEnd
 //  - NameSpace
 //  - Ids
-//  - RangeType
+//  - RangeTimeType
 type FetchBatchRawRequest struct {
-	RangeStart int64    `thrift:"rangeStart,1,required" db:"rangeStart" json:"rangeStart"`
-	RangeEnd   int64    `thrift:"rangeEnd,2,required" db:"rangeEnd" json:"rangeEnd"`
-	NameSpace  []byte   `thrift:"nameSpace,3,required" db:"nameSpace" json:"nameSpace"`
-	Ids        [][]byte `thrift:"ids,4,required" db:"ids" json:"ids"`
-	RangeType  TimeType `thrift:"rangeType,5" db:"rangeType" json:"rangeType,omitempty"`
+	RangeStart    int64    `thrift:"rangeStart,1,required" db:"rangeStart" json:"rangeStart"`
+	RangeEnd      int64    `thrift:"rangeEnd,2,required" db:"rangeEnd" json:"rangeEnd"`
+	NameSpace     []byte   `thrift:"nameSpace,3,required" db:"nameSpace" json:"nameSpace"`
+	Ids           [][]byte `thrift:"ids,4,required" db:"ids" json:"ids"`
+	RangeTimeType TimeType `thrift:"rangeTimeType,5" db:"rangeTimeType" json:"rangeTimeType,omitempty"`
 }
 
 func NewFetchBatchRawRequest() *FetchBatchRawRequest {
 	return &FetchBatchRawRequest{
-		RangeType: 0,
+		RangeTimeType: 0,
 	}
 }
 
@@ -1314,13 +1314,13 @@ func (p *FetchBatchRawRequest) GetIds() [][]byte {
 	return p.Ids
 }
 
-var FetchBatchRawRequest_RangeType_DEFAULT TimeType = 0
+var FetchBatchRawRequest_RangeTimeType_DEFAULT TimeType = 0
 
-func (p *FetchBatchRawRequest) GetRangeType() TimeType {
-	return p.RangeType
+func (p *FetchBatchRawRequest) GetRangeTimeType() TimeType {
+	return p.RangeTimeType
 }
-func (p *FetchBatchRawRequest) IsSetRangeType() bool {
-	return p.RangeType != FetchBatchRawRequest_RangeType_DEFAULT
+func (p *FetchBatchRawRequest) IsSetRangeTimeType() bool {
+	return p.RangeTimeType != FetchBatchRawRequest_RangeTimeType_DEFAULT
 }
 
 func (p *FetchBatchRawRequest) Read(iprot thrift.TProtocol) error {
@@ -1447,7 +1447,7 @@ func (p *FetchBatchRawRequest) ReadField5(iprot thrift.TProtocol) error {
 		return thrift.PrependError("error reading field 5: ", err)
 	} else {
 		temp := TimeType(v)
-		p.RangeType = temp
+		p.RangeTimeType = temp
 	}
 	return nil
 }
@@ -1543,15 +1543,15 @@ func (p *FetchBatchRawRequest) writeField4(oprot thrift.TProtocol) (err error) {
 }
 
 func (p *FetchBatchRawRequest) writeField5(oprot thrift.TProtocol) (err error) {
-	if p.IsSetRangeType() {
-		if err := oprot.WriteFieldBegin("rangeType", thrift.I32, 5); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:rangeType: ", p), err)
+	if p.IsSetRangeTimeType() {
+		if err := oprot.WriteFieldBegin("rangeTimeType", thrift.I32, 5); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:rangeTimeType: ", p), err)
 		}
-		if err := oprot.WriteI32(int32(p.RangeType)); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T.rangeType (5) field write error: ", p), err)
+		if err := oprot.WriteI32(int32(p.RangeTimeType)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.rangeTimeType (5) field write error: ", p), err)
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:rangeType: ", p), err)
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:rangeTimeType: ", p), err)
 		}
 	}
 	return err
@@ -3031,6 +3031,7 @@ func (p *Block) String() string {
 //  - PageToken
 //  - IncludeSizes
 //  - IncludeChecksums
+//  - IncludeLastRead
 type FetchBlocksMetadataRawRequest struct {
 	NameSpace        []byte `thrift:"nameSpace,1,required" db:"nameSpace" json:"nameSpace"`
 	Shard            int32  `thrift:"shard,2,required" db:"shard" json:"shard"`
@@ -3040,6 +3041,7 @@ type FetchBlocksMetadataRawRequest struct {
 	PageToken        *int64 `thrift:"pageToken,6" db:"pageToken" json:"pageToken,omitempty"`
 	IncludeSizes     *bool  `thrift:"includeSizes,7" db:"includeSizes" json:"includeSizes,omitempty"`
 	IncludeChecksums *bool  `thrift:"includeChecksums,8" db:"includeChecksums" json:"includeChecksums,omitempty"`
+	IncludeLastRead  *bool  `thrift:"includeLastRead,9" db:"includeLastRead" json:"includeLastRead,omitempty"`
 }
 
 func NewFetchBlocksMetadataRawRequest() *FetchBlocksMetadataRawRequest {
@@ -3092,6 +3094,15 @@ func (p *FetchBlocksMetadataRawRequest) GetIncludeChecksums() bool {
 	}
 	return *p.IncludeChecksums
 }
+
+var FetchBlocksMetadataRawRequest_IncludeLastRead_DEFAULT bool
+
+func (p *FetchBlocksMetadataRawRequest) GetIncludeLastRead() bool {
+	if !p.IsSetIncludeLastRead() {
+		return FetchBlocksMetadataRawRequest_IncludeLastRead_DEFAULT
+	}
+	return *p.IncludeLastRead
+}
 func (p *FetchBlocksMetadataRawRequest) IsSetPageToken() bool {
 	return p.PageToken != nil
 }
@@ -3102,6 +3113,10 @@ func (p *FetchBlocksMetadataRawRequest) IsSetIncludeSizes() bool {
 
 func (p *FetchBlocksMetadataRawRequest) IsSetIncludeChecksums() bool {
 	return p.IncludeChecksums != nil
+}
+
+func (p *FetchBlocksMetadataRawRequest) IsSetIncludeLastRead() bool {
+	return p.IncludeLastRead != nil
 }
 
 func (p *FetchBlocksMetadataRawRequest) Read(iprot thrift.TProtocol) error {
@@ -3159,6 +3174,10 @@ func (p *FetchBlocksMetadataRawRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 8:
 			if err := p.ReadField8(iprot); err != nil {
+				return err
+			}
+		case 9:
+			if err := p.ReadField9(iprot); err != nil {
 				return err
 			}
 		default:
@@ -3263,6 +3282,15 @@ func (p *FetchBlocksMetadataRawRequest) ReadField8(iprot thrift.TProtocol) error
 	return nil
 }
 
+func (p *FetchBlocksMetadataRawRequest) ReadField9(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 9: ", err)
+	} else {
+		p.IncludeLastRead = &v
+	}
+	return nil
+}
+
 func (p *FetchBlocksMetadataRawRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("FetchBlocksMetadataRawRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -3290,6 +3318,9 @@ func (p *FetchBlocksMetadataRawRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField8(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField9(oprot); err != nil {
 			return err
 		}
 	}
@@ -3407,6 +3438,21 @@ func (p *FetchBlocksMetadataRawRequest) writeField8(oprot thrift.TProtocol) (err
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 8:includeChecksums: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *FetchBlocksMetadataRawRequest) writeField9(oprot thrift.TProtocol) (err error) {
+	if p.IsSetIncludeLastRead() {
+		if err := oprot.WriteFieldBegin("includeLastRead", thrift.BOOL, 9); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 9:includeLastRead: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.IncludeLastRead)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.includeLastRead (9) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 9:includeLastRead: ", p), err)
 		}
 	}
 	return err
@@ -3667,7 +3713,9 @@ func (p *BlocksMetadata) ReadField2(iprot thrift.TProtocol) error {
 	tSlice := make([]*BlockMetadata, 0, size)
 	p.Blocks = tSlice
 	for i := 0; i < size; i++ {
-		_elem11 := &BlockMetadata{}
+		_elem11 := &BlockMetadata{
+			LastReadTimeType: 0,
+		}
 		if err := _elem11.Read(iprot); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem11), err)
 		}
@@ -3746,15 +3794,21 @@ func (p *BlocksMetadata) String() string {
 //  - Start
 //  - Size
 //  - Checksum
+//  - LastRead
+//  - LastReadTimeType
 type BlockMetadata struct {
-	Err      *Error `thrift:"err,1" db:"err" json:"err,omitempty"`
-	Start    int64  `thrift:"start,2,required" db:"start" json:"start"`
-	Size     *int64 `thrift:"size,3" db:"size" json:"size,omitempty"`
-	Checksum *int64 `thrift:"checksum,4" db:"checksum" json:"checksum,omitempty"`
+	Err              *Error   `thrift:"err,1" db:"err" json:"err,omitempty"`
+	Start            int64    `thrift:"start,2,required" db:"start" json:"start"`
+	Size             *int64   `thrift:"size,3" db:"size" json:"size,omitempty"`
+	Checksum         *int64   `thrift:"checksum,4" db:"checksum" json:"checksum,omitempty"`
+	LastRead         *int64   `thrift:"lastRead,5" db:"lastRead" json:"lastRead,omitempty"`
+	LastReadTimeType TimeType `thrift:"lastReadTimeType,6" db:"lastReadTimeType" json:"lastReadTimeType,omitempty"`
 }
 
 func NewBlockMetadata() *BlockMetadata {
-	return &BlockMetadata{}
+	return &BlockMetadata{
+		LastReadTimeType: 0,
+	}
 }
 
 var BlockMetadata_Err_DEFAULT *Error
@@ -3787,6 +3841,21 @@ func (p *BlockMetadata) GetChecksum() int64 {
 	}
 	return *p.Checksum
 }
+
+var BlockMetadata_LastRead_DEFAULT int64
+
+func (p *BlockMetadata) GetLastRead() int64 {
+	if !p.IsSetLastRead() {
+		return BlockMetadata_LastRead_DEFAULT
+	}
+	return *p.LastRead
+}
+
+var BlockMetadata_LastReadTimeType_DEFAULT TimeType = 0
+
+func (p *BlockMetadata) GetLastReadTimeType() TimeType {
+	return p.LastReadTimeType
+}
 func (p *BlockMetadata) IsSetErr() bool {
 	return p.Err != nil
 }
@@ -3797,6 +3866,14 @@ func (p *BlockMetadata) IsSetSize() bool {
 
 func (p *BlockMetadata) IsSetChecksum() bool {
 	return p.Checksum != nil
+}
+
+func (p *BlockMetadata) IsSetLastRead() bool {
+	return p.LastRead != nil
+}
+
+func (p *BlockMetadata) IsSetLastReadTimeType() bool {
+	return p.LastReadTimeType != BlockMetadata_LastReadTimeType_DEFAULT
 }
 
 func (p *BlockMetadata) Read(iprot thrift.TProtocol) error {
@@ -3830,6 +3907,14 @@ func (p *BlockMetadata) Read(iprot thrift.TProtocol) error {
 			}
 		case 4:
 			if err := p.ReadField4(iprot); err != nil {
+				return err
+			}
+		case 5:
+			if err := p.ReadField5(iprot); err != nil {
+				return err
+			}
+		case 6:
+			if err := p.ReadField6(iprot); err != nil {
 				return err
 			}
 		default:
@@ -3887,6 +3972,25 @@ func (p *BlockMetadata) ReadField4(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *BlockMetadata) ReadField5(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(); err != nil {
+		return thrift.PrependError("error reading field 5: ", err)
+	} else {
+		p.LastRead = &v
+	}
+	return nil
+}
+
+func (p *BlockMetadata) ReadField6(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(); err != nil {
+		return thrift.PrependError("error reading field 6: ", err)
+	} else {
+		temp := TimeType(v)
+		p.LastReadTimeType = temp
+	}
+	return nil
+}
+
 func (p *BlockMetadata) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("BlockMetadata"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -3902,6 +4006,12 @@ func (p *BlockMetadata) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField4(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField5(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField6(oprot); err != nil {
 			return err
 		}
 	}
@@ -3967,6 +4077,36 @@ func (p *BlockMetadata) writeField4(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:checksum: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *BlockMetadata) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLastRead() {
+		if err := oprot.WriteFieldBegin("lastRead", thrift.I64, 5); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:lastRead: ", p), err)
+		}
+		if err := oprot.WriteI64(int64(*p.LastRead)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.lastRead (5) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:lastRead: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *BlockMetadata) writeField6(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLastReadTimeType() {
+		if err := oprot.WriteFieldBegin("lastReadTimeType", thrift.I32, 6); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:lastReadTimeType: ", p), err)
+		}
+		if err := oprot.WriteI32(int32(p.LastReadTimeType)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.lastReadTimeType (6) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:lastReadTimeType: ", p), err)
 		}
 	}
 	return err
@@ -4224,7 +4364,7 @@ func (p *WriteBatchRawRequestElement) ReadField1(iprot thrift.TProtocol) error {
 
 func (p *WriteBatchRawRequestElement) ReadField2(iprot thrift.TProtocol) error {
 	p.Datapoint = &Datapoint{
-		TimestampType: 0,
+		TimestampTimeType: 0,
 	}
 	if err := p.Datapoint.Read(iprot); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Datapoint), err)
@@ -7874,7 +8014,7 @@ func (p *NodeFetchBatchRawArgs) Read(iprot thrift.TProtocol) error {
 
 func (p *NodeFetchBatchRawArgs) ReadField1(iprot thrift.TProtocol) error {
 	p.Req = &FetchBatchRawRequest{
-		RangeType: 0,
+		RangeTimeType: 0,
 	}
 	if err := p.Req.Read(iprot); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)

--- a/integration/client.go
+++ b/integration/client.go
@@ -102,11 +102,10 @@ func m3dbClient(opts client.Options) (client.Client, error) {
 
 // m3dbClientWriteBatch writes a data map using an m3db client.
 func m3dbClientWriteBatch(client client.Client, workerPool xsync.WorkerPool, namespace ts.ID, seriesList seriesList) error {
-	session, err := client.NewSession()
+	session, err := client.DefaultSession()
 	if err != nil {
 		return err
 	}
-	defer session.Close()
 
 	var (
 		errCh = make(chan error, 1)
@@ -142,11 +141,10 @@ func m3dbClientWriteBatch(client client.Client, workerPool xsync.WorkerPool, nam
 
 // m3dbClientFetch fulfills a fetch request using an m3db client.
 func m3dbClientFetch(client client.Client, req *rpc.FetchRequest) ([]ts.Datapoint, error) {
-	session, err := client.NewSession()
+	session, err := client.DefaultSession()
 	if err != nil {
 		return nil, err
 	}
-	defer session.Close()
 
 	iter, err := session.Fetch(
 		req.NameSpace,
@@ -172,11 +170,10 @@ func m3dbClientFetch(client client.Client, req *rpc.FetchRequest) ([]ts.Datapoin
 
 // m3dbClientTruncate fulfills a truncation request using an m3db client.
 func m3dbClientTruncate(c client.Client, req *rpc.TruncateRequest) (int64, error) {
-	session, err := c.NewSession()
+	session, err := c.DefaultSession()
 	if err != nil {
 		return 0, err
 	}
-	defer session.Close()
 
 	adminSession, ok := session.(client.AdminSession)
 	if !ok {
@@ -192,11 +189,10 @@ func m3dbClientFetchBlocksMetadata(
 	shards []uint32,
 	start, end time.Time,
 ) (map[uint32][]block.ReplicaMetadata, error) {
-	session, err := c.NewAdminSession()
+	session, err := c.DefaultAdminSession()
 	if err != nil {
 		return nil, err
 	}
-	defer session.Close()
 
 	metadatasByShard := make(map[uint32][]block.ReplicaMetadata, 10)
 

--- a/integration/client.go
+++ b/integration/client.go
@@ -56,9 +56,9 @@ func tchannelClientWriteBatch(client rpc.TChanNode, timeout time.Duration, names
 			elem := &rpc.WriteBatchRawRequestElement{
 				ID: series.ID.Data().Get(),
 				Datapoint: &rpc.Datapoint{
-					Timestamp:     xtime.ToNormalizedTime(dp.Timestamp, time.Second),
-					Value:         dp.Value,
-					TimestampType: rpc.TimeType_UNIX_SECONDS,
+					Timestamp:         xtime.ToNormalizedTime(dp.Timestamp, time.Second),
+					Value:             dp.Value,
+					TimestampTimeType: rpc.TimeType_UNIX_SECONDS,
 				},
 			}
 			elems = append(elems, elem)

--- a/integration/last_read_after_peer_bootstrap_test.go
+++ b/integration/last_read_after_peer_bootstrap_test.go
@@ -1,0 +1,304 @@
+// +build integration
+
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/retention"
+	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/ts"
+	xlog "github.com/m3db/m3x/log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test ensures that only reads against a node causes last read
+// for a block to be updated.  Also ensures that bootstrapping from
+// a peer does not cause the blocks to look like they've been read,
+// there is a clear distinction between FetchBlocks API and a read.
+func TestLastReadAfterPeerBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow() // Just skip if we're doing a short run
+	}
+
+	// Test setups
+	log := xlog.SimpleLogger
+	namesp := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions())
+	opts := newTestOptions().
+		SetNamespaces([]namespace.Metadata{namesp})
+
+	retentionOpts := retention.NewOptions().
+		SetRetentionPeriod(8 * time.Hour).
+		SetBlockSize(2 * time.Hour).
+		SetBufferPast(10 * time.Minute).
+		SetBufferFuture(2 * time.Minute).
+		SetBufferDrain(time.Minute)
+	setupOpts := []bootstrappableTestSetupOptions{
+		{disablePeersBootstrapper: true},
+		{disablePeersBootstrapper: false},
+	}
+	setups, closeFn := newDefaultBootstrappableTestSetups(t, opts,
+		retentionOpts, setupOpts)
+	defer closeFn()
+
+	// Write test data for first node
+	now := setups[0].getNowFn() // now is already truncate to block size
+	blockSize := setups[0].storageOpts.RetentionOptions().BlockSize()
+	start, end := now.Add(-3*blockSize), now
+	seriesMaps := generateTestDataByStart([]testData{
+		{ids: []string{"foo", "bar"}, numPoints: 50, start: now.Add(-3 * blockSize)},
+		{ids: []string{"foo", "baz"}, numPoints: 50, start: now.Add(-2 * blockSize)},
+		{ids: []string{"foo", "qux"}, numPoints: 50, start: now.Add(-1 * blockSize)},
+	})
+	err := writeTestDataToDisk(t, namesp.ID(), setups[0], seriesMaps)
+	require.NoError(t, err)
+
+	// Start the first server with filesystem bootstrapper
+	require.NoError(t, setups[0].startServer())
+
+	// Start the last server with peers and filesystem bootstrappers
+	require.NoError(t, setups[1].startServer())
+	log.Debug("servers are now up")
+
+	// Stop the servers
+	defer func() {
+		log.Debug("servers shutting down")
+		setups.parallel(func(s *testSetup) {
+			require.NoError(t, s.stopServer())
+		})
+		log.Debug("servers are now down")
+	}()
+
+	// Verify no reads have occurred
+	log.Debug("verifying no blocks seem read yet")
+	setups.parallel(func(s *testSetup) {
+		verifyLastReads(t, s, namesp.ID(), start, end, lastReadState{})
+	})
+
+	// Issue initial reads
+	_, err = m3dbClientFetch(setups[0].m3dbClient, &rpc.FetchRequest{
+		RangeType:  rpc.TimeType_UNIX_SECONDS,
+		RangeStart: start.Unix(),
+		RangeEnd:   start.Add(2 * blockSize).Unix(),
+		NameSpace:  namesp.ID().String(),
+		ID:         "foo",
+	})
+	assert.NoError(t, err)
+
+	_, err = m3dbClientFetch(setups[1].m3dbClient, &rpc.FetchRequest{
+		RangeType:  rpc.TimeType_UNIX_SECONDS,
+		RangeStart: start.Unix(),
+		RangeEnd:   start.Add(2 * blockSize).Unix(),
+		NameSpace:  namesp.ID().String(),
+		ID:         "bar",
+	})
+	assert.NoError(t, err)
+
+	_, err = m3dbClientFetch(setups[1].m3dbClient, &rpc.FetchRequest{
+		RangeType:  rpc.TimeType_UNIX_SECONDS,
+		RangeStart: start.Add(1 * blockSize).Unix(),
+		RangeEnd:   start.Add(3 * blockSize).Unix(),
+		NameSpace:  namesp.ID().String(),
+		ID:         "baz",
+	})
+	assert.NoError(t, err)
+
+	// Move time forward a little
+	now = now.Add(5 * time.Minute)
+	for _, setup := range setups {
+		setup.setNowFn(now)
+	}
+
+	// Issue subsequent read
+	_, err = m3dbClientFetch(setups[0].m3dbClient, &rpc.FetchRequest{
+		RangeType:  rpc.TimeType_UNIX_SECONDS,
+		RangeStart: start.Add(1 * blockSize).Unix(),
+		RangeEnd:   start.Add(2 * blockSize).Unix(),
+		NameSpace:  namesp.ID().String(),
+		ID:         "foo",
+	})
+	assert.NoError(t, err)
+
+	// Verify last read times
+	log.Debug("verifying initial set of reads")
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		verifyLastReads(t, setups[0], namesp.ID(), start, end, lastReadState{
+			ids: map[string]lastReadIDState{
+				"foo": {blocks: map[time.Time]lastReadBlockState{
+					start: {lastRead: end},
+					start.Add(1 * blockSize): {lastRead: end.Add(5 * time.Minute)},
+				}},
+			},
+		})
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		verifyLastReads(t, setups[1], namesp.ID(), start, end, lastReadState{
+			ids: map[string]lastReadIDState{
+				"bar": {blocks: map[time.Time]lastReadBlockState{
+					start: {lastRead: end},
+				}},
+				"baz": {blocks: map[time.Time]lastReadBlockState{
+					start.Add(1 * blockSize): {lastRead: end},
+				}},
+			},
+		})
+	}()
+	wg.Wait()
+
+	// Move time forward a little again
+	now = now.Add(2 * time.Minute)
+	for _, setup := range setups {
+		setup.setNowFn(now)
+	}
+
+	// Verify in-memory data match what we expect before we finish,
+	// also updating last read time of all blocks
+	log.Debug("verifying series data matches")
+	setups.parallel(func(s *testSetup) {
+		verifySeriesMaps(t, s, namesp.ID(), seriesMaps)
+	})
+
+	// Verify last read times
+	log.Debug("verifying all reads")
+	allRead := lastReadState{ids: map[string]lastReadIDState{
+		"foo": lastReadIDState{blocks: map[time.Time]lastReadBlockState{
+			start: {lastRead: end.Add(7 * time.Minute)},
+			start.Add(1 * blockSize): {lastRead: end.Add(7 * time.Minute)},
+			start.Add(2 * blockSize): {lastRead: end.Add(7 * time.Minute)},
+		}},
+		"bar": lastReadIDState{blocks: map[time.Time]lastReadBlockState{
+			start: {lastRead: end.Add(7 * time.Minute)},
+		}},
+		"baz": lastReadIDState{blocks: map[time.Time]lastReadBlockState{
+			start.Add(1 * blockSize): {lastRead: end.Add(7 * time.Minute)},
+		}},
+		"qux": lastReadIDState{blocks: map[time.Time]lastReadBlockState{
+			start.Add(2 * blockSize): {lastRead: end.Add(7 * time.Minute)},
+		}},
+	}}
+
+	setups.parallel(func(s *testSetup) {
+		verifyLastReads(t, s, namesp.ID(), start, end, allRead)
+	})
+
+	log.Debug("done verification")
+}
+
+type lastReadState struct {
+	ids map[string]lastReadIDState
+}
+
+type lastReadIDState struct {
+	blocks map[time.Time]lastReadBlockState
+}
+
+type lastReadBlockState struct {
+	lastRead time.Time
+}
+
+func verifyLastReads(
+	t *testing.T,
+	setup *testSetup,
+	namespace ts.ID,
+	start, end time.Time,
+	expected lastReadState,
+) {
+	metadatas, err := m3dbClientFetchBlocksMetadata(setup.m3dbAdminClient,
+		namespace, setup.shardSet.AllIDs(), start, end)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	// Build actual results
+	actual := lastReadState{ids: map[string]lastReadIDState{}}
+	for _, shardMetadatas := range metadatas {
+		for _, metadata := range shardMetadatas {
+			if metadata.LastRead.IsZero() {
+				// Don't consider metadata where last read is zero
+				continue
+			}
+
+			assert.Equal(t, setup.hostID, metadata.Host.ID())
+
+			id := metadata.ID.String()
+			state := actual.ids[id]
+			if state.blocks == nil {
+				state.blocks = map[time.Time]lastReadBlockState{}
+			}
+
+			block := state.blocks[metadata.Start]
+			block.lastRead = metadata.LastRead
+			state.blocks[metadata.Start] = block
+
+			actual.ids[id] = state
+		}
+	}
+
+	// Compare to expected results
+	assert.Equal(t, len(expected.ids), len(actual.ids), fmt.Sprintf(
+		"expected results mismatch with actual IDs: expected=%d, actual=%d",
+		len(expected.ids), len(actual.ids)))
+	for id, expectBlocks := range expected.ids {
+		actualBlocks, ok := actual.ids[id]
+		assert.True(t, ok, fmt.Sprintf(
+			"no actual result for expected ID: id=%s", id))
+		if !ok {
+			continue
+		}
+
+		expectedBlocksLen := len(expectBlocks.blocks)
+		actualBlocksLen := len(actualBlocks.blocks)
+		assert.Equal(t, expectedBlocksLen, actualBlocksLen, fmt.Sprintf(
+			"expected %d blocks instead actual: blocks=%d",
+			expectedBlocksLen, actualBlocksLen))
+
+		for start, expectBlock := range expectBlocks.blocks {
+			actualBlock, ok := actualBlocks.blocks[start]
+			assert.True(t, ok, fmt.Sprintf(
+				"no actual result for expected ID at block: id=%s, block=%v",
+				id, start))
+			if !ok {
+				continue
+			}
+
+			expectLastRead := expectBlock.lastRead
+			actualLastRead := actualBlock.lastRead
+			assert.True(t, expectLastRead.Equal(actualLastRead), fmt.Sprintf(
+				"last read mismatch for expected ID at block: id=%s, block=%v, "+
+					"expectLastRead=%v, actualLastRead=%v",
+				id, start, expectLastRead, actualLastRead))
+		}
+	}
+}

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -319,6 +319,14 @@ func (ts *testSetup) startServer() error {
 func (ts *testSetup) stopServer() error {
 	ts.doneCh <- struct{}{}
 
+	if ts.m3dbClient.DefaultSessionActive() {
+		session, err := ts.m3dbClient.DefaultSession()
+		if err != nil {
+			return err
+		}
+		defer session.Close()
+	}
+
 	if err := ts.waitUntilServerIsDown(); err != nil {
 		return err
 	}

--- a/network/server/tchannelthrift/cluster/service.go
+++ b/network/server/tchannelthrift/cluster/service.go
@@ -153,7 +153,7 @@ func (s *service) Write(tctx thrift.Context, req *rpc.WriteRequest) error {
 		return tterrors.NewBadRequestError(fmt.Errorf("requires datapoint"))
 	}
 	dp := req.Datapoint
-	unit, unitErr := convert.ToUnit(dp.TimestampType)
+	unit, unitErr := convert.ToUnit(dp.TimestampTimeType)
 	if unitErr != nil {
 		return tterrors.NewBadRequestError(unitErr)
 	}

--- a/network/server/tchannelthrift/convert/convert.go
+++ b/network/server/tchannelthrift/convert/convert.go
@@ -44,6 +44,10 @@ func ToTime(value int64, timeType rpc.TimeType) (time.Time, error) {
 	if err != nil {
 		return timeZero, err
 	}
+	// NB(r): Doesn't matter what unit is if we have zero of them.
+	if value == 0 {
+		return timeZero, nil
+	}
 	return xtime.FromNormalizedTime(value, unit), nil
 }
 

--- a/network/server/tchannelthrift/node/service.go
+++ b/network/server/tchannelthrift/node/service.go
@@ -435,23 +435,31 @@ func (s *service) FetchBlocksMetadataRaw(tctx thrift.Context, req *rpc.FetchBloc
 			if opts.IncludeSizes {
 				size := fetchedMetadataBlock.Size
 				blockMetadata.Size = &size
+			} else {
+				blockMetadata.Size = nil
 			}
 
-			if opts.IncludeChecksums {
-				if checksum := fetchedMetadataBlock.Checksum; checksum != nil {
-					value := int64(*checksum)
-					blockMetadata.Checksum = &value
-				}
+			checksum := fetchedMetadataBlock.Checksum
+			if opts.IncludeChecksums && checksum != nil {
+				value := int64(*checksum)
+				blockMetadata.Checksum = &value
+			} else {
+				blockMetadata.Checksum = nil
 			}
 
 			if opts.IncludeLastRead {
 				lastRead := fetchedMetadataBlock.LastRead.UnixNano()
 				blockMetadata.LastRead = &lastRead
 				blockMetadata.LastReadTimeType = rpc.TimeType_UNIX_NANOSECONDS
+			} else {
+				blockMetadata.LastRead = nil
+				blockMetadata.LastReadTimeType = rpc.TimeType(0)
 			}
 
 			if err := fetchedMetadataBlock.Err; err != nil {
 				blockMetadata.Err = convert.ToRPCError(err)
+			} else {
+				blockMetadata.Err = nil
 			}
 
 			blocksMetadata.Blocks = append(blocksMetadata.Blocks, blockMetadata)

--- a/storage/block/block_mock.go
+++ b/storage/block/block_mock.go
@@ -287,14 +287,22 @@ func (_mr *_MockDatabaseBlockRecorder) StartTime() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartTime")
 }
 
-func (_m *MockDatabaseBlock) LastAccessTime() time.Time {
-	ret := _m.ctrl.Call(_m, "LastAccessTime")
+func (_m *MockDatabaseBlock) SetLastReadTime(value time.Time) {
+	_m.ctrl.Call(_m, "SetLastReadTime", value)
+}
+
+func (_mr *_MockDatabaseBlockRecorder) SetLastReadTime(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLastReadTime", arg0)
+}
+
+func (_m *MockDatabaseBlock) LastReadTime() time.Time {
+	ret := _m.ctrl.Call(_m, "LastReadTime")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
 }
 
-func (_mr *_MockDatabaseBlockRecorder) LastAccessTime() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastAccessTime")
+func (_mr *_MockDatabaseBlockRecorder) LastReadTime() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastReadTime")
 }
 
 func (_m *MockDatabaseBlock) Len() int {

--- a/storage/block/metadata.go
+++ b/storage/block/metadata.go
@@ -27,11 +27,17 @@ import (
 )
 
 // NewMetadata creates a new block metadata
-func NewMetadata(start time.Time, size int64, checksum *uint32) Metadata {
+func NewMetadata(
+	start time.Time,
+	size int64,
+	checksum *uint32,
+	lastRead time.Time,
+) Metadata {
 	return Metadata{
 		Start:    start,
 		Size:     size,
 		Checksum: checksum,
+		LastRead: lastRead,
 	}
 }
 

--- a/storage/block/result.go
+++ b/storage/block/result.go
@@ -59,14 +59,16 @@ func SortFetchBlockResultByTimeAscending(results []FetchBlockResult) {
 // NewFetchBlockMetadataResult creates a new fetch block metadata result.
 func NewFetchBlockMetadataResult(
 	start time.Time,
-	size *int64,
+	size int64,
 	checksum *uint32,
+	lastRead time.Time,
 	err error,
 ) FetchBlockMetadataResult {
 	return FetchBlockMetadataResult{
 		Start:    start,
 		Size:     size,
 		Checksum: checksum,
+		LastRead: lastRead,
 		Err:      err,
 	}
 }
@@ -203,11 +205,7 @@ func (it *filteredBlocksMetadataIter) Next() bool {
 	}
 	it.id = it.res[it.resIdx].ID
 	block := blocks[it.blockIdx]
-	size := int64(0)
-	if block.Size != nil {
-		size = *block.Size
-	}
-	it.metadata = NewMetadata(block.Start, size, block.Checksum)
+	it.metadata = NewMetadata(block.Start, block.Size, block.Checksum, block.LastRead)
 	it.blockIdx++
 	return true
 }

--- a/storage/block/result_pool_test.go
+++ b/storage/block/result_pool_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +39,7 @@ func TestFetchBlockMetadataResultsPoolResetOnPut(t *testing.T) {
 	res := p.Get()
 
 	// Make res non-empty
-	res.Add(NewFetchBlockMetadataResult(time.Now(), nil, nil, nil))
+	res.Add(NewFetchBlockMetadataResult(time.Now(), 0, nil, time.Time{}, nil))
 	require.Equal(t, 1, len(res.Results()))
 
 	// Return res to pool
@@ -57,7 +57,7 @@ func TestFetchBlockMetadataResultsPoolRejectLargeSliceOnPut(t *testing.T) {
 	// Make res a large slice
 	iter := 1024
 	for i := 0; i < iter; i++ {
-		res.Add(NewFetchBlockMetadataResult(time.Now(), nil, nil, nil))
+		res.Add(NewFetchBlockMetadataResult(time.Now(), 0, nil, time.Time{}, nil))
 	}
 	require.True(t, cap(res.Results()) > 64)
 

--- a/storage/block/result_test.go
+++ b/storage/block/result_test.go
@@ -45,9 +45,9 @@ func TestSortFetchBlockResultByTimeAscending(t *testing.T) {
 func TestSortFetchBlockMetadataResultByTimeAscending(t *testing.T) {
 	now := time.Now()
 	inputs := []FetchBlockMetadataResult{
-		NewFetchBlockMetadataResult(now, nil, nil, nil),
-		NewFetchBlockMetadataResult(now.Add(time.Second), nil, nil, nil),
-		NewFetchBlockMetadataResult(now.Add(-time.Second), nil, nil, nil),
+		NewFetchBlockMetadataResult(now, 0, nil, time.Time{}, nil),
+		NewFetchBlockMetadataResult(now.Add(time.Second), 0, nil, time.Time{}, nil),
+		NewFetchBlockMetadataResult(now.Add(-time.Second), 0, nil, time.Time{}, nil),
 	}
 	expected := []FetchBlockMetadataResult{inputs[2], inputs[0], inputs[1]}
 	res := newPooledFetchBlockMetadataResults(nil, nil)
@@ -67,16 +67,17 @@ func TestFilteredBlocksMetadataIter(t *testing.T) {
 	now := time.Now()
 	sizes := []int64{1, 2, 3}
 	checksums := []uint32{6, 7, 8}
+	lastRead := now.Add(-100 * time.Millisecond)
 	inputs := []FetchBlocksMetadataResult{
 		NewFetchBlocksMetadataResult(ts.StringID("foo"), newPooledFetchBlockMetadataResults(
 			[]FetchBlockMetadataResult{
-				NewFetchBlockMetadataResult(now.Add(-time.Second), &sizes[0], &checksums[0], nil),
+				NewFetchBlockMetadataResult(now.Add(-time.Second), sizes[0], &checksums[0], lastRead, nil),
 			}, nil)),
 		NewFetchBlocksMetadataResult(ts.StringID("bar"), newPooledFetchBlockMetadataResults(
 			[]FetchBlockMetadataResult{
-				NewFetchBlockMetadataResult(now, &sizes[1], &checksums[1], nil),
-				NewFetchBlockMetadataResult(now.Add(time.Second), &sizes[2], &checksums[2], errors.New("foo")),
-				NewFetchBlockMetadataResult(now.Add(2*time.Second), nil, nil, nil),
+				NewFetchBlockMetadataResult(now, sizes[1], &checksums[1], lastRead, nil),
+				NewFetchBlockMetadataResult(now.Add(time.Second), sizes[2], &checksums[2], lastRead, errors.New("foo")),
+				NewFetchBlockMetadataResult(now.Add(2*time.Second), 0, nil, lastRead, nil),
 			}, nil)),
 	}
 	res := newPooledFetchBlocksMetadataResults(nil, nil)
@@ -90,9 +91,9 @@ func TestFilteredBlocksMetadataIter(t *testing.T) {
 		actual = append(actual, testValue{id.String(), metadata})
 	}
 	expected := []testValue{
-		{"foo", NewMetadata(now.Add(-time.Second), sizes[0], &checksums[0])},
-		{"bar", NewMetadata(now, sizes[1], &checksums[1])},
-		{"bar", NewMetadata(now.Add(2*time.Second), int64(0), nil)},
+		{"foo", NewMetadata(now.Add(-time.Second), sizes[0], &checksums[0], lastRead)},
+		{"bar", NewMetadata(now, sizes[1], &checksums[1], lastRead)},
+		{"bar", NewMetadata(now.Add(2*time.Second), int64(0), nil, lastRead)},
 	}
 	require.Equal(t, expected, actual)
 }

--- a/storage/block/types.go
+++ b/storage/block/types.go
@@ -38,6 +38,7 @@ type Metadata struct {
 	Start    time.Time
 	Size     int64
 	Checksum *uint32
+	LastRead time.Time
 }
 
 // BlocksMetadata contains blocks metadata from a peer
@@ -80,11 +81,19 @@ type FetchBlockResult interface {
 	Checksum() *uint32
 }
 
+// FetchBlocksMetadataOptions are options used when fetching blocks metadata.
+type FetchBlocksMetadataOptions struct {
+	IncludeSizes     bool
+	IncludeChecksums bool
+	IncludeLastRead  bool
+}
+
 // FetchBlockMetadataResult captures the block start time, the block size, and any errors encountered
 type FetchBlockMetadataResult struct {
 	Start    time.Time
-	Size     *int64
+	Size     int64
 	Checksum *uint32
+	LastRead time.Time
 	Err      error
 }
 
@@ -135,8 +144,11 @@ type DatabaseBlock interface {
 	// StartTime returns the start time of the block.
 	StartTime() time.Time
 
-	// LastAccessTime returns the last access time of the block.
-	LastAccessTime() time.Time
+	// SetLastReadTime sets the last read time of the block.
+	SetLastReadTime(value time.Time)
+
+	// LastReadTime returns the last read time of the block.
+	LastReadTime() time.Time
 
 	// Len returns the block length.
 	Len() int

--- a/storage/database.go
+++ b/storage/database.go
@@ -324,8 +324,7 @@ func (d *db) FetchBlocksMetadata(
 	start, end time.Time,
 	limit int64,
 	pageToken int64,
-	includeSizes bool,
-	includeChecksums bool,
+	opts block.FetchBlocksMetadataOptions,
 ) (block.FetchBlocksMetadataResults, *int64, error) {
 	callStart := d.nowFn()
 	n, err := d.namespaceFor(namespace)
@@ -335,8 +334,11 @@ func (d *db) FetchBlocksMetadata(
 		return nil, nil, res
 	}
 
-	res, ptr, err := n.FetchBlocksMetadata(ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
-	d.metrics.fetchBlocksMetadata.ReportSuccessOrError(err, d.nowFn().Sub(callStart))
+	res, ptr, err := n.FetchBlocksMetadata(ctx, shardID, start, end, limit,
+		pageToken, opts)
+
+	duration := d.nowFn().Sub(callStart)
+	d.metrics.fetchBlocksMetadata.ReportSuccessOrError(err, duration)
 	return res, ptr, err
 }
 

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -363,15 +363,14 @@ func (n *dbNamespace) FetchBlocksMetadata(
 	start, end time.Time,
 	limit int64,
 	pageToken int64,
-	includeSizes bool,
-	includeChecksums bool,
+	opts block.FetchBlocksMetadataOptions,
 ) (block.FetchBlocksMetadataResults, *int64, error) {
 	shard, err := n.readableShardAt(shardID)
 	if err != nil {
 		return nil, nil, err
 	}
 	res, nextPageToken := shard.FetchBlocksMetadata(ctx, start, end, limit,
-		pageToken, includeSizes, includeChecksums)
+		pageToken, opts)
 	return res, nextPageToken, nil
 }
 

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -115,7 +115,11 @@ func (r shardRepairer) Repair(
 	ctx.RegisterFinalizer(metadata)
 
 	// Add local metadata
-	localMetadata, _ := shard.FetchBlocksMetadata(ctx, start, end, math.MaxInt64, 0, true, true)
+	opts := block.FetchBlocksMetadataOptions{
+		IncludeSizes:     true,
+		IncludeChecksums: true,
+	}
+	localMetadata, _ := shard.FetchBlocksMetadata(ctx, start, end, math.MaxInt64, 0, opts)
 	ctx.RegisterFinalizer(context.FinalizerFn(localMetadata.Close))
 
 	localIter := block.NewFilteredBlocksMetadataIter(localMetadata)

--- a/storage/repair/metadata_test.go
+++ b/storage/repair/metadata_test.go
@@ -131,9 +131,9 @@ func TestReplicaMetadataComparerAddLocalMetadata(t *testing.T) {
 		id   ts.ID
 		meta block.Metadata
 	}{
-		{ts.StringID("foo"), block.NewMetadata(now, int64(0), new(uint32))},
-		{ts.StringID("foo"), block.NewMetadata(now.Add(time.Second), int64(2), new(uint32))},
-		{ts.StringID("bar"), block.NewMetadata(now, int64(4), nil)},
+		{ts.StringID("foo"), block.NewMetadata(now, int64(0), new(uint32), time.Time{})},
+		{ts.StringID("foo"), block.NewMetadata(now.Add(time.Second), int64(2), new(uint32), time.Time{})},
+		{ts.StringID("bar"), block.NewMetadata(now, int64(4), nil, time.Time{})},
 	}
 
 	gomock.InOrder(
@@ -167,10 +167,30 @@ func TestReplicaMetadataComparerAddPeerMetadata(t *testing.T) {
 		host topology.Host
 		meta block.BlocksMetadata
 	}{
-		{topology.NewHost("1", "addr1"), block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{block.NewMetadata(now, int64(0), new(uint32))})},
-		{topology.NewHost("1", "addr1"), block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{block.NewMetadata(now.Add(time.Second), int64(1), new(uint32))})},
-		{topology.NewHost("2", "addr2"), block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{block.NewMetadata(now, int64(2), nil)})},
-		{topology.NewHost("2", "addr2"), block.NewBlocksMetadata(ts.StringID("bar"), []block.Metadata{block.NewMetadata(now.Add(time.Second), int64(3), nil)})},
+		{
+			host: topology.NewHost("1", "addr1"),
+			meta: block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{
+				block.NewMetadata(now, int64(0), new(uint32), time.Time{}),
+			}),
+		},
+		{
+			host: topology.NewHost("1", "addr1"),
+			meta: block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{
+				block.NewMetadata(now.Add(time.Second), int64(1), new(uint32), time.Time{}),
+			}),
+		},
+		{
+			host: topology.NewHost("2", "addr2"),
+			meta: block.NewBlocksMetadata(ts.StringID("foo"), []block.Metadata{
+				block.NewMetadata(now, int64(2), nil, time.Time{}),
+			}),
+		},
+		{
+			host: topology.NewHost("2", "addr2"),
+			meta: block.NewBlocksMetadata(ts.StringID("bar"), []block.Metadata{
+				block.NewMetadata(now.Add(time.Second), int64(3), nil, time.Time{}),
+			}),
+		},
 	}
 	expectedErr := errors.New("some error")
 

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -386,14 +386,12 @@ func (b *dbBuffer) FetchBlocksMetadata(
 		if opts.IncludeSizes {
 			resultSize = size
 		}
-		// NB(r): Ignore if opts.IncludeChecksum because we avoid
-		// calculating checksum since block is open and is being mutated
 		var resultLastRead time.Time
 		if opts.IncludeLastRead {
 			resultLastRead = bucket.lastRead()
 		}
-		// NB(xichen): intentionally returning nil checksums for buckets
-		// because they haven't been flushed yet
+		// NB(r): Ignore if opts.IncludeChecksum because we avoid
+		// calculating checksum since block is open and is being mutated
 		res.Add(block.FetchBlockMetadataResult{
 			Start:    bucket.start,
 			Size:     resultSize,

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/m3db/m3db/clock"
@@ -80,8 +81,7 @@ type databaseBuffer interface {
 	FetchBlocksMetadata(
 		ctx context.Context,
 		start, end time.Time,
-		includeSizes bool,
-		includeChecksums bool,
+		opts block.FetchBlocksMetadataOptions,
 	) block.FetchBlockMetadataResults
 
 	IsEmpty() bool
@@ -240,6 +240,10 @@ func bucketDrainAndReset(now time.Time, b *dbBuffer, idx int, start time.Time) i
 			mergedOutOfOrderBlocks = 1
 		}
 		if merged.block.Len() > 0 {
+			// If this block was read mark it as such
+			if lastRead := b.buckets[idx].lastRead(); !lastRead.IsZero() {
+				merged.block.SetLastReadTime(lastRead)
+			}
 			b.drainFn(merged.block)
 		} else {
 			log := b.opts.InstrumentOptions().Logger()
@@ -306,7 +310,7 @@ func (b *dbBuffer) computedForEachBucketAsc(
 
 func (b *dbBuffer) ReadEncoded(ctx context.Context, start, end time.Time) [][]xio.SegmentReader {
 	// TODO(r): pool these results arrays
-	var results [][]xio.SegmentReader
+	var res [][]xio.SegmentReader
 	b.forEachBucketAsc(func(bucket *dbBufferBucket) {
 		if !bucket.canRead() {
 			return
@@ -318,10 +322,18 @@ func (b *dbBuffer) ReadEncoded(ctx context.Context, start, end time.Time) [][]xi
 			return
 		}
 
-		results = append(results, bucket.streams(ctx))
+		res = append(res, bucket.streams(ctx))
+
+		// NB(r): Store the last read time, should not set this when
+		// calling FetchBlocks as a read is differentiated from
+		// a FetchBlocks call. One is initiated by an external
+		// entity and the other is used for streaming blocks between
+		// the storage nodes. This distinction is important as this
+		// data is important for use with understanding access patterns, etc.
+		bucket.setLastRead(b.nowFn())
 	})
 
-	return results
+	return res
 }
 
 func (b *dbBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
@@ -354,8 +366,7 @@ func (b *dbBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.
 func (b *dbBuffer) FetchBlocksMetadata(
 	ctx context.Context,
 	start, end time.Time,
-	includeSizes bool,
-	includeChecksums bool,
+	opts block.FetchBlocksMetadataOptions,
 ) block.FetchBlockMetadataResults {
 	blockSize := b.opts.RetentionOptions().BlockSize()
 	res := b.opts.FetchBlockMetadataResultsPool().Get()
@@ -371,13 +382,23 @@ func (b *dbBuffer) FetchBlocksMetadata(
 		if size == 0 {
 			return
 		}
-		var pSize *int64
-		if includeSizes {
-			pSize = &size
+		var resultSize int64
+		if opts.IncludeSizes {
+			resultSize = size
+		}
+		// NB(r): Ignore if opts.IncludeChecksum because we avoid
+		// calculating checksum since block is open and is being mutated
+		var resultLastRead time.Time
+		if opts.IncludeLastRead {
+			resultLastRead = bucket.lastRead()
 		}
 		// NB(xichen): intentionally returning nil checksums for buckets
 		// because they haven't been flushed yet
-		res.Add(block.NewFetchBlockMetadataResult(bucket.start, pSize, nil, nil))
+		res.Add(block.FetchBlockMetadataResult{
+			Start:    bucket.start,
+			Size:     resultSize,
+			LastRead: resultLastRead,
+		})
 	})
 
 	return res
@@ -386,13 +407,14 @@ func (b *dbBuffer) FetchBlocksMetadata(
 type dbBufferBucketStreamFn func(stream xio.SegmentReader)
 
 type dbBufferBucket struct {
-	ctx          context.Context
-	opts         Options
-	start        time.Time
-	encoders     []inOrderEncoder
-	bootstrapped []block.DatabaseBlock
-	empty        bool
-	drained      bool
+	ctx               context.Context
+	opts              Options
+	start             time.Time
+	encoders          []inOrderEncoder
+	bootstrapped      []block.DatabaseBlock
+	lastReadUnixNanos int64
+	empty             bool
+	drained           bool
 }
 
 type inOrderEncoder struct {
@@ -419,6 +441,7 @@ func (b *dbBufferBucket) resetTo(
 		encoder:     encoder,
 	})
 	b.bootstrapped = nil
+	atomic.StoreInt64(&b.lastReadUnixNanos, 0)
 	b.empty = true
 	b.drained = false
 }
@@ -538,6 +561,14 @@ func (b *dbBufferBucket) streamsLen() int {
 		length += b.encoders[i].encoder.StreamLen()
 	}
 	return length
+}
+
+func (b *dbBufferBucket) setLastRead(value time.Time) {
+	atomic.StoreInt64(&b.lastReadUnixNanos, value.UnixNano())
+}
+
+func (b *dbBufferBucket) lastRead() time.Time {
+	return time.Unix(0, atomic.LoadInt64(&b.lastReadUnixNanos))
 }
 
 func (b *dbBufferBucket) resetEncoders() {

--- a/storage/series/buffer_mock.go
+++ b/storage/series/buffer_mock.go
@@ -28,8 +28,8 @@ import (
 	context "github.com/m3db/m3db/context"
 	block "github.com/m3db/m3db/storage/block"
 	io "github.com/m3db/m3db/x/io"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of databaseBuffer interface
@@ -53,7 +53,7 @@ func (_m *MockdatabaseBuffer) EXPECT() *_MockdatabaseBufferRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseBuffer) Write(ctx context.Context, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -63,7 +63,7 @@ func (_mr *_MockdatabaseBufferRecorder) Write(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time0.Time, end time0.Time) [][]io.SegmentReader {
+func (_m *MockdatabaseBuffer) ReadEncoded(ctx context.Context, start time.Time, end time.Time) [][]io.SegmentReader {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, start, end)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	return ret0
@@ -73,7 +73,7 @@ func (_mr *_MockdatabaseBufferRecorder) ReadEncoded(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time0.Time) []block.FetchBlockResult {
+func (_m *MockdatabaseBuffer) FetchBlocks(ctx context.Context, starts []time.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -83,14 +83,14 @@ func (_mr *_MockdatabaseBufferRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, includeSizes bool, includeChecksums bool) block.FetchBlockMetadataResults {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, includeSizes, includeChecksums)
+func (_m *MockdatabaseBuffer) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, opts block.FetchBlocksMetadataOptions) block.FetchBlockMetadataResults {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, opts)
 	ret0, _ := ret[0].(block.FetchBlockMetadataResults)
 	return ret0
 }
 
-func (_mr *_MockdatabaseBufferRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockdatabaseBufferRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockdatabaseBuffer) IsEmpty() bool {
@@ -113,10 +113,10 @@ func (_mr *_MockdatabaseBufferRecorder) Stats() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stats")
 }
 
-func (_m *MockdatabaseBuffer) MinMax() (time0.Time, time0.Time) {
+func (_m *MockdatabaseBuffer) MinMax() (time.Time, time.Time) {
 	ret := _m.ctrl.Call(_m, "MinMax")
-	ret0, _ := ret[0].(time0.Time)
-	ret1, _ := ret[1].(time0.Time)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(time.Time)
 	return ret0, ret1
 }
 

--- a/storage/series/buffer_test.go
+++ b/storage/series/buffer_test.go
@@ -498,7 +498,7 @@ func TestBufferFetchBlocksMetadata(t *testing.T) {
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, b.start, res[0].Start)
 	assert.Equal(t, expectedSize, res[0].Size)
-	assert.Equal(t, uint32(0), res[0].Checksum) // checksum is never available for buffer block
+	assert.Equal(t, (*uint32)(nil), res[0].Checksum) // checksum is never available for buffer block
 	assert.True(t, expectedLastRead.Equal(res[0].LastRead))
 }
 

--- a/storage/series/buffer_test.go
+++ b/storage/series/buffer_test.go
@@ -475,6 +475,9 @@ func TestBufferFetchBlocks(t *testing.T) {
 func TestBufferFetchBlocksMetadata(t *testing.T) {
 	b, opts, _ := newTestBufferBucketWithData(t)
 
+	expectedLastRead := time.Now()
+	b.lastReadUnixNanos = expectedLastRead.UnixNano()
+
 	ctx := opts.ContextPool().Get()
 	defer ctx.Close()
 
@@ -486,10 +489,17 @@ func TestBufferFetchBlocksMetadata(t *testing.T) {
 
 	expectedSize := int64(b.streamsLen())
 
-	res := buffer.FetchBlocksMetadata(ctx, start, end, true, true).Results()
-	require.Equal(t, 1, len(res))
-	require.Equal(t, b.start, res[0].Start)
-	require.Equal(t, expectedSize, *res[0].Size)
+	fetchOpts := block.FetchBlocksMetadataOptions{
+		IncludeSizes:     true,
+		IncludeChecksums: true,
+		IncludeLastRead:  true,
+	}
+	res := buffer.FetchBlocksMetadata(ctx, start, end, fetchOpts).Results()
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, b.start, res[0].Start)
+	assert.Equal(t, expectedSize, res[0].Size)
+	assert.Equal(t, uint32(0), res[0].Checksum) // checksum is never available for buffer block
+	assert.True(t, expectedLastRead.Equal(res[0].LastRead))
 }
 
 func TestBufferReadEncodedValidAfterDrain(t *testing.T) {

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -24,7 +24,7 @@
 package series
 
 import (
-	time "time"
+	time0 "time"
 
 	gomock "github.com/golang/mock/gomock"
 	context "github.com/m3db/m3db/context"
@@ -32,7 +32,7 @@ import (
 	block "github.com/m3db/m3db/storage/block"
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
-	time0 "github.com/m3db/m3x/time"
+	time "github.com/m3db/m3x/time"
 )
 
 // Mock of DatabaseSeries interface
@@ -74,7 +74,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time.Time) []block.FetchBlockResult {
+func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time0.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", _param0, _param1)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -84,17 +84,17 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time.Time, _param2 time.Time, _param3 bool, _param4 bool) block.FetchBlocksMetadataResult {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", _param0, _param1, _param2, _param3, _param4)
+func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 block.FetchBlocksMetadataOptions) block.FetchBlocksMetadataResult {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResult)
 	return ret0
 }
 
-func (_mr *_MockDatabaseSeriesRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockDatabaseSeriesRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time.Time, _param2 persist.Fn) error {
+func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time0.Time, _param2 persist.Fn) error {
 	ret := _m.ctrl.Call(_m, "Flush", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -134,7 +134,7 @@ func (_mr *_MockDatabaseSeriesRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time.Time, _param2 time.Time) ([][]io.SegmentReader, error) {
+func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time0.Time, _param2 time0.Time) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", _param0, _param1, _param2)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -164,7 +164,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Tick() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick")
 }
 
-func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time.Time, _param2 float64, _param3 time0.Unit, _param4 []byte) error {
+func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time0.Time, _param2 float64, _param3 time.Unit, _param4 []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -441,18 +441,22 @@ func TestSeriesFetchBlocksMetadata(t *testing.T) {
 	expected := []struct {
 		start    time.Time
 		size     int64
-		checksum uint32
+		checksum *uint32
 		lastRead time.Time
 		hasError bool
 	}{
-		{starts[0], expectedSize, expectedChecksum, expectedLastRead, false},
-		{starts[2], 0, 0, time.Time{}, false},
+		{starts[0], expectedSize, &expectedChecksum, expectedLastRead, false},
+		{starts[2], 0, nil, time.Time{}, false},
 	}
 	require.Equal(t, len(expected), len(metadata))
 	for i := 0; i < len(expected); i++ {
 		require.Equal(t, expected[i].start, metadata[i].Start)
 		require.Equal(t, expected[i].size, metadata[i].Size)
-		require.Equal(t, expected[i].checksum, metadata[i].Checksum)
+		if expected[i].checksum == nil {
+			require.Nil(t, metadata[i].Checksum)
+		} else {
+			require.Equal(t, *expected[i].checksum, *metadata[i].Checksum)
+		}
 		require.True(t, expected[i].lastRead.Equal(metadata[i].LastRead))
 		if expected[i].hasError {
 			require.Error(t, metadata[i].Err)

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -406,16 +406,24 @@ func TestSeriesFetchBlocksMetadata(t *testing.T) {
 	b.EXPECT().Len().Return(expectedSegment.Len())
 	expectedChecksum := digest.SegmentChecksum(expectedSegment)
 	b.EXPECT().Checksum().Return(expectedChecksum)
+	expectedLastRead := time.Now()
+	b.EXPECT().LastReadTime().Return(expectedLastRead)
 	blocks[starts[0]] = b
 	blocks[starts[3]] = nil
 
 	// Set up the buffer
 	buffer := NewMockdatabaseBuffer(ctrl)
 	expectedResults := block.NewFetchBlockMetadataResults()
-	expectedResults.Add(block.NewFetchBlockMetadataResult(starts[2], new(int64), nil, nil))
+	expectedResults.Add(block.FetchBlockMetadataResult{Start: starts[2]})
+
+	fetchOpts := block.FetchBlocksMetadataOptions{
+		IncludeSizes:     true,
+		IncludeChecksums: true,
+		IncludeLastRead:  true,
+	}
 	buffer.EXPECT().IsEmpty().Return(false)
 	buffer.EXPECT().
-		FetchBlocksMetadata(ctx, start, end, true, true).
+		FetchBlocksMetadata(ctx, start, end, fetchOpts).
 		Return(expectedResults)
 
 	series := NewDatabaseSeries(ts.StringID("bar"), opts).(*dbSeries)
@@ -425,33 +433,27 @@ func TestSeriesFetchBlocksMetadata(t *testing.T) {
 	series.blocks = mockBlocks
 	series.buffer = buffer
 
-	res := series.FetchBlocksMetadata(ctx, start, end, true, true)
+	res := series.FetchBlocksMetadata(ctx, start, end, fetchOpts)
 	require.Equal(t, "bar", res.ID.String())
 
 	metadata := res.Blocks.Results()
 	expectedSize := int64(4)
 	expected := []struct {
-		t        time.Time
-		s        *int64
-		c        *uint32
+		start    time.Time
+		size     int64
+		checksum uint32
+		lastRead time.Time
 		hasError bool
 	}{
-		{starts[0], &expectedSize, &expectedChecksum, false},
-		{starts[2], new(int64), nil, false},
+		{starts[0], expectedSize, expectedChecksum, expectedLastRead, false},
+		{starts[2], 0, 0, time.Time{}, false},
 	}
 	require.Equal(t, len(expected), len(metadata))
 	for i := 0; i < len(expected); i++ {
-		require.Equal(t, expected[i].t, metadata[i].Start)
-		if expected[i].s == nil {
-			require.Nil(t, metadata[i].Size)
-		} else {
-			require.Equal(t, *expected[i].s, *metadata[i].Size)
-		}
-		if expected[i].c == nil {
-			require.Nil(t, metadata[i].Checksum)
-		} else {
-			require.Equal(t, *expected[i].c, *metadata[i].Checksum)
-		}
+		require.Equal(t, expected[i].start, metadata[i].Start)
+		require.Equal(t, expected[i].size, metadata[i].Size)
+		require.Equal(t, expected[i].checksum, metadata[i].Checksum)
+		require.True(t, expected[i].lastRead.Equal(metadata[i].LastRead))
 		if expected[i].hasError {
 			require.Error(t, metadata[i].Err)
 		} else {

--- a/storage/series/types.go
+++ b/storage/series/types.go
@@ -65,8 +65,7 @@ type DatabaseSeries interface {
 	FetchBlocksMetadata(
 		ctx context.Context,
 		start, end time.Time,
-		includeSizes bool,
-		includeChecksums bool,
+		opts block.FetchBlocksMetadataOptions,
 	) block.FetchBlocksMetadataResult
 
 	// IsEmpty returns whether series is empty

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -148,16 +148,16 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockDatabaseRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+func (_mr *_MockDatabaseRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 func (_m *MockDatabase) Bootstrap() error {
@@ -312,16 +312,16 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, includeSizes, includeChecksums)
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockdatabaseRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+func (_mr *_MockdatabaseRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 func (_m *Mockdatabase) Bootstrap() error {
@@ -535,16 +535,16 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64, error) {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, includeSizes, includeChecksums)
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 func (_m *MockdatabaseNamespace) Bootstrap(process bootstrap.Process, targetRanges []bootstrap.TargetRange) error {
@@ -762,15 +762,15 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, includeSizes bool, includeChecksums bool) (block.FetchBlocksMetadataResults, *int64) {
-	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, includeSizes, includeChecksums)
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64) {
+	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
 	return ret0, ret1
 }
 
-func (_mr *_MockdatabaseShardRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (_mr *_MockdatabaseShardRecorder) FetchBlocksMetadata(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockdatabaseShard) Bootstrap(bootstrappedSeries map[ts.Hash]result.DatabaseSeriesBlocks) error {

--- a/storage/types.go
+++ b/storage/types.go
@@ -100,8 +100,7 @@ type Database interface {
 		start, end time.Time,
 		limit int64,
 		pageToken int64,
-		includeSizes bool,
-		includeChecksums bool,
+		opts block.FetchBlocksMetadataOptions,
 	) (block.FetchBlocksMetadataResults, *int64, error)
 
 	// Bootstrap bootstraps the database.
@@ -190,8 +189,7 @@ type databaseNamespace interface {
 		start, end time.Time,
 		limit int64,
 		pageToken int64,
-		includeSizes bool,
-		includeChecksums bool,
+		opts block.FetchBlocksMetadataOptions,
 	) (block.FetchBlocksMetadataResults, *int64, error)
 
 	// Bootstrap performs bootstrapping
@@ -265,8 +263,7 @@ type databaseShard interface {
 		start, end time.Time,
 		limit int64,
 		pageToken int64,
-		includeSizes bool,
-		includeChecksums bool,
+		opts block.FetchBlocksMetadataOptions,
 	) (block.FetchBlocksMetadataResults, *int64)
 
 	Bootstrap(


### PR DESCRIPTION
This change adds the ability to read the last read time for a block from the `FetchBlocksMetadata` API.  This allows for one to observe the analyze the read patterns of a cluster by using the client's `FetchBlocksMetadataFromPeers(...)` method.

cc @xichen2020 @prateek 