### PR TITLE
Upgrade m3db vendored packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,5 @@ env:
 sudo: required
 dist: trusty
 script:
- - make lint
- - make test-ci-unit
- - make test-ci-integration
- - make m3dbnode
+ - make all
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ TOOLS :=         \
 	read_ids       \
 	read_index_ids \
 	clone_fileset  \
-	dtest          \
 
 setup:
 	mkdir -p $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,11 @@ VENDOR_ENV := GO15VENDOREXPERIMENT=1
 SERVICES := \
 	m3dbnode
 
-TOOLS :=              \
+TOOLS :=         \
 	read_ids       \
 	read_index_ids \
-	clone_fileset
+	clone_fileset  \
+	dtest          \
 
 setup:
 	mkdir -p $(BUILD)
@@ -73,6 +74,9 @@ tools-linux-amd64:
 
 $(foreach SERVICE,$(SERVICES),$(eval $(SERVICE_RULES)))
 $(foreach TOOL,$(TOOLS),$(eval $(TOOL_RULES)))
+
+all: lint test-ci-unit test-ci-integration services tools
+	@echo Made all successfully
 
 install-license-bin: install-vendor
 	@echo Installing node modules
@@ -142,4 +146,4 @@ clean:
 	@rm -f *.html *.xml *.out *.test
 
 .DEFAULT_GOAL := test
-.PHONY: test test-xml test-internal testhtml clean
+.PHONY: test test-xml test-internal testhtml clean all

--- a/client/session_fetch_test.go
+++ b/client/session_fetch_test.go
@@ -272,7 +272,7 @@ func testFetchConsistencyLevel(
 	reporterOpts := xmetrics.NewTestStatsReporterOptions().
 		SetCaptureEvents(true)
 	reporter := xmetrics.NewTestStatsReporter(reporterOpts)
-	scope, closer := tally.NewRootScope("", nil, reporter, time.Millisecond, tally.DefaultSeparator)
+	scope, closer := tally.NewRootScope(tally.ScopeOptions{Reporter: reporter}, time.Millisecond)
 	defer closer.Close()
 
 	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().

--- a/client/session_topology_test.go
+++ b/client/session_topology_test.go
@@ -94,7 +94,8 @@ func TestSessionTopologyChangeCreatesNewClosesOldHostQueues(t *testing.T) {
 		SetConfigServiceClient(fake.NewM3ClusterClient(svcs, nil))
 	topoInit := topology.NewDynamicInitializer(topoOpts)
 
-	scope := tally.NewTestScope("", nil)
+	var testScopeTags map[string]string
+	scope := tally.NewTestScope("", testScopeTags)
 
 	opts := newSessionTestOptions().
 		SetTopologyInitializer(topoInit)
@@ -145,8 +146,9 @@ func TestSessionTopologyChangeCreatesNewClosesOldHostQueues(t *testing.T) {
 	svcs.NotifyServiceUpdate("m3db")
 
 	// Wait for topology to be processed
+	testScopeCounterKey := tally.KeyForPrefixedStringMap("topology.updated-success", testScopeTags)
 	for {
-		updated, ok := scope.Snapshot().Counters()["topology.updated-success"]
+		updated, ok := scope.Snapshot().Counters()[testScopeCounterKey]
 		if ok && updated.Value() > 0 {
 			break
 		}

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -228,7 +228,8 @@ func testWriteConsistencyLevel(
 	reporterOpts := xmetrics.NewTestStatsReporterOptions().
 		SetCaptureEvents(true)
 	reporter := xmetrics.NewTestStatsReporter(reporterOpts)
-	scope, closer := tally.NewRootScope("", nil, reporter, time.Millisecond, tally.DefaultSeparator)
+	scope, closer := tally.NewRootScope(tally.ScopeOptions{Reporter: reporter}, time.Millisecond)
+
 	defer closer.Close()
 
 	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().

--- a/glide.lock
+++ b/glide.lock
@@ -1,47 +1,108 @@
-hash: 6d155e34454932674b0773ad9668f14d4d0f58cc74a1a56f0bd8efa364a158ce
-updated: 2017-02-20T17:31:51.03659332-05:00
+hash: 12a02c9ba7a871f373bf293099b7557dc63f0e0eba38c826ae814c94830047ad
+updated: 2017-05-25T14:44:18.355801502-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
   - lib/go/thrift
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
+- name: github.com/coreos/etcd
+  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
+  subpackages:
+  - auth/authpb
+  - clientv3
+  - etcdserver/api/v3rpc/rpctypes
+  - etcdserver/etcdserverpb
+  - integration
+  - mvcc/mvccpb
+  - pkg/tlsutil
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-ole/go-ole
+  version: de8695c8edbf8236f30d6e1376e20b198a028d42
+  subpackages:
+  - oleutil
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: bf531ff1a004f24ee53329dfd5ce0b41bfdc17df
+  version: 3852dcfda249c2097355a6aabb199a28d97b30df
   subpackages:
+  - jsonpb
   - proto
+- name: github.com/grpc-ecosystem/go-grpc-prometheus
+  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+- name: github.com/grpc-ecosystem/grpc-gateway
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
+  subpackages:
+  - runtime
+  - runtime/internal
+  - utilities
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/m3db/m3cluster
-  version: 1054ce5875f3f13519cfc1c4e816c06bab8587fe
+  version: 2eb541bb4b0883e27c78f7594f0eda09f8bf9665
   subpackages:
   - client
+  - client/etcd
+  - etcd/watchmanager
+  - generated/proto/metadata
+  - generated/proto/placement
   - kv
+  - kv/etcd
+  - proto/util
   - services
+  - services/client
+  - services/heartbeat/etcd
   - services/placement
+  - services/placement/algo
+  - services/placement/service
   - shard
+- name: github.com/m3db/m3em
+  version: c7991e36f84c32e25e1cc7759d4779a319414578
+  subpackages:
+  - build
+  - cluster
+  - generated/proto/heartbeat
+  - generated/proto/m3em
+  - node
+  - node/m3db
+  - node/m3db/util
+  - os/fs
 - name: github.com/m3db/m3x
-  version: 2adc966acde14c9f0cc04c3eaeb338c5f9673a74
+  version: bd6be18ffb184691512eb442561b16a59c15d797
   vcs: git
   subpackages:
   - checked
   - clock
   - close
+  - config
   - errors
   - instrument
   - log
   - pool
+  - process
   - retry
   - sync
+  - tcp
   - time
   - watch
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
+- name: github.com/nu7hatch/gouuid
+  version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 - name: github.com/opentracing/opentracing-go
   version: 855519783f479520497c6b3445611b05fc42f009
   subpackages:
@@ -52,8 +113,41 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
+- name: github.com/shirou/gopsutil
+  version: b62e301a8b9958eebb7299683eb57fab229a9501
+  subpackages:
+  - cpu
+  - host
+  - internal/common
+  - mem
+  - net
+  - process
+- name: github.com/shirou/w32
+  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/spaolacci/murmur3
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
+- name: github.com/spf13/cobra
+  version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
+- name: github.com/spf13/pflag
+  version: 4f9190456aed1c2113ca51ea9b89219747458dc1
+- name: github.com/StackExchange/wmi
+  version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/stretchr/testify
   version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
   subpackages:
@@ -62,14 +156,21 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 43c1379c0577ac1eb74f9f3869cea07191c9992b
-- name: github.com/uber/tchannel-go
-  version: 8d570ed87acb2661d390c096215260f3f9e9b931
+  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
   subpackages:
+  - m3
+  - m3/customtransports
+  - m3/thrift
+  - m3/thriftudp
+- name: github.com/uber/tchannel-go
+  version: 5d979b31a7405a676919fca637bb2f715fb9ed65
+  subpackages:
+  - internal/argreader
   - relay
   - thrift
   - thrift/gen-go/meta
   - tnet
+  - tos
   - trand
   - typed
 - name: github.com/willf/bitset
@@ -77,7 +178,18 @@ imports:
 - name: golang.org/x/net
   version: 61557ac0112b576429a0df080e1c2cef5dfbb642
   subpackages:
+  - bpf
   - context
+  - http2
+  - http2/hpack
+  - idna
+  - internal/iana
+  - internal/netreflect
+  - internal/timeseries
+  - ipv4
+  - ipv6
+  - lex/httplex
+  - trace
 - name: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
   subpackages:
@@ -89,8 +201,23 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
+- name: google.golang.org/grpc
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
+- name: gopkg.in/validator.v2
+  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/vmihailenco/msgpack.v2
   version: a1382b1ce0c749733b814157c245e02cc1f41076
   subpackages:
   - codes
+- name: gopkg.in/yaml.v2
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,32 +1,16 @@
-hash: 12a02c9ba7a871f373bf293099b7557dc63f0e0eba38c826ae814c94830047ad
-updated: 2017-05-25T14:44:18.355801502-04:00
+hash: 475d22f5db82006a615bb66ec9b0196b1fbe813cfa869da71899615d1f7fafe5
+updated: 2017-05-28T19:02:29.881683466-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
   - lib/go/thrift
-- name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-  subpackages:
-  - quantile
-- name: github.com/coreos/etcd
-  version: 8ba2897a21e4fc51b298ca553d251318425f93ae
-  subpackages:
-  - auth/authpb
-  - clientv3
-  - etcdserver/api/v3rpc/rpctypes
-  - etcdserver/etcdserverpb
-  - integration
-  - mvcc/mvccpb
-  - pkg/tlsutil
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
@@ -38,47 +22,17 @@ imports:
 - name: github.com/golang/protobuf
   version: 3852dcfda249c2097355a6aabb199a28d97b30df
   subpackages:
-  - jsonpb
   - proto
-- name: github.com/grpc-ecosystem/go-grpc-prometheus
-  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-- name: github.com/grpc-ecosystem/grpc-gateway
-  version: 84398b94e188ee336f307779b57b3aa91af7063c
-  subpackages:
-  - runtime
-  - runtime/internal
-  - utilities
-- name: github.com/inconshreveable/mousetrap
-  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/m3db/m3cluster
   version: 2eb541bb4b0883e27c78f7594f0eda09f8bf9665
   subpackages:
   - client
-  - client/etcd
-  - etcd/watchmanager
-  - generated/proto/metadata
-  - generated/proto/placement
   - kv
-  - kv/etcd
-  - proto/util
   - services
-  - services/client
-  - services/heartbeat/etcd
   - services/placement
-  - services/placement/algo
-  - services/placement/service
   - shard
 - name: github.com/m3db/m3em
   version: c7991e36f84c32e25e1cc7759d4779a319414578
-  subpackages:
-  - build
-  - cluster
-  - generated/proto/heartbeat
-  - generated/proto/m3em
-  - node
-  - node/m3db
-  - node/m3db/util
-  - os/fs
 - name: github.com/m3db/m3x
   version: bd6be18ffb184691512eb442561b16a59c15d797
   vcs: git
@@ -86,7 +40,6 @@ imports:
   - checked
   - clock
   - close
-  - config
   - errors
   - instrument
   - log
@@ -94,15 +47,8 @@ imports:
   - process
   - retry
   - sync
-  - tcp
   - time
   - watch
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
-  subpackages:
-  - pbutil
-- name: github.com/nu7hatch/gouuid
-  version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 - name: github.com/opentracing/opentracing-go
   version: 855519783f479520497c6b3445611b05fc42f009
   subpackages:
@@ -113,22 +59,6 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
-- name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
-  subpackages:
-  - expfmt
-  - internal/bitbucket.org/ww/goautoneg
-  - model
-- name: github.com/prometheus/procfs
-  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: github.com/shirou/gopsutil
   version: b62e301a8b9958eebb7299683eb57fab229a9501
   subpackages:
@@ -144,8 +74,6 @@ imports:
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 - name: github.com/spf13/cobra
   version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
-- name: github.com/spf13/pflag
-  version: 4f9190456aed1c2113ca51ea9b89219747458dc1
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/stretchr/testify
@@ -180,16 +108,10 @@ imports:
   subpackages:
   - bpf
   - context
-  - http2
-  - http2/hpack
-  - idna
   - internal/iana
   - internal/netreflect
-  - internal/timeseries
   - ipv4
   - ipv6
-  - lex/httplex
-  - trace
 - name: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
   subpackages:
@@ -201,23 +123,8 @@ imports:
   - internal/log
   - internal/modules
   - internal/remote_api
-- name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
-  subpackages:
-  - codes
-  - credentials
-  - grpclog
-  - internal
-  - metadata
-  - naming
-  - peer
-  - transport
-- name: gopkg.in/validator.v2
-  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/vmihailenco/msgpack.v2
   version: a1382b1ce0c749733b814157c245e02cc1f41076
   subpackages:
   - codes
-- name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,7 +12,7 @@ import:
   - gomock
 
 - package: github.com/golang/protobuf
-  version: bf531ff1a004f24ee53329dfd5ce0b41bfdc17df
+  version: 3852dcfda249c2097355a6aabb199a28d97b30df
   subpackages:
   - proto
 
@@ -25,7 +25,7 @@ import:
   - require
 
 - package: github.com/uber/tchannel-go
-  version: 8d570ed87acb2661d390c096215260f3f9e9b931
+  version: 5d979b31a7405a676919fca637bb2f715fb9ed65
   subpackages:
   - thrift
 
@@ -36,16 +36,16 @@ import:
   version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c
 
 - package: github.com/uber-go/tally
-  version: v1.1.0
+  version: v3.0.0
 
 - package: github.com/m3db/m3cluster
-  version: 1054ce5875f3f13519cfc1c4e816c06bab8587fe
+  version: 2eb541bb4b0883e27c78f7594f0eda09f8bf9665
   subpackages:
   - client
   - services
 
 - package: github.com/m3db/m3x
-  version: 2adc966acde14c9f0cc04c3eaeb338c5f9673a74
+  version: bd6be18ffb184691512eb442561b16a59c15d797
   vcs: git
   subpackages:
   - checked
@@ -63,3 +63,9 @@ import:
 
 - package: google.golang.org/appengine/datastore
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
+
+- package: github.com/m3db/m3em
+  version: c7991e36f84c32e25e1cc7759d4779a319414578
+
+- package: github.com/spf13/cobra
+  version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,7 +36,7 @@ import:
   version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c
 
 - package: github.com/uber-go/tally
-  version: v3.0.0
+  version: <4.0.0
 
 - package: github.com/m3db/m3cluster
   version: 2eb541bb4b0883e27c78f7594f0eda09f8bf9665

--- a/integration/fake/cluster_services.go
+++ b/integration/fake/cluster_services.go
@@ -71,6 +71,11 @@ type M3ClusterKVStore interface {
 	kv.Store
 }
 
+// M3ClusterTxnStore is a fake m3cluster txn store
+type M3ClusterTxnStore interface {
+	kv.TxnStore
+}
+
 // NewM3ClusterClient creates a new fake m3cluster client
 func NewM3ClusterClient(
 	services M3ClusterServices,
@@ -82,6 +87,7 @@ func NewM3ClusterClient(
 type m3ClusterClient struct {
 	services M3ClusterServices
 	kvStore  M3ClusterKVStore
+	txnStore M3ClusterTxnStore
 }
 
 func (c *m3ClusterClient) Services() (services.Services, error) {
@@ -90,6 +96,10 @@ func (c *m3ClusterClient) Services() (services.Services, error) {
 
 func (c *m3ClusterClient) KV() (kv.Store, error) {
 	return c.kvStore, nil
+}
+
+func (c *m3ClusterClient) Txn() (kv.TxnStore, error) {
+	return c.txnStore, nil
 }
 
 // NewM3ClusterServices creates a new fake m3cluster services
@@ -149,6 +159,12 @@ func (s *m3ClusterServices) Unadvertise(
 	id string,
 ) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (s *m3ClusterServices) HeartbeatService(
+	service services.ServiceID,
+) (services.HeartbeatService, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (s *m3ClusterServices) Query(
@@ -224,8 +240,8 @@ func (s *m3ClusterPlacementService) AddReplica() (
 }
 func (s *m3ClusterPlacementService) AddInstance(
 	candidates []services.PlacementInstance,
-) (services.ServicePlacement, error) {
-	return nil, fmt.Errorf("not implemented")
+) (services.ServicePlacement, services.PlacementInstance, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 func (s *m3ClusterPlacementService) RemoveInstance(
 	leavingInstanceID string,
@@ -234,8 +250,8 @@ func (s *m3ClusterPlacementService) RemoveInstance(
 }
 func (s *m3ClusterPlacementService) ReplaceInstance(
 	leavingInstanceID string, candidates []services.PlacementInstance,
-) (services.ServicePlacement, error) {
-	return nil, fmt.Errorf("not implemented")
+) (services.ServicePlacement, []services.PlacementInstance, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 func (s *m3ClusterPlacementService) MarkShardAvailable(
 	instanceID string, shardID uint32,

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -245,7 +245,7 @@ func newDefaultBootstrappableTestSetups(
 		logger = logger.WithFields(xlog.NewLogField("instance", instance))
 		iopts := setup.storageOpts.InstrumentOptions().SetLogger(logger)
 		if testStatsReporter != nil {
-			scope, _ := tally.NewRootScope("", nil, testStatsReporter, 100*time.Millisecond, tally.DefaultSeparator)
+			scope, _ := tally.NewRootScope(tally.ScopeOptions{Reporter: testStatsReporter}, 100*time.Millisecond)
 			iopts = iopts.SetMetricsScope(scope)
 		}
 		setup.storageOpts = setup.storageOpts.SetInstrumentOptions(iopts)

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -207,12 +207,15 @@ func writeCommitLogs(
 
 	getAllWrites := func() int {
 		result := int64(0)
-		snapshot := scope.Snapshot()
-		counters := snapshot.Counters()
-		if c, ok := counters["commitlog.writes.success"]; ok {
+		counters := scope.Snapshot().Counters()
+
+		successID := tally.KeyForPrefixedStringMap("commitlog.writes.success", nil)
+		if c, ok := counters[successID]; ok {
 			result += c.Value()
 		}
-		if c, ok := counters["commitlog.writes.errors"]; ok {
+
+		errorsID := tally.KeyForPrefixedStringMap("commitlog.writes.errors", nil)
+		if c, ok := counters[errorsID]; ok {
 			result += c.Value()
 		}
 		return int(result)

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -206,10 +206,15 @@ func writeCommitLogs(
 	wg := sync.WaitGroup{}
 
 	getAllWrites := func() int {
+		result := int64(0)
 		snapshot := scope.Snapshot()
 		counters := snapshot.Counters()
-		result := counters["commitlog.writes.success"].Value() +
-			counters["commitlog.writes.errors"].Value()
+		if c, ok := counters["commitlog.writes.success"]; ok {
+			result += c.Value()
+		}
+		if c, ok := counters["commitlog.writes.errors"]; ok {
+			result += c.Value()
+		}
 		return int(result)
 	}
 

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -512,7 +512,7 @@ func TestNamespaceAssignShardSet(t *testing.T) {
 	dopts := testDatabaseOptions()
 
 	reporter := xmetrics.NewTestStatsReporter(xmetrics.NewTestStatsReporterOptions())
-	scope, closer := tally.NewRootScope("", nil, reporter, time.Millisecond, tally.DefaultSeparator)
+	scope, closer := tally.NewRootScope(tally.ScopeOptions{Reporter: reporter}, time.Millisecond)
 	defer closer.Close()
 
 	dopts = dopts.SetInstrumentOptions(dopts.InstrumentOptions().

--- a/x/metrics/test_reporter.go
+++ b/x/metrics/test_reporter.go
@@ -121,6 +121,28 @@ func (r *testStatsReporter) ReportTimer(name string, tags map[string]string, int
 	r.Unlock()
 }
 
+func (r *testStatsReporter) ReportHistogramValueSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound float64,
+	samples int64,
+) {
+	// TODO: implement
+}
+
+func (r *testStatsReporter) ReportHistogramDurationSamples(
+	name string,
+	tags map[string]string,
+	buckets tally.Buckets,
+	bucketLowerBound,
+	bucketUpperBound time.Duration,
+	samples int64,
+) {
+	// TODO: implement
+}
+
 func (r *testStatsReporter) Capabilities() tally.Capabilities {
 	return r
 }


### PR DESCRIPTION
Upgrading vendored packages to latest versions. 

- Update Makefile to `m3db/ci-scripts` convention 
- Pull latest m3cluster version, corresponding changes
- Pull latest Tally version, corresponding changes

/cc @robskillington 