### PR TITLE
Cleanup import ordering in repository

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -24,7 +24,8 @@
 package client
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time0 "time"
+
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
 	encoding "github.com/m3db/m3db/encoding"
@@ -37,8 +38,9 @@ import (
 	pool "github.com/m3db/m3x/pool"
 	retry "github.com/m3db/m3x/retry"
 	time "github.com/m3db/m3x/time"
+
+	gomock "github.com/golang/mock/gomock"
 	tchannel_go "github.com/uber/tchannel-go"
-	time0 "time"
 )
 
 // Mock of Client interface

--- a/client/connection_pool_test.go
+++ b/client/connection_pool_test.go
@@ -27,11 +27,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3db/topology"
 	xclose "github.com/m3db/m3x/close"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -44,9 +44,9 @@ import (
 	"github.com/m3db/m3x/retry"
 	"github.com/m3db/m3x/sync"
 	"github.com/m3db/m3x/time"
+	"github.com/m3db/m3db/storage/block"
 
 	"github.com/golang/mock/gomock"
-	"github.com/m3db/m3db/storage/block"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/client/session_topology_test.go
+++ b/client/session_topology_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/integration/fake"
 	"github.com/m3db/m3db/topology"
-	"github.com/uber-go/tally"
 
+	"github.com/uber-go/tally"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client/session_write_test.go
+++ b/client/session_write_test.go
@@ -34,8 +34,8 @@ import (
 	xmetrics "github.com/m3db/m3db/x/metrics"
 	xerrors "github.com/m3db/m3x/errors"
 	xtime "github.com/m3db/m3x/time"
-	"github.com/uber-go/tally"
 
+	"github.com/uber-go/tally"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/topology"
-
-	"github.com/golang/mock/gomock"
 	tterrors "github.com/m3db/m3db/network/server/tchannelthrift/errors"
 	xerrors "github.com/m3db/m3x/errors"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -24,14 +24,16 @@
 package encoding
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	io0 "io"
+	time0 "time"
+
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
 	checked "github.com/m3db/m3x/checked"
 	pool "github.com/m3db/m3x/pool"
 	time "github.com/m3db/m3x/time"
-	io0 "io"
-	time0 "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Encoder interface

--- a/generated/thrift/rpc/rpc-consts.go
+++ b/generated/thrift/rpc/rpc-consts.go
@@ -26,6 +26,7 @@ package rpc
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/apache/thrift/lib/go/thrift"
 )
 

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -28,6 +28,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+
 	"github.com/apache/thrift/lib/go/thrift"
 )
 

--- a/integration/admin_session_fetch_blocks_test.go
+++ b/integration/admin_session_fetch_blocks_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3db/integration/generate"
 	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/ts"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/integration/cluster_add_one_node_test.go
+++ b/integration/cluster_add_one_node_test.go
@@ -33,9 +33,9 @@ import (
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
 	xlog "github.com/m3db/m3x/log"
-
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/integration/disk_cleanup_test.go
+++ b/integration/disk_cleanup_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/storage"
 	"github.com/m3db/m3db/ts"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/integration/generate/writer.go
+++ b/integration/generate/writer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/ts"
-
 	"github.com/m3db/m3x/checked"
 	xtime "github.com/m3db/m3x/time"
 )

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -41,9 +41,9 @@ import (
 	xmetrics "github.com/m3db/m3db/x/metrics"
 	"github.com/m3db/m3x/instrument"
 	xlog "github.com/m3db/m3x/log"
-	"github.com/uber-go/tally"
-
 	"github.com/m3db/m3cluster/shard"
+
+	"github.com/uber-go/tally"
 	"github.com/stretchr/testify/require"
 )
 

--- a/integration/roundtrip_test.go
+++ b/integration/roundtrip_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3db/integration/generate"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/integration/write_quorum_test.go
+++ b/integration/write_quorum_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
 	xtime "github.com/m3db/m3x/time"
-
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/network/server/tchannelthrift/node/service_test.go
+++ b/network/server/tchannelthrift/node/service_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/m3db/m3db/ts"
 	xio "github.com/m3db/m3db/x/io"
 	xtime "github.com/m3db/m3x/time"
+	"github.com/m3db/m3db/digest"
 
 	"github.com/golang/mock/gomock"
-	"github.com/m3db/m3db/digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/thrift"

--- a/persist/fs/clone/cloner_test.go
+++ b/persist/fs/clone/cloner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/checked"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/persist/fs/commitlog/commit_log_mock.go
+++ b/persist/fs/commitlog/commit_log_mock.go
@@ -24,7 +24,8 @@
 package commitlog
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
 	fs "github.com/m3db/m3db/persist/fs"
@@ -33,7 +34,8 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	time0 "github.com/m3db/m3x/time"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of CommitLog interface

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/time"
-	"github.com/uber-go/tally"
 
+	"github.com/uber-go/tally"
 	mclock "github.com/facebookgo/clock"
 	"github.com/stretchr/testify/assert"
 )

--- a/persist/fs/commitlog/iterator.go
+++ b/persist/fs/commitlog/iterator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
+
 	"github.com/uber-go/tally"
 )
 

--- a/persist/fs/fs_mock.go
+++ b/persist/fs/fs_mock.go
@@ -24,11 +24,13 @@
 package fs
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	ts "github.com/m3db/m3db/ts"
 	checked "github.com/m3db/m3x/checked"
 	time0 "github.com/m3db/m3x/time"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of FileSetWriter interface

--- a/persist/fs/read.go
+++ b/persist/fs/read.go
@@ -33,7 +33,6 @@ import (
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/time"
-
 	"github.com/m3db/m3db/digest"
 )
 

--- a/persist/fs/read_write_test.go
+++ b/persist/fs/read_write_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/persist/fs/retriever_options.go
+++ b/persist/fs/retriever_options.go
@@ -22,7 +22,6 @@ package fs
 
 import (
 	"github.com/m3db/m3db/x/io"
-
 	"github.com/m3db/m3x/pool"
 )
 

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -34,7 +34,6 @@ import (
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/time"
-
 	"github.com/m3db/m3db/digest"
 )
 

--- a/persist/persist_mock.go
+++ b/persist/persist_mock.go
@@ -24,9 +24,11 @@
 package persist
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	ts "github.com/m3db/m3db/ts"
 	time "time"
+
+	ts "github.com/m3db/m3db/ts"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Manager interface

--- a/storage/block/block_mock.go
+++ b/storage/block/block_mock.go
@@ -24,7 +24,8 @@
 package block
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	context "github.com/m3db/m3db/context"
 	encoding "github.com/m3db/m3db/encoding"
 	ts "github.com/m3db/m3db/ts"
@@ -32,7 +33,8 @@ import (
 	clock "github.com/m3db/m3x/clock"
 	pool "github.com/m3db/m3x/pool"
 	sync "github.com/m3db/m3x/sync"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of FilteredBlocksMetadataIter interface

--- a/storage/block/result_test.go
+++ b/storage/block/result_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3db/ts"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -24,9 +24,10 @@
 package bootstrap
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	result "github.com/m3db/m3db/storage/bootstrap/result"
 	ts "github.com/m3db/m3db/ts"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Process interface

--- a/storage/bootstrap/bootstrapper/fs/source_test.go
+++ b/storage/bootstrap/bootstrapper/fs/source_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/digest"
 	"github.com/m3db/m3db/persist/encoding/msgpack"
@@ -41,6 +40,7 @@ import (
 	"github.com/m3db/m3x/pool"
 	"github.com/m3db/m3x/time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 

--- a/storage/cluster/cluster_test.go
+++ b/storage/cluster/cluster_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/storage"
@@ -32,6 +31,8 @@ import (
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/watch"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 

--- a/storage/cluster/database_test.go
+++ b/storage/cluster/database_test.go
@@ -25,12 +25,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/storage"
 	"github.com/m3db/m3db/storage/namespace"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/storage/flush_test.go
+++ b/storage/flush_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )

--- a/storage/series/buffer_mock.go
+++ b/storage/series/buffer_mock.go
@@ -24,12 +24,14 @@
 package series
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	context "github.com/m3db/m3db/context"
 	block "github.com/m3db/m3db/storage/block"
 	io "github.com/m3db/m3db/x/io"
 	time0 "github.com/m3db/m3x/time"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of databaseBuffer interface

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -26,13 +26,14 @@ package series
 import (
 	time0 "time"
 
-	gomock "github.com/golang/mock/gomock"
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
 	block "github.com/m3db/m3db/storage/block"
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
 	time "github.com/m3db/m3x/time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of DatabaseSeries interface

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -24,7 +24,8 @@
 package storage
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
 	encoding "github.com/m3db/m3db/encoding"
@@ -44,7 +45,8 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	time0 "github.com/m3db/m3x/time"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Database interface

--- a/tools/clone_fileset/main/main.go
+++ b/tools/clone_fileset/main/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/m3db/m3db/persist/fs/clone"
-
 	xlog "github.com/m3db/m3x/log"
 	xtime "github.com/m3db/m3x/time"
 )

--- a/tools/dtest/config/config.go
+++ b/tools/dtest/config/config.go
@@ -5,9 +5,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	etcdclient "github.com/m3db/m3cluster/client/etcd"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/services/placement"
@@ -18,6 +15,9 @@ import (
 	"github.com/m3db/m3em/x/grpc"
 	"github.com/m3db/m3x/config"
 	xlog "github.com/m3db/m3x/log"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Configuration is a collection of knobs to control test behavior

--- a/tools/dtest/config/opts.go
+++ b/tools/dtest/config/opts.go
@@ -3,9 +3,9 @@ package config
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	xerrors "github.com/m3db/m3x/errors"
+
+	"github.com/spf13/cobra"
 )
 
 // Args represents the CLI arguments to be set during a dtest

--- a/tools/dtest/tests/add_down_node_bring_up.go
+++ b/tools/dtest/tests/add_down_node_bring_up.go
@@ -1,10 +1,10 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
 	"github.com/m3db/m3em/node"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/add_up_node_remove.go
+++ b/tools/dtest/tests/add_up_node_remove.go
@@ -1,11 +1,11 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/tools/dtest/harness"
 	xclock "github.com/m3db/m3x/clock"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/dtest.go
+++ b/tools/dtest/tests/dtest.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/config"
 	"github.com/m3db/m3x/log"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/remove_down_node.go
+++ b/tools/dtest/tests/remove_down_node.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var removeDownNodeTestCmd = &cobra.Command{

--- a/tools/dtest/tests/remove_up_node.go
+++ b/tools/dtest/tests/remove_up_node.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var removeUpNodeTestCmd = &cobra.Command{

--- a/tools/dtest/tests/replace_down_node.go
+++ b/tools/dtest/tests/replace_down_node.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/replace_up_node.go
+++ b/tools/dtest/tests/replace_up_node.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/replace_up_node_remove.go
+++ b/tools/dtest/tests/replace_up_node_remove.go
@@ -1,11 +1,11 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/tools/dtest/harness"
 	xclock "github.com/m3db/m3x/clock"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/replace_up_node_remove_unseeded.go
+++ b/tools/dtest/tests/replace_up_node_remove_unseeded.go
@@ -1,11 +1,11 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/tools/dtest/harness"
 	xclock "github.com/m3db/m3x/clock"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/tools/dtest/tests/seeded_bootstrap.go
+++ b/tools/dtest/tests/seeded_bootstrap.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var seededBootstrapTestCmd = &cobra.Command{

--- a/tools/dtest/tests/simple_bootstrap.go
+++ b/tools/dtest/tests/simple_bootstrap.go
@@ -1,9 +1,9 @@
 package dtests
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/m3db/m3db/tools/dtest/harness"
+
+	"github.com/spf13/cobra"
 )
 
 var simpleBootstrapTestCmd = &cobra.Command{

--- a/tools/dtest/util/seed/generator_test.go
+++ b/tools/dtest/util/seed/generator_test.go
@@ -12,14 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-
 	"github.com/m3db/m3db/integration/generate"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/instrument"
 	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerator(t *testing.T) {

--- a/tools/read_index_ids/main/main.go
+++ b/tools/read_index_ids/main/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/m3db/m3db/ts"
 	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/pool"
+
 	"github.com/pborman/getopt"
 )
 

--- a/topology/dynamic_test.go
+++ b/topology/dynamic_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/topology/host_test.go
+++ b/topology/host_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/ts"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/topology/topology_mock.go
+++ b/topology/topology_mock.go
@@ -24,13 +24,15 @@
 package topology
 
 import (
-	gomock "github.com/golang/mock/gomock"
+	time "time"
+
 	client "github.com/m3db/m3cluster/client"
 	services "github.com/m3db/m3cluster/services"
 	sharding "github.com/m3db/m3db/sharding"
 	ts "github.com/m3db/m3db/ts"
 	instrument "github.com/m3db/m3x/instrument"
-	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Host interface

--- a/x/io/io_mock.go
+++ b/x/io/io_mock.go
@@ -24,9 +24,11 @@
 package xio
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	ts "github.com/m3db/m3db/ts"
 	io "io"
+
+	ts "github.com/m3db/m3db/ts"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of ReaderSliceReader interface

--- a/x/m3em/convert/convert.go
+++ b/x/m3em/convert/convert.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	m3emnode "github.com/m3db/m3db/x/m3em/node"
-
 	"github.com/m3db/m3em/node"
 )
 

--- a/x/m3em/node/node.go
+++ b/x/m3em/node/node.go
@@ -25,12 +25,11 @@ import (
 	"sync"
 
 	"github.com/m3db/m3em/node"
+	m3dbrpc "github.com/m3db/m3db/generated/thrift/rpc"
+	m3dbchannel "github.com/m3db/m3db/network/server/tchannelthrift/node/channel"
 
 	tchannel "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
-
-	m3dbrpc "github.com/m3db/m3db/generated/thrift/rpc"
-	m3dbchannel "github.com/m3db/m3db/network/server/tchannelthrift/node/channel"
 )
 
 type m3emNode struct {

--- a/x/m3em/node/node_test.go
+++ b/x/m3em/node/node_test.go
@@ -23,14 +23,14 @@ package m3db
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	m3dbrpc "github.com/m3db/m3db/generated/thrift/rpc"
 	"github.com/m3db/m3em/generated/proto/m3em"
 	"github.com/m3db/m3em/node"
 	mocknode "github.com/m3db/m3em/node/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func newTestOptions() Options {

--- a/x/m3em/node/options.go
+++ b/x/m3em/node/options.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/m3db/m3em/node"
-
 	"github.com/m3db/m3x/instrument"
 )
 

--- a/x/m3em/node/types.go
+++ b/x/m3em/node/types.go
@@ -22,7 +22,6 @@ package m3db
 
 import (
 	"github.com/m3db/m3em/node"
-
 	"github.com/m3db/m3x/instrument"
 )
 


### PR DESCRIPTION
Wrote a little [script](https://gist.github.com/prateek/31484ec4211a3bbd2350b14a37596794#file-golang_import_order_cleaner-py) to order imports as per the convention:

```
import (
"stdlib"

"m3db-org-local"

"third-party"
)
```

Diff is the result of running against `m3db` repo.

/cc @robskillington @xichen2020 