### PR TITLE
Update to latest m3em

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: da7d0f254167eb396d3d419950ca553da8fabd7bec70b0e2f94e086731addf3d
-updated: 2017-06-09T17:46:10.420972332-04:00
+hash: db31f8e4a8d2ef268db1a74eb24a5ad032ca5976a338f897dbba09394ff27049
+updated: 2017-06-19T13:23:16.778444112-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -69,7 +69,7 @@ imports:
   - services/placement/service
   - shard
 - name: github.com/m3db/m3em
-  version: b2df2120f842f90e734eb8048bcc5b02cd8e199b
+  version: f5b48d1c5d2d6a990b8b4ef534a3431639027c12
   subpackages:
   - build
   - checksum

--- a/glide.yaml
+++ b/glide.yaml
@@ -65,7 +65,7 @@ import:
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
 
 - package: github.com/m3db/m3em
-  version: b2df2120f842f90e734eb8048bcc5b02cd8e199b
+  version: f5b48d1c5d2d6a990b8b4ef534a3431639027c12
 
 - package: github.com/spf13/cobra
   version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f


### PR DESCRIPTION
Got a bunch of build issues with Travis today. e.g. [failed build](https://travis-ci.org/m3db/m3db/builds/244590286?utm_source=github_status&utm_medium=notification). 

```
[ERROR]	Failed to set version on github.com/m3db/m3em to b2df2120f842f90e734eb8048bcc5b02cd8e199b: Unable to update checked out version
[DEBUG]	Output was: fatal: reference is not a tree: b2df2120f842f90e734eb8048bcc5b02cd8e199b
```

It's complaining about a reference it can't find, but it exists afaict [b2df2120f842f90e734eb8048bcc5b02cd8e199b](https://github.com/m3db/m3em/commit/b2df2120f842f90e734eb8048bcc5b02cd8e199b)

Not sure what's going on. Updating to the latest m3em head seems to resolve this. 

