### PR TITLE
Speed up commitlog bootstrapper by parallelizing bootstrapper and reader

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: db31f8e4a8d2ef268db1a74eb24a5ad032ca5976a338f897dbba09394ff27049
-updated: 2017-06-19T13:23:16.778444112-04:00
+hash: 496a8a8e24eb8ea51ddd2c4f7b91fd756a967fb5febd8535e873940efc3b13f5
+updated: 2017-07-13T10:05:34.240038157-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -216,7 +216,7 @@ imports:
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/vmihailenco/msgpack.v2
-  version: a1382b1ce0c749733b814157c245e02cc1f41076
+  version: f4f8982de4ef0de18be76456617cc3f5d8d8141e
   subpackages:
   - codes
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,7 +30,7 @@ import:
   - thrift
 
 - package: gopkg.in/vmihailenco/msgpack.v2
-  version: master
+  version: f4f8982de4ef0de18be76456617cc3f5d8d8141e
 
 - package: github.com/willf/bitset
   version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,7 +30,7 @@ import:
   - thrift
 
 - package: gopkg.in/vmihailenco/msgpack.v2
-  version: a1382b1ce0c749733b814157c245e02cc1f41076
+  version: master
 
 - package: github.com/willf/bitset
   version: 5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -103,6 +103,9 @@ func writeCommitLog(
 		// write this point
 		idx, ok := indexes[point.ID.String()]
 		require.True(t, ok)
+		// fmt.Println("ID: ", point.ID)
+		// fmt.Println("Shard: ", shardSet.Lookup(point.ID))
+		// fmt.Println("-------------------------------------")
 		cId := commitlog.Series{
 			Namespace:   namespace,
 			Shard:       shardSet.Lookup(point.ID),

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -1,0 +1,132 @@
+// +build integration
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/context"
+	"github.com/m3db/m3db/integration/generate"
+	"github.com/m3db/m3db/persist/fs/commitlog"
+	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	defaultIntegrationTestFlushInterval = 10 * time.Millisecond
+)
+
+func computeMetricIndexes(timeBlocks generate.SeriesBlocksByStart) map[string]uint64 {
+	var idx uint64
+	indexes := make(map[string]uint64)
+	for _, blks := range timeBlocks {
+		for _, blk := range blks {
+			id := blk.ID.String()
+			if _, ok := indexes[id]; !ok {
+				indexes[id] = idx
+				idx++
+			}
+		}
+	}
+	return indexes
+}
+
+func writeCommitLog(
+	t *testing.T,
+	s *testSetup,
+	data generate.SeriesBlocksByStart,
+	namespace ts.ID,
+) {
+	indexes := computeMetricIndexes(data)
+	opts := s.storageOpts.CommitLogOptions()
+
+	// ensure commit log is flushing frequently
+	require.Equal(t, defaultIntegrationTestFlushInterval, opts.FlushInterval())
+	ctx := context.NewContext()
+
+	var (
+		shardSet  = s.shardSet
+		points    = generate.ToPointsByTime(data) // points are sorted in chronological order
+		blockSize = opts.RetentionOptions().BlockSize()
+		commitLog commitlog.CommitLog
+		now       time.Time
+	)
+
+	closeCommitLogFn := func() {
+		if commitLog != nil {
+			// wait a bit to ensure writes are done, and then close the commit log
+			time.Sleep(10 * defaultIntegrationTestFlushInterval)
+			require.NoError(t, commitLog.Close())
+		}
+
+	}
+
+	for _, point := range points {
+		pointTime := point.Timestamp
+
+		// check if this point falls in the current commit log block
+		if truncated := pointTime.Truncate(blockSize); truncated != now {
+			// close commit log if it exists
+			closeCommitLogFn()
+			// move time forward
+			now = truncated
+			s.setNowFn(now)
+			// create new commit log
+			commitLog = commitlog.NewCommitLog(opts)
+			require.NoError(t, commitLog.Open())
+		}
+
+		// write this point
+		idx, ok := indexes[point.ID.String()]
+		require.True(t, ok)
+		cId := commitlog.Series{
+			Namespace:   namespace,
+			Shard:       shardSet.Lookup(point.ID),
+			ID:          point.ID,
+			UniqueIndex: idx,
+		}
+		require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
+	}
+
+	closeCommitLogFn()
+}
+
+func testSetupMetadatas(
+	t *testing.T,
+	testSetup *testSetup,
+	namespace ts.ID,
+	start time.Time,
+	end time.Time,
+) map[uint32][]block.ReplicaMetadata {
+	// Retrieve written data using the AdminSession APIs
+	// FetchMetadataBlocksFromPeers/FetchBlocksFromPeers
+	adminClient := testSetup.m3dbAdminClient
+	metadatasByShard, err := m3dbClientFetchBlocksMetadata(
+		adminClient, namespace, testSetup.shardSet.AllIDs(), start, end)
+	require.NoError(t, err)
+	return metadatasByShard
+}

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -1,0 +1,96 @@
+// +build integration
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/integration/generate"
+	"github.com/m3db/m3db/retention"
+	"github.com/m3db/m3db/storage/bootstrap"
+	"github.com/m3db/m3db/storage/bootstrap/bootstrapper"
+	bcl "github.com/m3db/m3db/storage/bootstrap/bootstrapper/commitlog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitLogBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow() // Just skip if we're doing a short run
+	}
+
+	// Test setup
+	var (
+		ropts     = retention.NewOptions().SetRetentionPeriod(12 * time.Hour)
+		blockSize = ropts.BlockSize()
+		testOpts  = newTestOptions()
+	)
+	setup, err := newTestSetup(testOpts)
+	require.NoError(t, err)
+	defer setup.close()
+
+	commitLogOpts := setup.storageOpts.CommitLogOptions().
+		SetFlushInterval(defaultIntegrationTestFlushInterval).
+		SetRetentionOptions(ropts)
+	setup.storageOpts = setup.storageOpts.SetCommitLogOptions(commitLogOpts)
+
+	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	bsOpts := newDefaulTestResultOptions(setup.storageOpts, setup.storageOpts.InstrumentOptions())
+	bclOpts := bcl.NewOptions().
+		SetResultOptions(bsOpts).
+		SetCommitLogOptions(commitLogOpts)
+	bs := bcl.NewCommitLogBootstrapper(bclOpts, noOpAll)
+	process := bootstrap.NewProcess(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+
+	log := setup.storageOpts.InstrumentOptions().Logger()
+	log.Info("commit log bootstrap test")
+
+	// Write test data
+	log.Info("generating data")
+	now := setup.getNowFn()
+	seriesMaps := generate.BlocksByStart([]generate.BlockConfig{
+		{[]string{"foo", "bar"}, 20, now.Add(-2 * blockSize)},
+		{[]string{"bar", "baz"}, 50, now.Add(-blockSize)},
+	})
+	log.Info("writing data")
+	writeCommitLog(t, setup, seriesMaps, testNamespaces[0])
+	log.Info("written data")
+
+	setup.setNowFn(now)
+	// Start the server with filesystem bootstrapper
+	require.NoError(t, setup.startServer())
+	log.Debug("server is now up")
+
+	// Stop the server
+	defer func() {
+		require.NoError(t, setup.stopServer())
+		log.Debug("server is now down")
+	}()
+
+	// Verify in-memory data match what we expect
+	metadatasByShard := testSetupMetadatas(t, setup, testNamespaces[0], now.Add(-2*blockSize), now)
+	observedSeriesMaps := testSetupToSeriesMaps(t, setup, testNamespaces[0], metadatasByShard)
+	verifySeriesMapsEqual(t, seriesMaps, observedSeriesMaps)
+}

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -90,7 +90,9 @@ func TestCommitLogBootstrap(t *testing.T) {
 		}
 
 		blockConfig = append(blockConfig, generate.BlockConfig{
-			IDs: name, NumPoints: rand.Intn(100) + 1, Start: now.Add(-2 * blockSize).Add(time.Duration(i) * time.Minute),
+			IDs: name,
+			NumPoints: rand.Intn(100) + 1,
+			Start: now.Add(-2 * blockSize).Add(time.Duration(i) * time.Minute),
 		}
 	}
 	seriesMaps := generate.BlocksByStart(blockConfig)

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -90,10 +90,10 @@ func TestCommitLogBootstrap(t *testing.T) {
 		}
 
 		blockConfig = append(blockConfig, generate.BlockConfig{
-			IDs: name,
+			IDs:       name,
 			NumPoints: rand.Intn(100) + 1,
-			Start: now.Add(-2 * blockSize).Add(time.Duration(i) * time.Minute),
-		}
+			Start:     now.Add(-2 * blockSize).Add(time.Duration(i) * time.Minute),
+		})
 	}
 	seriesMaps := generate.BlocksByStart(blockConfig)
 	log.Info("writing data")

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -23,6 +23,7 @@
 package integration
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -34,6 +35,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
 
 func TestCommitLogBootstrap(t *testing.T) {
 	if testing.Short() {
@@ -70,10 +81,19 @@ func TestCommitLogBootstrap(t *testing.T) {
 	// Write test data
 	log.Info("generating data")
 	now := setup.getNowFn()
-	seriesMaps := generate.BlocksByStart([]generate.BlockConfig{
-		{[]string{"foo", "bar"}, 20, now.Add(-2 * blockSize)},
-		{[]string{"bar", "baz"}, 50, now.Add(-blockSize)},
-	})
+
+	blockConfig := []generate.BlockConfig{}
+	for i := 0; i < 30; i++ {
+		name := []string{}
+		for j := 0; j < rand.Intn(10)+1; j++ {
+			name = append(name, randStringRunes(100))
+		}
+
+		blockConfig = append(blockConfig, generate.BlockConfig{
+			IDs: name, NumPoints: rand.Intn(100) + 1, Start: now.Add(-2 * blockSize).Add(time.Duration(i) * time.Minute),
+		}
+	}
+	seriesMaps := generate.BlocksByStart(blockConfig)
 	log.Info("writing data")
 	writeCommitLog(t, setup, seriesMaps, testNamespaces[0])
 	log.Info("written data")

--- a/integration/generate/generate.go
+++ b/integration/generate/generate.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"bytes"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/m3db/m3db/encoding/testgen"
@@ -48,4 +49,32 @@ func BlocksByStart(confs []BlockConfig) SeriesBlocksByStart {
 		seriesMaps[conf.Start] = Block(conf)
 	}
 	return seriesMaps
+}
+
+// ToPointsByTime converts a SeriesBlocksByStart to SeriesDataPointsByTime
+func ToPointsByTime(seriesMaps SeriesBlocksByStart) SeriesDataPointsByTime {
+	var pointsByTime SeriesDataPointsByTime
+	for _, blks := range seriesMaps {
+		for _, blk := range blks {
+			for _, dp := range blk.Data {
+				pointsByTime = append(pointsByTime, SeriesDataPoint{
+					ID:        blk.ID,
+					Datapoint: dp,
+				})
+			}
+		}
+	}
+	sort.Sort(pointsByTime)
+	return pointsByTime
+}
+
+// Making SeriesDataPointsByTimes sortable
+
+func (l SeriesDataPointsByTime) Len() int      { return len(l) }
+func (l SeriesDataPointsByTime) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l SeriesDataPointsByTime) Less(i, j int) bool {
+	if !l[i].Timestamp.Equal(l[j].Timestamp) {
+		return l[i].Timestamp.Before(l[j].Timestamp)
+	}
+	return bytes.Compare(l[i].ID.Data().Get(), l[j].ID.Data().Get()) < 0
 }

--- a/integration/generate/types.go
+++ b/integration/generate/types.go
@@ -23,6 +23,15 @@ type Series struct {
 	Data []ts.Datapoint
 }
 
+// SeriesDataPoint represents a single data point of a generated series of data
+type SeriesDataPoint struct {
+	ts.Datapoint
+	ID ts.ID
+}
+
+// SeriesDataPointsByTime are a sorted list of SeriesDataPoints
+type SeriesDataPointsByTime []SeriesDataPoint
+
 // SeriesBlock is a collection of Series'
 type SeriesBlock []Series
 

--- a/persist/fs/commitlog/iterator.go
+++ b/persist/fs/commitlog/iterator.go
@@ -67,7 +67,6 @@ func NewIterator(opts Options) (Iterator, error) {
 	iops := opts.InstrumentOptions()
 	iops = iops.SetMetricsScope(iops.MetricsScope().SubScope("iterator"))
 	fsopts := opts.FilesystemOptions()
-	// Get a list of all the commit log files in a specified DIR
 	files, err := fs.CommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	if err != nil {
 		return nil, err
@@ -148,8 +147,6 @@ func (i *iterator) nextReader() bool {
 		i.reader = nil
 	}
 
-	// Shift list of files to read left <--
-	// Basically popping off the left side until its empty
 	file := i.files[0]
 	i.files = i.files[1:]
 

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -331,7 +331,7 @@ func (s *commitLogSource) Read(
 	wg.Wait()
 
 	endMergeTime := time.Now()
-	s.log.Errorf("Complete merge took: %f\n", endMergeTime.Sub(startMergeTime).Seconds())
+	s.log.Infof("Complete merge took: %fs\n", endMergeTime.Sub(startMergeTime).Seconds())
 	errSum = 0
 	for _, numErrs := range shardErrs {
 		errSum += numErrs

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -23,6 +23,7 @@ package commitlog
 import (
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/m3db/m3db/encoding"
@@ -49,8 +50,20 @@ type encoder struct {
 }
 
 type encoderMap struct {
-	id       ts.ID
-	encoders map[time.Time][]encoder
+	id ts.ID
+	// int64 instead of time.Time because there is an optimized map access pattern
+	// for i64's
+	encoders map[int64][]encoder
+}
+
+// encoderArg contains all the information a worker go-routine needs to encode
+// a data point as M3TSZ
+type encoderArg struct {
+	series     commitlog.Series
+	dp         ts.Datapoint
+	unit       xtime.Unit
+	annotation ts.Annotation
+	blockStart time.Time
 }
 
 func newCommitLogSource(opts Options) bootstrap.Source {
@@ -95,155 +108,244 @@ func (s *commitLogSource) Read(
 	defer iter.Close()
 
 	var (
-		unmerged    = make(map[uint32]map[ts.Hash]encoderMap)
+		numShards = len(shardsTimeRanges)
+		unmerged  = make([]map[ts.Hash]encoderMap, numShards, numShards)
+		// TODO: Add to opts
+		numConc     = uint32(4)
 		bopts       = s.opts.ResultOptions()
 		blopts      = bopts.DatabaseBlockOptions()
 		blockSize   = bopts.RetentionOptions().BlockSize()
 		encoderPool = bopts.DatabaseBlockOptions().EncoderPool()
-		errs        = 0
 	)
-	for iter.Next() {
-		series, dp, unit, annotation := iter.Current()
-		ranges, ok := shardsTimeRanges[series.Shard]
-		if !ok {
-			// Not bootstrapping this shard
-			continue
-		}
 
-		blockStart := dp.Timestamp.Truncate(blockSize)
-		blockEnd := blockStart.Add(blockSize)
-		blockRange := xtime.Range{
-			Start: blockStart,
-			End:   blockEnd,
-		}
-		if !ranges.Overlaps(blockRange) {
-			// Data in this block does not match the requested ranges
-			continue
-		}
-
-		unmergedShard, ok := unmerged[series.Shard]
-		if !ok {
-			unmergedShard = make(map[ts.Hash]encoderMap)
-			unmerged[series.Shard] = unmergedShard
-		}
-
-		unmergedSeries, ok := unmergedShard[series.ID.Hash()]
-		if !ok {
-			unmergedSeries = encoderMap{
-				id:       series.ID,
-				encoders: make(map[time.Time][]encoder)}
-			unmergedShard[series.ID.Hash()] = unmergedSeries
-		}
-
-		var (
-			err           error
-			unmergedBlock = unmergedSeries.encoders[blockStart]
-			wroteExisting = false
-		)
-		for i := range unmergedBlock {
-			if unmergedBlock[i].lastWriteAt.Before(dp.Timestamp) {
-				unmergedBlock[i].lastWriteAt = dp.Timestamp
-				err = unmergedBlock[i].enc.Encode(dp, unit, annotation)
-				wroteExisting = true
-				break
-			}
-		}
-		if !wroteExisting {
-			enc := encoderPool.Get()
-			enc.Reset(blockStart, blopts.DatabaseBlockAllocSize())
-
-			err = enc.Encode(dp, unit, annotation)
-			if err == nil {
-				unmergedBlock = append(unmergedBlock, encoder{
-					lastWriteAt: dp.Timestamp,
-					enc:         enc,
-				})
-				unmergedSeries.encoders[blockStart] = unmergedBlock
-			}
-		}
-		if err != nil {
-			errs++
-		}
+	encoderChans := []chan encoderArg{}
+	for i := uint32(0); i < numConc; i++ {
+		encoderChans = append(encoderChans, make(chan encoderArg, 1000))
 	}
-	if errs > 0 {
-		s.log.Errorf("error bootstrapping from commit log: %d block encode errors", errs)
+
+	// One routine to handle IO
+	go func() {
+		for iter.Next() {
+			series, dp, unit, annotation := iter.Current()
+			ranges, ok := shardsTimeRanges[series.Shard]
+			if !ok {
+				// Not bootstrapping this shard
+				continue
+			}
+
+			blockStart := dp.Timestamp.Truncate(blockSize)
+			blockEnd := blockStart.Add(blockSize)
+			blockRange := xtime.Range{
+				Start: blockStart,
+				End:   blockEnd,
+			}
+			if !ranges.Overlaps(blockRange) {
+				// Data in this block does not match the requested ranges
+				continue
+			}
+
+			// Distribute work such that each encoder goroutine is responsible for
+			// approximately numShards / numConc shards. This also means that all
+			// datapoints for a given shard/series will be processed in a serialized
+			// manner.
+			encoderChans[series.Shard%numConc] <- struct {
+				series     commitlog.Series
+				dp         ts.Datapoint
+				unit       xtime.Unit
+				annotation ts.Annotation
+				blockStart time.Time
+			}{
+				series:     series,
+				dp:         dp,
+				unit:       unit,
+				annotation: annotation,
+				blockStart: blockStart,
+			}
+		}
+		for _, encoderChan := range encoderChans {
+			close(encoderChan)
+		}
+	}()
+
+	// numConc routines to handle M3TSZ encoding
+	wg := sync.WaitGroup{}
+	workerErrs := make([]int, numConc, numConc)
+	for workerNum, encoderChan := range encoderChans {
+		wg.Add(1)
+		go func(workerNum int, ec <-chan encoderArg) {
+			for arg := range ec {
+				var (
+					series     = arg.series
+					dp         = arg.dp
+					unit       = arg.unit
+					annotation = arg.annotation
+					blockStart = arg.blockStart
+				)
+
+				unmergedShard := unmerged[series.Shard]
+				if unmergedShard == nil {
+					unmergedShard = make(map[ts.Hash]encoderMap)
+					unmerged[series.Shard] = unmergedShard
+				}
+
+				unmergedSeries, ok := unmergedShard[series.ID.Hash()]
+				if !ok {
+					unmergedSeries = encoderMap{
+						id:       series.ID,
+						encoders: make(map[int64][]encoder)}
+					unmergedShard[series.ID.Hash()] = unmergedSeries
+				}
+
+				var (
+					err           error
+					unmergedBlock = unmergedSeries.encoders[blockStart.UnixNano()]
+					wroteExisting = false
+				)
+				for i := range unmergedBlock {
+					if unmergedBlock[i].lastWriteAt.Before(dp.Timestamp) {
+						unmergedBlock[i].lastWriteAt = dp.Timestamp
+						err = unmergedBlock[i].enc.Encode(dp, unit, annotation)
+						wroteExisting = true
+						break
+					}
+				}
+				if !wroteExisting {
+					enc := encoderPool.Get()
+					enc.Reset(blockStart, blopts.DatabaseBlockAllocSize())
+
+					err = enc.Encode(dp, unit, annotation)
+					if err == nil {
+						unmergedBlock = append(unmergedBlock, encoder{
+							lastWriteAt: dp.Timestamp,
+							enc:         enc,
+						})
+						unmergedSeries.encoders[blockStart.UnixNano()] = unmergedBlock
+					}
+				}
+				if err != nil {
+					workerErrs[workerNum]++
+				}
+			}
+			wg.Done()
+		}(workerNum, encoderChan)
+	}
+
+	// Block until all data has been read and encoded by the worker goroutines
+	wg.Wait()
+	errSum := 0
+	for _, numErrs := range workerErrs {
+		errSum += numErrs
+	}
+	if errSum > 0 {
+		s.log.Errorf("error bootstrapping from commit log: %d block encode errors", errSum)
 	}
 	if err := iter.Err(); err != nil {
 		s.log.Errorf("error reading commit log: %v", err)
 	}
 
-	errs = 0
-	emptyErrs := 0
+	startMergeTime := time.Now()
+	shardErrs := make([]int, numShards, numShards)
+	shardEmptyErrs := make([]int, numShards, numShards)
 	bootstrapResult := result.NewBootstrapResult()
 	blocksPool := bopts.DatabaseBlockOptions().DatabaseBlockPool()
 	multiReaderIteratorPool := blopts.MultiReaderIteratorPool()
+	// Controls how many shards can be merged in parallel
+	mergeSemaphore := make(chan bool, numConc)
+	bootstrapResultLock := sync.Mutex{}
+	wg = sync.WaitGroup{}
+
 	for shard, unmergedShard := range unmerged {
-		shardResult := result.NewShardResult(len(unmergedShard), s.opts.ResultOptions())
-		for _, unmergedBlocks := range unmergedShard {
-			blocks := block.NewDatabaseSeriesBlocks(len(unmergedBlocks.encoders), blopts)
-			for start, unmergedBlock := range unmergedBlocks.encoders {
-				block := blocksPool.Get()
-				if len(unmergedBlock) == 0 {
-					emptyErrs++
-					continue
-				} else if len(unmergedBlock) == 1 {
-					block.Reset(start, unmergedBlock[0].enc.Discard())
-				} else {
-					readers := make([]io.Reader, len(unmergedBlock))
-					for i := range unmergedBlock {
-						stream := unmergedBlock[i].enc.Stream()
-						readers[i] = stream
-						defer stream.Finalize()
-					}
-
-					iter := multiReaderIteratorPool.Get()
-					iter.Reset(readers)
-
-					var err error
-					enc := encoderPool.Get()
-					enc.Reset(start, blopts.DatabaseBlockAllocSize())
-					for iter.Next() {
-						dp, unit, annotation := iter.Current()
-						encodeErr := enc.Encode(dp, unit, annotation)
-						if encodeErr != nil {
-							err = encodeErr
-							errs++
-							break
-						}
-					}
-					if iterErr := iter.Err(); iterErr != nil {
-						if err == nil {
-							err = iter.Err()
-						}
-						errs++
-					}
-
-					iter.Close()
-					for i := range unmergedBlock {
-						unmergedBlock[i].enc.Close()
-					}
-
-					if err != nil {
+		mergeSemaphore <- true
+		wg.Add(1)
+		go func(shard int, unmergedShard map[ts.Hash]encoderMap) {
+			shardResult := result.NewShardResult(len(unmergedShard), s.opts.ResultOptions())
+			for _, unmergedBlocks := range unmergedShard {
+				blocks := block.NewDatabaseSeriesBlocks(len(unmergedBlocks.encoders), blopts)
+				for start, unmergedBlock := range unmergedBlocks.encoders {
+					startInNano := time.Unix(0, start)
+					block := blocksPool.Get()
+					if len(unmergedBlock) == 0 {
+						shardEmptyErrs[shard]++
 						continue
-					}
+					} else if len(unmergedBlock) == 1 {
+						block.Reset(startInNano, unmergedBlock[0].enc.Discard())
+					} else {
+						readers := make([]io.Reader, len(unmergedBlock))
+						for i := range unmergedBlock {
+							stream := unmergedBlock[i].enc.Stream()
+							readers[i] = stream
+							defer stream.Finalize()
+						}
 
-					block.Reset(start, enc.Discard())
+						iter := multiReaderIteratorPool.Get()
+						iter.Reset(readers)
+
+						var err error
+						enc := encoderPool.Get()
+						enc.Reset(startInNano, blopts.DatabaseBlockAllocSize())
+						for iter.Next() {
+							dp, unit, annotation := iter.Current()
+							encodeErr := enc.Encode(dp, unit, annotation)
+							if encodeErr != nil {
+								err = encodeErr
+								shardErrs[shard]++
+								break
+							}
+						}
+						if iterErr := iter.Err(); iterErr != nil {
+							if err == nil {
+								err = iter.Err()
+							}
+							shardErrs[shard]++
+						}
+
+						iter.Close()
+						for i := range unmergedBlock {
+							unmergedBlock[i].enc.Close()
+						}
+
+						if err != nil {
+							continue
+						}
+
+						block.Reset(startInNano, enc.Discard())
+					}
+					blocks.AddBlock(block)
 				}
-				blocks.AddBlock(block)
+				if blocks.Len() > 0 {
+					shardResult.AddSeries(unmergedBlocks.id, blocks)
+				}
 			}
-			if blocks.Len() > 0 {
-				shardResult.AddSeries(unmergedBlocks.id, blocks)
+			if len(shardResult.AllSeries()) > 0 {
+				// Prevent race conditions while updating bootstrapResult from multiple go-routines
+				bootstrapResultLock.Lock()
+				// Shard is a slice index so conversion to uint32 is safe
+				bootstrapResult.Add(uint32(shard), shardResult, nil)
+				bootstrapResultLock.Unlock()
 			}
-		}
-		if len(shardResult.AllSeries()) > 0 {
-			bootstrapResult.Add(shard, shardResult, nil)
-		}
+			<-mergeSemaphore
+			wg.Done()
+		}(shard, unmergedShard)
 	}
-	if errs > 0 {
-		s.log.Errorf("error bootstrapping from commit log: %d merge out of order errors", errs)
+	// Wait for all merge goroutines to complete
+	wg.Wait()
+
+	endMergeTime := time.Now()
+	s.log.Errorf("Complete merge took: %f\n", endMergeTime.Sub(startMergeTime).Seconds())
+	errSum = 0
+	for _, numErrs := range shardErrs {
+		errSum += numErrs
 	}
-	if emptyErrs > 0 {
-		s.log.Errorf("error bootstrapping from commit log: %d empty unmerged blocks errors", emptyErrs)
+	if errSum > 0 {
+		s.log.Errorf("error bootstrapping from commit log: %d merge out of order errors", errSum)
+	}
+
+	emptyErrSum := 0
+	for _, numEmptyErr := range shardEmptyErrs {
+		emptyErrSum += numEmptyErr
+	}
+	if emptyErrSum > 0 {
+		s.log.Errorf("error bootstrapping from commit log: %d empty unmerged blocks errors", emptyErrSum)
 	}
 
 	return bootstrapResult, nil


### PR DESCRIPTION
Speed up the commitlog bootstrapper with the following changes:

1) Parallelize the commitlog reader such that msgpack decoding is done in parallel
2) Parallelize the commitlog bootstrap such that M3TSZ encoding is done in parallel
3) Replace a frequently accessed map with a slice
4) Replace a map[time.Time] with a map[f64] for faster access
5) Update msgpack library to take advantage of speed improvements
6) Fix file descriptors not being immediately closed when switching from one file to the next

With a concurrency of 4 for the reader and a concurrency of 4 for the M3TSZ encoders I was able to get bootstrapping time down from 3 hours to 35 minutes. CPU utilization sits in the 600-700% range with occasional short-lived spikes in the 10000+% range (I assume due to garbage collection). Maximum utilized memory was ~42G towards the end of the bootstrapping.

I'll do some more experimentation with different concurrency numbers to see what our options there are.

Also, I git cherry-picked this pull request: https://github.com/m3db/m3db/pull/314 and ran the tests to make sure I hadn't subtly altered the behavior of the bootstrapper and the tests passed.