### PR TITLE
Add commit log integration test

### DIFF
--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -76,11 +76,12 @@ func writeCommitLog(
 		now       time.Time
 	)
 
-	defer func() {
+	closeCommitLogFn := func() {
 		if commitLog != nil {
 			require.NoError(t, commitLog.Close())
 		}
-	}()
+	}
+	defer closeCommitLogFn()
 
 	for _, point := range points {
 		pointTime := point.Timestamp

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -109,8 +109,6 @@ func writeCommitLog(
 		}
 		require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
 	}
-
-	closeCommitLogFn()
 }
 
 func testSetupMetadatas(

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -1,0 +1,132 @@
+// +build integration
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/context"
+	"github.com/m3db/m3db/integration/generate"
+	"github.com/m3db/m3db/persist/fs/commitlog"
+	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	defaultIntegrationTestFlushInterval = 10 * time.Millisecond
+)
+
+func computeMetricIndexes(timeBlocks generate.SeriesBlocksByStart) map[string]uint64 {
+	var idx uint64
+	indexes := make(map[string]uint64)
+	for _, blks := range timeBlocks {
+		for _, blk := range blks {
+			id := blk.ID.String()
+			if _, ok := indexes[id]; !ok {
+				indexes[id] = idx
+				idx++
+			}
+		}
+	}
+	return indexes
+}
+
+func writeCommitLog(
+	t *testing.T,
+	s *testSetup,
+	data generate.SeriesBlocksByStart,
+	namespace ts.ID,
+) {
+	indexes := computeMetricIndexes(data)
+	opts := s.storageOpts.CommitLogOptions()
+
+	// ensure commit log is flushing frequently
+	require.Equal(t, defaultIntegrationTestFlushInterval, opts.FlushInterval())
+	ctx := context.NewContext()
+
+	var (
+		shardSet  = s.shardSet
+		points    = generate.ToPointsByTime(data) // points are sorted in chronological order
+		blockSize = opts.RetentionOptions().BlockSize()
+		commitLog commitlog.CommitLog
+		now       time.Time
+	)
+
+	closeCommitLogFn := func() {
+		if commitLog != nil {
+			// wait a bit to ensure writes are done, and then close the commit log
+			time.Sleep(10 * defaultIntegrationTestFlushInterval)
+			require.NoError(t, commitLog.Close())
+		}
+
+	}
+
+	for _, point := range points {
+		pointTime := point.Timestamp
+
+		// check if this point falls in the current commit log block
+		if truncated := pointTime.Truncate(blockSize); truncated != now {
+			// close commit log if it exists
+			closeCommitLogFn()
+			// move time forward
+			now = truncated
+			s.setNowFn(now)
+			// create new commit log
+			commitLog = commitlog.NewCommitLog(opts)
+			require.NoError(t, commitLog.Open())
+		}
+
+		// write this point
+		idx, ok := indexes[point.ID.String()]
+		require.True(t, ok)
+		cId := commitlog.Series{
+			Namespace:   namespace,
+			Shard:       shardSet.Lookup(point.ID),
+			ID:          point.ID,
+			UniqueIndex: idx,
+		}
+		require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
+	}
+
+	closeCommitLogFn()
+}
+
+func testSetupMetadatas(
+	t *testing.T,
+	testSetup *testSetup,
+	namespace ts.ID,
+	start time.Time,
+	end time.Time,
+) map[uint32][]block.ReplicaMetadata {
+	// Retrieve written data using the AdminSession APIs
+	// FetchMetadataBlocksFromPeers/FetchBlocksFromPeers
+	adminClient := testSetup.m3dbAdminClient
+	metadatasByShard, err := m3dbClientFetchBlocksMetadata(
+		adminClient, namespace, testSetup.shardSet.AllIDs(), start, end)
+	require.NoError(t, err)
+	return metadatasByShard
+}

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -1,0 +1,96 @@
+// +build integration
+
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/integration/generate"
+	"github.com/m3db/m3db/retention"
+	"github.com/m3db/m3db/storage/bootstrap"
+	"github.com/m3db/m3db/storage/bootstrap/bootstrapper"
+	bcl "github.com/m3db/m3db/storage/bootstrap/bootstrapper/commitlog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitLogBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow() // Just skip if we're doing a short run
+	}
+
+	// Test setup
+	var (
+		ropts     = retention.NewOptions().SetRetentionPeriod(12 * time.Hour)
+		blockSize = ropts.BlockSize()
+		testOpts  = newTestOptions()
+	)
+	setup, err := newTestSetup(testOpts)
+	require.NoError(t, err)
+	defer setup.close()
+
+	commitLogOpts := setup.storageOpts.CommitLogOptions().
+		SetFlushInterval(defaultIntegrationTestFlushInterval).
+		SetRetentionOptions(ropts)
+	setup.storageOpts = setup.storageOpts.SetCommitLogOptions(commitLogOpts)
+
+	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	bsOpts := newDefaulTestResultOptions(setup.storageOpts, setup.storageOpts.InstrumentOptions())
+	bclOpts := bcl.NewOptions().
+		SetResultOptions(bsOpts).
+		SetCommitLogOptions(commitLogOpts)
+	bs := bcl.NewCommitLogBootstrapper(bclOpts, noOpAll)
+	process := bootstrap.NewProcess(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+
+	log := setup.storageOpts.InstrumentOptions().Logger()
+	log.Info("commit log bootstrap test")
+
+	// Write test data
+	log.Info("generating data")
+	now := setup.getNowFn()
+	seriesMaps := generate.BlocksByStart([]generate.BlockConfig{
+		{[]string{"foo", "bar"}, 20, now.Add(-2 * blockSize)},
+		{[]string{"bar", "baz"}, 50, now.Add(-blockSize)},
+	})
+	log.Info("writing data")
+	writeCommitLog(t, setup, seriesMaps, testNamespaces[0])
+	log.Info("written data")
+
+	setup.setNowFn(now)
+	// Start the server with filesystem bootstrapper
+	require.NoError(t, setup.startServer())
+	log.Debug("server is now up")
+
+	// Stop the server
+	defer func() {
+		require.NoError(t, setup.stopServer())
+		log.Debug("server is now down")
+	}()
+
+	// Verify in-memory data match what we expect
+	metadatasByShard := testSetupMetadatas(t, setup, testNamespaces[0], now.Add(-2*blockSize), now)
+	observedSeriesMaps := testSetupToSeriesMaps(t, setup, testNamespaces[0], metadatasByShard)
+	verifySeriesMapsEqual(t, seriesMaps, observedSeriesMaps)
+}

--- a/integration/generate/generate.go
+++ b/integration/generate/generate.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"bytes"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/m3db/m3db/encoding/testgen"
@@ -48,4 +49,32 @@ func BlocksByStart(confs []BlockConfig) SeriesBlocksByStart {
 		seriesMaps[conf.Start] = Block(conf)
 	}
 	return seriesMaps
+}
+
+// ToPointsByTime converts a SeriesBlocksByStart to SeriesDataPointsByTime
+func ToPointsByTime(seriesMaps SeriesBlocksByStart) SeriesDataPointsByTime {
+	var pointsByTime SeriesDataPointsByTime
+	for _, blks := range seriesMaps {
+		for _, blk := range blks {
+			for _, dp := range blk.Data {
+				pointsByTime = append(pointsByTime, SeriesDataPoint{
+					ID:        blk.ID,
+					Datapoint: dp,
+				})
+			}
+		}
+	}
+	sort.Sort(pointsByTime)
+	return pointsByTime
+}
+
+// Making SeriesDataPointsByTimes sortable
+
+func (l SeriesDataPointsByTime) Len() int      { return len(l) }
+func (l SeriesDataPointsByTime) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l SeriesDataPointsByTime) Less(i, j int) bool {
+	if !l[i].Timestamp.Equal(l[j].Timestamp) {
+		return l[i].Timestamp.Before(l[j].Timestamp)
+	}
+	return bytes.Compare(l[i].ID.Data().Get(), l[j].ID.Data().Get()) < 0
 }

--- a/integration/generate/types.go
+++ b/integration/generate/types.go
@@ -23,6 +23,15 @@ type Series struct {
 	Data []ts.Datapoint
 }
 
+// SeriesDataPoint represents a single data point of a generated series of data
+type SeriesDataPoint struct {
+	ts.Datapoint
+	ID ts.ID
+}
+
+// SeriesDataPointsByTime are a sorted list of SeriesDataPoints
+type SeriesDataPointsByTime []SeriesDataPoint
+
 // SeriesBlock is a collection of Series'
 type SeriesBlock []Series
 


### PR DESCRIPTION
This is PR 1 in three PR's that together will improve the performance of the commitlog bootstrapper. This PR just adds the integration tests so that the other two PRs can be merged with confidence.

Adds a commit log integration test. Most of that code was written by prateek, but I made a few small changes to:

1) Remove an unnecessary sleep (the commitlogs Close() method waits for all writes to complete so the sleep was not necessary)
2) Increased defaultIntegrationTestFlushInterval to 100ms based on feedback from Rob
3) Increased the amount of data generated by the integration test such that it was enough (in my experience testing it) to detect concurrency / parallelism issues.
4) Rename computeMetricIndexes to generateUniqueMetricIndexes based on Rob's feedback
5) Replace named function with anonymous defer based on Rob's feedback