### PR TITLE
Address bug in integration tests: testSetup.Close()

### DIFF
--- a/integration/fake/cluster_services.go
+++ b/integration/fake/cluster_services.go
@@ -334,6 +334,7 @@ func (s *m3ClusterService) SetReplication(
 	r services.ServiceReplication,
 ) services.Service {
 	s.Lock()
+	defer s.Unlock()
 	s.replication = r
 	return s
 }
@@ -341,6 +342,7 @@ func (s *m3ClusterService) SetReplication(
 func (s *m3ClusterService) SetSharding(
 	ss services.ServiceSharding,
 ) services.Service {
+	s.Lock()
 	defer s.Unlock()
 	s.sharding = ss
 	return s

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -460,8 +460,8 @@ func newNodes(
 				require.NoError(t, s.stopServer())
 			}
 		})
-		log.Debug("servers are now down")
 		closeFn()
+		log.Debug("servers are now down")
 	}
 
 	return nodes, topoInit, nodeClose


### PR DESCRIPTION
race condition when shutting down the integration `testSetup` constructs: the testSetups receive lot of redundant kv updates