### PR TITLE
Rework CommitLog cleanup times

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 822dccdbdb7b2cb662bb44f39aafed25384d0696acb1175573ad2d982bd4c2df
-updated: 2017-07-19T12:44:10.220910567-04:00
+hash: f0f0a5939000440b833d7ab051c5c9550b398e8629830a9934bf36b22790c083
+updated: 2017-07-26T20:21:58.10096968-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -125,6 +125,11 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jonboulle/clockwork
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+- name: github.com/leanovate/gopter
+  version: 9e6101e5a87586b269acf3d0d61f363e4317309f
+  subpackages:
+  - gen
+  - prop
 - name: github.com/m3db/m3cluster
   version: 73f7742b6c639865a27da64cf719f15e5ceed0cd
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -81,3 +81,6 @@ import:
 
 - package: github.com/fortytw2/leaktest
   version: 3677f62bb30dbf3b042c4c211245d072aa9ee075
+
+- package: github.com/leanovate/gopter
+  version: 9e6101e5a87586b269acf3d0d61f363e4317309f

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -58,9 +58,12 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 	// Test setup
 	var (
 		commitLogBlockSize = 15 * time.Minute
-		clROpts            = retention.NewOptions().SetRetentionPeriod(12 * time.Hour).SetBlockSize(commitLogBlockSize)
-		ns1BlockSize       = 2 * time.Hour
-		ns1ROpts           = clROpts.SetRetentionPeriod(12 * time.Hour).SetBlockSize(ns1BlockSize)
+		clROpts            = retention.NewOptions().
+					SetRetentionPeriod(12 * time.Hour).
+					SetBlockSize(commitLogBlockSize).
+					SetBufferFuture(0).SetBufferPast(0)
+		ns1BlockSize = 2 * time.Hour
+		ns1ROpts     = clROpts.SetRetentionPeriod(12 * time.Hour).SetBlockSize(ns1BlockSize)
 	)
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))
 	require.NoError(t, err)

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -57,13 +57,11 @@ import (
 func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 	// Test setup
 	var (
+		rOpts              = retention.NewOptions().SetRetentionPeriod(12 * time.Hour)
+		ns1BlockSize       = 2 * time.Hour
 		commitLogBlockSize = 15 * time.Minute
-		clROpts            = retention.NewOptions().
-					SetRetentionPeriod(12 * time.Hour).
-					SetBlockSize(commitLogBlockSize).
-					SetBufferFuture(0).SetBufferPast(0)
-		ns1BlockSize = 2 * time.Hour
-		ns1ROpts     = clROpts.SetRetentionPeriod(12 * time.Hour).SetBlockSize(ns1BlockSize)
+		clROpts            = rOpts.SetBlockSize(commitLogBlockSize).SetBufferFuture(0).SetBufferPast(0)
+		ns1ROpts           = rOpts.SetBlockSize(ns1BlockSize)
 	)
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))
 	require.NoError(t, err)

--- a/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/integration/commitlog_bootstrap_multi_ns_test.go
@@ -44,17 +44,13 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 
 	// Test setup
 	var (
+		rOpts              = retention.NewOptions().SetRetentionPeriod(48 * time.Hour)
 		commitLogBlockSize = 15 * time.Minute
-		clROpts            = retention.NewOptions().
-					SetRetentionPeriod(48 * time.Hour).
-					SetBlockSize(commitLogBlockSize).
-					SetBufferFuture(0).
-					SetBufferPast(0)
-
-		ns1BlockSize = time.Hour
-		ns1ROpts     = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns1BlockSize)
-		ns2BlockSize = 30 * time.Minute
-		ns2ROpts     = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns2BlockSize)
+		ns1BlockSize       = time.Hour
+		ns2BlockSize       = 30 * time.Minute
+		clROpts            = rOpts.SetBlockSize(commitLogBlockSize).SetBufferFuture(0).SetBufferPast(0)
+		ns1ROpts           = rOpts.SetBlockSize(ns1BlockSize)
+		ns2ROpts           = rOpts.SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/integration/commitlog_bootstrap_multi_ns_test.go
@@ -45,11 +45,16 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	// Test setup
 	var (
 		commitLogBlockSize = 15 * time.Minute
-		clROpts            = retention.NewOptions().SetRetentionPeriod(48 * time.Hour).SetBlockSize(commitLogBlockSize)
-		ns1BlockSize       = time.Hour
-		ns1ROpts           = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns1BlockSize)
-		ns2BlockSize       = 30 * time.Minute
-		ns2ROpts           = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns2BlockSize)
+		clROpts            = retention.NewOptions().
+					SetRetentionPeriod(48 * time.Hour).
+					SetBlockSize(commitLogBlockSize).
+					SetBufferFuture(0).
+					SetBufferPast(0)
+
+		ns1BlockSize = time.Hour
+		ns1ROpts     = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns1BlockSize)
+		ns2BlockSize = 30 * time.Minute
+		ns2ROpts     = clROpts.SetRetentionPeriod(48 * time.Hour).SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -43,7 +43,7 @@ func TestCommitLogBootstrap(t *testing.T) {
 
 	// Test setup
 	var (
-		ropts     = retention.NewOptions().SetRetentionPeriod(12 * time.Hour)
+		ropts     = retention.NewOptions().SetRetentionPeriod(12 * time.Hour).SetBufferFuture(0).SetBufferPast(0)
 		blockSize = ropts.BlockSize()
 	)
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ropts))

--- a/integration/disk_cleanup_multi_ns_test.go
+++ b/integration/disk_cleanup_multi_ns_test.go
@@ -63,18 +63,14 @@ func TestDiskCleanupMultipleNamespace(t *testing.T) {
 
 	// Test setup
 	var (
+		rOpts              = retention.NewOptions().SetRetentionPeriod(8 * time.Hour)
 		commitLogBlockSize = 30 * time.Minute
-		clROpts            = retention.NewOptions().
-					SetRetentionPeriod(8 * time.Hour).
-					SetBlockSize(commitLogBlockSize).
-					SetBufferFuture(0).
-					SetBufferPast(0)
-
-		ns1BlockSize = 4 * time.Hour
-		ns1ROpts     = clROpts.SetRetentionPeriod(8 * time.Hour).SetBlockSize(ns1BlockSize)
-		ns2BlockSize = 2 * time.Hour
-		ns2ROpts     = clROpts.SetRetentionPeriod(6 * time.Hour).SetBlockSize(ns2BlockSize)
-		nsOpts       = namespace.NewOptions().SetNeedsFlush(false) // disabling flushing to ensure data isn't flushed during test
+		ns1BlockSize       = 4 * time.Hour
+		ns2BlockSize       = 2 * time.Hour
+		clROpts            = rOpts.SetBlockSize(commitLogBlockSize).SetBufferFuture(0).SetBufferPast(0)
+		ns1ROpts           = rOpts.SetRetentionPeriod(8 * time.Hour).SetBlockSize(ns1BlockSize)
+		ns2ROpts           = rOpts.SetRetentionPeriod(6 * time.Hour).SetBlockSize(ns2BlockSize)
+		nsOpts             = namespace.NewOptions().SetNeedsFlush(false) // disabling flushing to ensure data isn't flushed during test
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], nsOpts.SetRetentionOptions(ns1ROpts))

--- a/integration/disk_cleanup_multi_ns_test.go
+++ b/integration/disk_cleanup_multi_ns_test.go
@@ -64,12 +64,17 @@ func TestDiskCleanupMultipleNamespace(t *testing.T) {
 	// Test setup
 	var (
 		commitLogBlockSize = 30 * time.Minute
-		clROpts            = retention.NewOptions().SetRetentionPeriod(8 * time.Hour).SetBlockSize(commitLogBlockSize)
-		ns1BlockSize       = 4 * time.Hour
-		ns1ROpts           = clROpts.SetRetentionPeriod(8 * time.Hour).SetBlockSize(ns1BlockSize)
-		ns2BlockSize       = 2 * time.Hour
-		ns2ROpts           = clROpts.SetRetentionPeriod(6 * time.Hour).SetBlockSize(ns2BlockSize)
-		nsOpts             = namespace.NewOptions().SetNeedsFlush(false) // disabling flushing to ensure data isn't flushed during test
+		clROpts            = retention.NewOptions().
+					SetRetentionPeriod(8 * time.Hour).
+					SetBlockSize(commitLogBlockSize).
+					SetBufferFuture(0).
+					SetBufferPast(0)
+
+		ns1BlockSize = 4 * time.Hour
+		ns1ROpts     = clROpts.SetRetentionPeriod(8 * time.Hour).SetBlockSize(ns1BlockSize)
+		ns2BlockSize = 2 * time.Hour
+		ns2ROpts     = clROpts.SetRetentionPeriod(6 * time.Hour).SetBlockSize(ns2BlockSize)
+		nsOpts       = namespace.NewOptions().SetNeedsFlush(false) // disabling flushing to ensure data isn't flushed during test
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], nsOpts.SetRetentionOptions(ns1ROpts))

--- a/integration/disk_flush_multi_ns_test.go
+++ b/integration/disk_flush_multi_ns_test.go
@@ -40,17 +40,13 @@ func TestDiskFlushMultipleNamespace(t *testing.T) {
 
 	// Test setup
 	var (
+		rOpts              = retention.NewOptions().SetRetentionPeriod(18 * time.Hour)
 		commitLogBlockSize = time.Hour
-		clROpts            = retention.NewOptions().
-					SetRetentionPeriod(18 * time.Hour).
-					SetBlockSize(commitLogBlockSize).
-					SetBufferFuture(0).
-					SetBufferPast(0)
-
-		ns1BlockSize = 2 * time.Hour
-		ns1ROpts     = clROpts.SetBlockSize(ns1BlockSize)
-		ns2BlockSize = 3 * time.Hour
-		ns2ROpts     = clROpts.SetBlockSize(ns2BlockSize)
+		ns1BlockSize       = 2 * time.Hour
+		ns2BlockSize       = 3 * time.Hour
+		clROpts            = rOpts.SetBlockSize(commitLogBlockSize).SetBufferFuture(0).SetBufferPast(0)
+		ns1ROpts           = rOpts.SetBlockSize(ns1BlockSize)
+		ns2ROpts           = rOpts.SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/disk_flush_multi_ns_test.go
+++ b/integration/disk_flush_multi_ns_test.go
@@ -41,11 +41,16 @@ func TestDiskFlushMultipleNamespace(t *testing.T) {
 	// Test setup
 	var (
 		commitLogBlockSize = time.Hour
-		clROpts            = retention.NewOptions().SetRetentionPeriod(18 * time.Hour).SetBlockSize(commitLogBlockSize)
-		ns1BlockSize       = 2 * time.Hour
-		ns1ROpts           = clROpts.SetBlockSize(ns1BlockSize)
-		ns2BlockSize       = 3 * time.Hour
-		ns2ROpts           = clROpts.SetBlockSize(ns2BlockSize)
+		clROpts            = retention.NewOptions().
+					SetRetentionPeriod(18 * time.Hour).
+					SetBlockSize(commitLogBlockSize).
+					SetBufferFuture(0).
+					SetBufferPast(0)
+
+		ns1BlockSize = 2 * time.Hour
+		ns1ROpts     = clROpts.SetBlockSize(ns1BlockSize)
+		ns2BlockSize = 3 * time.Hour
+		ns2ROpts     = clROpts.SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/fs_bootstrap_multi_ns_test.go
+++ b/integration/fs_bootstrap_multi_ns_test.go
@@ -44,17 +44,13 @@ func TestFilesystemBootstrapMultipleNamespaces(t *testing.T) {
 
 	// Test setup
 	var (
+		rOpts              = retention.NewOptions().SetRetentionPeriod(6 * time.Hour)
 		commitLogBlockSize = time.Hour
-		clROpts            = retention.NewOptions().
-					SetRetentionPeriod(6 * time.Hour).
-					SetBlockSize(commitLogBlockSize).
-					SetBufferFuture(0).
-					SetBufferPast(0)
-
-		ns1BlockSize = 2 * time.Hour
-		ns1ROpts     = clROpts.SetBlockSize(ns1BlockSize)
-		ns2BlockSize = 3 * time.Hour
-		ns2ROpts     = clROpts.SetBlockSize(ns2BlockSize)
+		ns1BlockSize       = 2 * time.Hour
+		ns2BlockSize       = 3 * time.Hour
+		clROpts            = rOpts.SetBlockSize(commitLogBlockSize).SetBufferFuture(0).SetBufferPast(0)
+		ns1ROpts           = rOpts.SetBlockSize(ns1BlockSize)
+		ns2ROpts           = rOpts.SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/fs_bootstrap_multi_ns_test.go
+++ b/integration/fs_bootstrap_multi_ns_test.go
@@ -45,11 +45,16 @@ func TestFilesystemBootstrapMultipleNamespaces(t *testing.T) {
 	// Test setup
 	var (
 		commitLogBlockSize = time.Hour
-		clROpts            = retention.NewOptions().SetRetentionPeriod(6 * time.Hour).SetBlockSize(commitLogBlockSize)
-		ns1BlockSize       = 2 * time.Hour
-		ns1ROpts           = clROpts.SetBlockSize(ns1BlockSize)
-		ns2BlockSize       = 3 * time.Hour
-		ns2ROpts           = clROpts.SetBlockSize(ns2BlockSize)
+		clROpts            = retention.NewOptions().
+					SetRetentionPeriod(6 * time.Hour).
+					SetBlockSize(commitLogBlockSize).
+					SetBufferFuture(0).
+					SetBufferPast(0)
+
+		ns1BlockSize = 2 * time.Hour
+		ns1ROpts     = clROpts.SetBlockSize(ns1BlockSize)
+		ns2BlockSize = 3 * time.Hour
+		ns2ROpts     = clROpts.SetBlockSize(ns2BlockSize)
 	)
 
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(ns1ROpts))

--- a/integration/fs_bootstrap_test.go
+++ b/integration/fs_bootstrap_test.go
@@ -45,6 +45,7 @@ func TestFilesystemBootstrap(t *testing.T) {
 	var (
 		blockSize = 2 * time.Hour
 		rOpts     = retention.NewOptions().SetRetentionPeriod(2 * time.Hour).SetBlockSize(blockSize)
+		clROpts   = rOpts.SetBufferPast(0).SetBufferFuture(0)
 	)
 	ns1, err := namespace.NewMetadata(testNamespaces[0], namespace.NewOptions().SetRetentionOptions(rOpts))
 	require.NoError(t, err)
@@ -53,7 +54,7 @@ func TestFilesystemBootstrap(t *testing.T) {
 
 	opts := newTestOptions(t).
 		SetNamespaces([]namespace.Metadata{ns1, ns2}).
-		SetCommitLogRetention(rOpts)
+		SetCommitLogRetention(clROpts)
 
 	// Test setup
 	setup, err := newTestSetup(t, opts)

--- a/integration/options.go
+++ b/integration/options.go
@@ -73,9 +73,12 @@ const (
 
 var (
 	defaultIntegrationTestRetentionOpts = retention.NewOptions().
-		SetRetentionPeriod(6 * time.Hour).
-		SetBufferFuture(0).
-		SetBufferPast(0)
+						SetRetentionPeriod(6 * time.Hour).
+						SetBufferFuture(0).
+						SetBufferPast(0)
+
+	defaultIntegrationTestNsRetentionOpts = retention.NewOptions().
+						SetRetentionPeriod(6 * time.Hour)
 )
 
 type testOptions interface {
@@ -253,12 +256,16 @@ type options struct {
 
 func newTestOptions(t *testing.T) testOptions {
 	var namespaces []namespace.Metadata
-	nsOpts := namespace.NewOptions().SetNeedsRepair(false).SetRetentionOptions(defaultIntegrationTestRetentionOpts)
+	nsOpts := namespace.NewOptions().
+		SetNeedsRepair(false).
+		SetRetentionOptions(defaultIntegrationTestNsRetentionOpts)
+
 	for _, ns := range testNamespaces {
 		md, err := namespace.NewMetadata(ns, nsOpts)
 		require.NoError(t, err)
 		namespaces = append(namespaces, md)
 	}
+
 	return &options{
 		namespaces:             namespaces,
 		commitlogRetentionOpts: defaultIntegrationTestRetentionOpts,

--- a/integration/options.go
+++ b/integration/options.go
@@ -72,7 +72,10 @@ const (
 )
 
 var (
-	defaultIntegrationTestRetentionOpts = retention.NewOptions().SetRetentionPeriod(6 * time.Hour)
+	defaultIntegrationTestRetentionOpts = retention.NewOptions().
+		SetRetentionPeriod(6 * time.Hour).
+		SetBufferFuture(0).
+		SetBufferPast(0)
 )
 
 type testOptions interface {

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/m3db/m3db/clock"
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/persist/fs"
-	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/time"
@@ -69,7 +68,7 @@ func newTestOptions(
 
 	scope := tally.NewTestScope("", nil)
 
-	ropts := retention.NewOptions().SetBlockSize(2 * time.Hour)
+	ropts := defaultRetentionOptions().SetBlockSize(2 * time.Hour)
 
 	opts := NewOptions().
 		SetClockOptions(clock.NewOptions().SetNowFn(c.Now)).

--- a/persist/fs/commitlog/options.go
+++ b/persist/fs/commitlog/options.go
@@ -87,7 +87,9 @@ func NewOptions() Options {
 
 func defaultRetentionOptions() retention.Options {
 	return retention.NewOptions().
-		SetBlockSize(defaultBlockSize)
+		SetBlockSize(defaultBlockSize).
+		SetBufferFuture(0).
+		SetBufferPast(0)
 }
 
 func (o *options) Validate() error {
@@ -95,8 +97,17 @@ func (o *options) Validate() error {
 		return errFlushIntervalNonNegative
 	}
 
-	if err := o.retentionOpts.Validate(); err != nil {
+	ropts := o.retentionOpts
+	if err := ropts.Validate(); err != nil {
 		return fmt.Errorf("invalid commit log retention options: %v", err)
+	}
+
+	if v := ropts.BufferFuture(); v != 0 {
+		return fmt.Errorf("invalid commit log retention buffer future, expected 0, observed: %v", v)
+	}
+
+	if v := ropts.BufferPast(); v != 0 {
+		return fmt.Errorf("invalid commit log retention buffer past, expected 0, observed: %v", v)
 	}
 
 	return nil

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -184,7 +184,7 @@ func (m *cleanupManager) commitLogTimes(t time.Time) (time.Time, []time.Time) {
 // for the commit log block with start time `t`, we can receive data for a range of namespace
 // blocks depending on the namespace retention options. The range is given by these relationships:
 //	- earliest ns block start = t.Add(-ns_bp).Truncate(ns_bs)
-//  - latest ns block start   = t.Add(cl_bs).Add(ns_bf).Ceil(ns_bs)
+//  - latest ns block start   = t.Add(cl_bs).Add(ns_bf).Truncate(ns_bs)
 // NB:
 // - blockStart assumed to be aligned to commit log block size
 func commitLogNamespaceBlockTimes(

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -192,23 +192,14 @@ func commitLogNamespaceBlockTimes(
 	commitlogBlockSize time.Duration,
 	nsRetention retention.Options,
 ) (time.Time, time.Time) {
-	earliest := blockStart.Add(-nsRetention.BufferPast()).Truncate(nsRetention.BlockSize())
-	latest := blockStart.Add(commitlogBlockSize).Add(nsRetention.BufferFuture())
-	latest = ceilDate(latest).ceil(nsRetention.BlockSize())
+	earliest := blockStart.
+		Add(-nsRetention.BufferPast()).
+		Truncate(nsRetention.BlockSize())
+	latest := blockStart.
+		Add(commitlogBlockSize).
+		Add(nsRetention.BufferFuture()).
+		Truncate(nsRetention.BlockSize())
 	return earliest, latest
-}
-
-type ceilDate time.Time
-
-// ceil returns the result of aligning t to the nearest multiple of d (since the zero time).
-// The ceil behavior for aligned values is to return them un-touched.
-// If d <= 0, ceil returns t unchanged.
-func (c ceilDate) ceil(d time.Duration) time.Time {
-	cp := time.Time(c).Truncate(d)
-	if time.Time(cp).Equal(time.Time(c)) {
-		return time.Time(c)
-	}
-	return cp.Add(d)
 }
 
 func (m *cleanupManager) cleanupCommitLogs(earliestToRetain time.Time, cleanupTimes []time.Time) error {

--- a/storage/cleanup_prop_test.go
+++ b/storage/cleanup_prop_test.go
@@ -60,7 +60,7 @@ func TestPropertyCommitLogNotCleanedForUnflushedData(t *testing.T) {
 	properties := gopter.NewProperties(parameters)
 
 	now := time.Now()
-	year := time.Hour * 24 * 365
+	year := time.Hour * 24 * 15
 
 	properties.Property("Commit log is retained if one namespace needs to flush", prop.ForAll(
 		func(t time.Time, cRopts retention.Options, ns *gNamespace) (bool, error) {
@@ -93,7 +93,7 @@ func TestPropertyCommitLogNotCleanedForUnflushedDataMultipleNs(t *testing.T) {
 	properties := gopter.NewProperties(parameters)
 
 	now := time.Now()
-	year := time.Hour * 24 * 365
+	year := time.Hour * 24 * 15
 
 	properties.Property("Commit log is retained if any namespace needs to flush", prop.ForAll(
 		func(t time.Time, cRopts retention.Options, nses []*gNamespace) (bool, error) {

--- a/storage/cleanup_prop_test.go
+++ b/storage/cleanup_prop_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	"github.com/m3db/m3db/retention"
+
+	"github.com/golang/mock/gomock"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+	"github.com/uber-go/tally"
+)
+
+func propTestCleanupMgr(ctrl *gomock.Controller, ns ...databaseNamespace) *cleanupManager {
+	db := newMockdatabase(ctrl, ns...)
+	scope := tally.NoopScope
+	fm := newFlushManager(db, scope)
+	cm := newCleanupManager(db, fm, scope)
+	return cm.(*cleanupManager)
+}
+
+func TestPropertyCommitLogNotCleanedForUnflushedData(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	parameters := gopter.DefaultTestParameters()
+	parameters.Rng.Seed(7823434) // generate reproducable results
+	parameters.MinSuccessfulTests = 10000
+	properties := gopter.NewProperties(parameters)
+
+	now := time.Now()
+	year := time.Hour * 24 * 365
+
+	properties.Property("Commit log is retained if one namespace needs to flush", prop.ForAll(
+		func(t time.Time, cRopts retention.Options, ns *gNamespace) (bool, error) {
+			cm := propTestCleanupMgr(ctrl, ns)
+			_, cleanupTimes := cm.commitLogTimes(t)
+			for _, ct := range cleanupTimes {
+				s, e := commitLogBlockDataRange(ct, cRopts, ns.ropts)
+				if ns.NeedsFlush(s, e) {
+					return false, fmt.Errorf("trying to cleanup commit log at %v, but ns needsFlush; (range: %v, %v)",
+						ct.String(), s.String(), e.String())
+				}
+			}
+			return true, nil
+		},
+		gen.TimeRange(now.Add(-year), 2*year).WithLabel("cleanup time"),
+		genRetention().WithLabel("commit log retention"),
+		genNamespace(now).WithLabel("namespace"),
+	))
+
+	properties.TestingRun(t)
+}
+
+// return the earliest and latest data a commit log block could possibly receive
+// for a given namespace retention
+func commitLogBlockDataRange(
+	commitLogBlockStart time.Time,
+	commitLogRetention retention.Options,
+	nsRetention retention.Options,
+) (time.Time, time.Time) {
+	earliestData := commitLogBlockStart.Add(-nsRetention.BufferPast())
+	latestData := commitLogBlockStart.Add(commitLogRetention.BlockSize()).Add(nsRetention.BufferFuture())
+	return earliestData, latestData
+}
+
+// generated namespace struct
+type gNamespace struct {
+	databaseNamespace
+
+	ropts             *gRetention
+	blockSize         time.Duration
+	oldestBlock       time.Time
+	newestBlock       time.Time
+	needsFlushMarkers []bool
+}
+
+func (ns *gNamespace) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("\n\tretention: %v", ns.ropts.String()))
+
+	buf.WriteString(fmt.Sprintf("\n\tneedsFlush: \n"))
+	w := new(tabwriter.Writer)
+	w.Init(&buf, 5, 0, 1, ' ', 0)
+	fmt.Fprintln(w, "blockStart\tneedFlush\t")
+	for i := range ns.needsFlushMarkers {
+		t := ns.oldestBlock.Add(time.Duration(i) * ns.blockSize)
+		fmt.Fprintf(w, "%v\t%v\t\n", t, ns.needsFlushMarkers[i])
+	}
+	w.Flush()
+
+	return buf.String()
+}
+
+func (ns *gNamespace) blockIdx(t time.Time) int {
+	idx := int(t.Truncate(ns.blockSize).Sub(ns.oldestBlock) / ns.blockSize)
+	if idx < 0 {
+		return 0
+	}
+	if idx >= len(ns.needsFlushMarkers) {
+		return len(ns.needsFlushMarkers) - 1
+	}
+	return idx
+}
+
+func (ns *gNamespace) NeedsFlush(start, end time.Time) bool {
+	if start.Before(ns.oldestBlock) && end.Before(ns.oldestBlock) {
+		return false
+	}
+	if start.After(ns.newestBlock) && end.After(ns.newestBlock) {
+		return false
+	}
+	sIdx, eIdx := ns.blockIdx(start), ns.blockIdx(end)
+	for i := sIdx; i <= eIdx; i++ {
+		if ns.needsFlushMarkers[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// generator for gNamespace
+func genNamespace(t time.Time) gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		rng := genParams.Rng
+		ropts := randomRetention(rng)
+		oldest := retention.FlushTimeStart(ropts, t)
+		newest := retention.FlushTimeEnd(ropts, t)
+
+		n := numIntervals(oldest, newest, ropts.BlockSize())
+		flushStates := make([]bool, n)
+		for i := range flushStates {
+			flushStates[i] = rng.Float32() > 0.6 // flip a coin to get a bool
+		}
+
+		ns := &gNamespace{
+			ropts:             ropts,
+			blockSize:         ropts.BlockSize(),
+			oldestBlock:       oldest,
+			newestBlock:       newest,
+			needsFlushMarkers: flushStates,
+		}
+
+		genResult := gopter.NewGenResult(ns, gopter.NoShrinker)
+		genResult.Sieve = func(v interface{}) bool {
+			ns := v.(*gNamespace)
+			if len(ns.needsFlushMarkers) <= 0 {
+				return false
+			}
+			return ns.ropts.Validate() == nil
+		}
+		return genResult
+	}
+}
+
+func randomRetention(rng *rand.Rand) *gRetention {
+	var (
+		blockSizeMins    = maxInt(1, rng.Intn(60*12)) // 12 hours
+		retentionMins    = maxInt(1, rng.Intn(40)) * blockSizeMins
+		bufferPastMins   = maxInt(1, rng.Intn(blockSizeMins))
+		bufferFutureMins = maxInt(1, rng.Intn(blockSizeMins))
+	)
+
+	return &gRetention{retention.NewOptions().
+		SetRetentionPeriod(time.Duration(retentionMins) * time.Minute).
+		SetBlockSize(time.Duration(blockSizeMins) * time.Minute).
+		SetBufferPast(time.Duration(bufferPastMins) * time.Minute).
+		SetBufferFuture(time.Duration(bufferFutureMins) * time.Minute)}
+}
+
+// generator for retention options
+func genRetention() gopter.Gen {
+	return func(genParams *gopter.GenParameters) *gopter.GenResult {
+		opts := randomRetention(genParams.Rng)
+		genResult := gopter.NewGenResult(opts, gopter.NoShrinker)
+		genResult.Sieve = func(v interface{}) bool {
+			return v.(retention.Options).Validate() == nil
+		}
+		return genResult
+	}
+}
+
+type gRetention struct {
+	retention.Options
+}
+
+func (ro *gRetention) String() string {
+	return fmt.Sprintf(
+		"[ retention-period = %v, block-size = %v, buffer-past = %v, buffer-future = %v ]",
+		ro.RetentionPeriod().String(),
+		ro.BlockSize().String(),
+		ro.BufferPast().String(),
+		ro.BufferFuture().String())
+}
+
+func maxInt(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -58,6 +58,11 @@ var (
 					SetBufferPast(10 * time.Minute).
 					SetBlockSize(4 * time.Hour).
 					SetRetentionPeriod(2 * 24 * time.Hour)
+	defaultTestCommitlogRetentionOpts = retention.NewOptions().
+						SetBufferFuture(0).
+						SetBufferPast(0).
+						SetBlockSize(2 * time.Hour).
+						SetRetentionPeriod(2 * 24 * time.Hour)
 
 	defaultTestNs1Opts = namespace.NewOptions().SetRetentionOptions(defaultTestRetentionOpts)
 	defaultTestNs2Opts = namespace.NewOptions().SetRetentionOptions(defaultTestNs2RetentionOpts)
@@ -69,7 +74,7 @@ var (
 					SetMaxFlushRetries(3).
 					SetTickInterval(10 * time.Minute).
 					SetCommitLogOptions(_opts.CommitLogOptions().
-						SetRetentionOptions(defaultTestRetentionOpts))
+						SetRetentionOptions(defaultTestCommitlogRetentionOpts))
 )
 
 type nsMapCh chan namespace.Map

--- a/storage/flush.go
+++ b/storage/flush.go
@@ -60,16 +60,6 @@ func newFlushManager(database database, scope tally.Scope) databaseFlushManager 
 	}
 }
 
-func (m *flushManager) NeedsFlush(startInclusive time.Time, endInclusive time.Time) bool {
-	namespaces := m.database.GetOwnedNamespaces()
-	for _, n := range namespaces {
-		if n.NeedsFlush(startInclusive, endInclusive) {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *flushManager) Flush(curr time.Time) error {
 	// ensure only a single flush is happening at a time
 	m.Lock()
@@ -128,7 +118,7 @@ func (m *flushManager) namespaceFlushTimes(ns databaseNamespace, curr time.Time)
 
 	candidateTimes := timesInRange(earliest, latest, blockSize)
 	return filterTimes(candidateTimes, func(t time.Time) bool {
-		return ns.NeedsFlush(t, t.Add(blockSize))
+		return ns.NeedsFlush(t, t)
 	})
 }
 

--- a/storage/flush_test.go
+++ b/storage/flush_test.go
@@ -104,71 +104,6 @@ func TestFlushManagerFlushAlreadyInProgress(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFlushManagerNeedsFlushSingle(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
-
-	// short circuit second ns for this test case
-	ns2.EXPECT().NeedsFlush(now, now).Return(false).AnyTimes()
-
-	ns1.EXPECT().NeedsFlush(now, now).Return(true)
-	require.True(t, fm.NeedsFlush(now, now))
-
-	ns1.EXPECT().NeedsFlush(now, now).Return(false)
-	require.False(t, fm.NeedsFlush(now, now))
-}
-
-func TestFlushManagerNeedsFlushMultipleAllFalse(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
-
-	ns2.EXPECT().NeedsFlush(now, now).Return(false)
-	ns1.EXPECT().NeedsFlush(now, now).Return(false)
-	require.False(t, fm.NeedsFlush(now, now))
-}
-
-func TestFlushManagerNeedsFlushMultipleAllTrue(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
-
-	ns2.EXPECT().NeedsFlush(now, now).Return(true).AnyTimes()
-	ns1.EXPECT().NeedsFlush(now, now).Return(true).AnyTimes()
-	require.True(t, fm.NeedsFlush(now, now))
-}
-
-func TestFlushManagerNeedsFlushMultipleSingleTrueFirst(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
-
-	ns1.EXPECT().NeedsFlush(now, now).Return(false).AnyTimes()
-	ns2.EXPECT().NeedsFlush(now, now).Return(true)
-	require.True(t, fm.NeedsFlush(now, now))
-}
-
-func TestFlushManagerNeedsFlushMultipleSingleTrueSecond(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
-
-	ns1.EXPECT().NeedsFlush(now, now).Return(true)
-	ns2.EXPECT().NeedsFlush(now, now).Return(false).AnyTimes()
-	require.True(t, fm.NeedsFlush(now, now))
-}
-
 func TestFlushManagerFlushTimeStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -257,15 +192,14 @@ func TestFlushManagerNamespaceFlushTimesSomeNeedFlush(t *testing.T) {
 	var expectedTimes []time.Time
 	for i := 0; i < num; i++ {
 		st := start.Add(time.Duration(i) * blockSize)
-		en := st.Add(blockSize)
 
 		// skip 1/3 of input
 		if i%3 == 0 {
-			ns1.EXPECT().NeedsFlush(st, en).Return(false)
+			ns1.EXPECT().NeedsFlush(st, st).Return(false)
 			continue
 		}
 
-		ns1.EXPECT().NeedsFlush(st, en).Return(true)
+		ns1.EXPECT().NeedsFlush(st, st).Return(true)
 		expectedTimes = append(expectedTimes, st)
 	}
 

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -74,7 +74,7 @@ func newFileSystemManager(
 	instrumentOpts := opts.InstrumentOptions()
 	scope := instrumentOpts.MetricsScope().SubScope("fs")
 	fm := newFlushManager(database, scope)
-	cm := newCleanupManager(database, fm, scope)
+	cm := newCleanupManager(database, scope)
 
 	return &fileSystemManager{
 		databaseFlushManager:   fm,

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -565,10 +565,10 @@ func (n *dbNamespace) Flush(
 	return res
 }
 
-func (n *dbNamespace) NeedsFlush(startInclusive time.Time, endInclusive time.Time) bool {
+func (n *dbNamespace) NeedsFlush(alignedStartInclusive time.Time, alignedEndInclusive time.Time) bool {
 	var (
 		blockSize   = n.nopts.RetentionOptions().BlockSize()
-		blockStarts = timesInRange(startInclusive, endInclusive, blockSize)
+		blockStarts = timesInRange(alignedStartInclusive, alignedEndInclusive, blockSize)
 	)
 
 	// NB(r): Essentially if all are success, we don't need to flush, if any

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -568,9 +568,7 @@ func (n *dbNamespace) Flush(
 func (n *dbNamespace) NeedsFlush(startInclusive time.Time, endInclusive time.Time) bool {
 	var (
 		blockSize   = n.nopts.RetentionOptions().BlockSize()
-		startBlock  = startInclusive.Truncate(blockSize)
-		endBlock    = endInclusive.Truncate(blockSize)
-		blockStarts = timesInRange(startBlock, endBlock, blockSize)
+		blockStarts = timesInRange(startInclusive, endInclusive, blockSize)
 	)
 
 	// NB(r): Essentially if all are success, we don't need to flush, if any

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -565,10 +565,10 @@ func (n *dbNamespace) Flush(
 	return res
 }
 
-func (n *dbNamespace) NeedsFlush(alignedStartInclusive time.Time, alignedEndInclusive time.Time) bool {
+func (n *dbNamespace) NeedsFlush(alignedInclusiveStart time.Time, alignedInclusiveEnd time.Time) bool {
 	var (
 		blockSize   = n.nopts.RetentionOptions().BlockSize()
-		blockStarts = timesInRange(alignedStartInclusive, alignedEndInclusive, blockSize)
+		blockStarts = timesInRange(alignedInclusiveStart, alignedInclusiveEnd, blockSize)
 	)
 
 	// NB(r): Essentially if all are success, we don't need to flush, if any

--- a/storage/types.go
+++ b/storage/types.go
@@ -222,7 +222,7 @@ type databaseNamespace interface {
 	// NeedsFlush returns true if the namespace needs a flush for the
 	// period: [start, end] (both inclusive).
 	// NB: The start/end times are assumed to be aligned to block size boundary.
-	NeedsFlush(start time.Time, end time.Time) bool
+	NeedsFlush(alignedStartInclusive time.Time, alignedEndInclusive time.Time) bool
 
 	// CleanupFileset cleans up fileset files
 	CleanupFileset(earliestToRetain time.Time) error

--- a/storage/types.go
+++ b/storage/types.go
@@ -222,7 +222,7 @@ type databaseNamespace interface {
 	// NeedsFlush returns true if the namespace needs a flush for the
 	// period: [start, end] (both inclusive).
 	// NB: The start/end times are assumed to be aligned to block size boundary.
-	NeedsFlush(alignedStartInclusive time.Time, alignedEndInclusive time.Time) bool
+	NeedsFlush(alignedInclusiveStart time.Time, alignedInclusiveEnd time.Time) bool
 
 	// CleanupFileset cleans up fileset files
 	CleanupFileset(earliestToRetain time.Time) error

--- a/storage/types.go
+++ b/storage/types.go
@@ -221,8 +221,7 @@ type databaseNamespace interface {
 
 	// NeedsFlush returns true if the namespace needs a flush for the
 	// period: [start, end] (both inclusive).
-	// NB(prateek): The start/end times do not need to be aligned to
-	// block size boundary.
+	// NB: The start/end times are assumed to be aligned to block size boundary.
 	NeedsFlush(start time.Time, end time.Time) bool
 
 	// CleanupFileset cleans up fileset files
@@ -325,10 +324,6 @@ type databaseBootstrapManager interface {
 
 // databaseFlushManager manages flushing in-memory data to persistent storage.
 type databaseFlushManager interface {
-	// NeedsFlush returns true if any registered namespaces require a flush
-	// in the time period specified: [startInclusive, endInclusive].
-	NeedsFlush(startInclusive time.Time, endInclusive time.Time) bool
-
 	// Flush flushes in-memory data to persistent storage.
 	Flush(t time.Time) error
 

--- a/storage/util_test.go
+++ b/storage/util_test.go
@@ -29,15 +29,15 @@ import (
 
 func TestNumIntervals(t *testing.T) {
 	var (
-		bs = 10
-		tf = func(i int) time.Time {
+		bs      = 10
+		timeFor = func(i int) time.Time {
 			return time.Unix(int64(bs*i), 0)
 		}
 	)
 
 	w := time.Second * time.Duration(bs)
-	t0 := tf(0)
-	t1 := tf(1)
+	t0 := timeFor(0)
+	t1 := timeFor(1)
 
 	require.Equal(t, 0, numIntervals(t1, t0, w))
 	require.Equal(t, 1, numIntervals(t0, t0, w))
@@ -71,37 +71,37 @@ func TestNumIntervalsNegativeWindow(t *testing.T) {
 
 func TestTimesInRange(t *testing.T) {
 	var (
-		w  = 10 * time.Second
-		tf = func(i int64) time.Time {
+		w       = 10 * time.Second
+		timeFor = func(i int64) time.Time {
 			return time.Unix(0, int64(w)*i)
 		}
-		tfN = func(i, j int64) []time.Time {
+		timesForN = func(i, j int64) []time.Time {
 			times := make([]time.Time, 0, j-i+1)
 			for k := j; k >= i; k-- {
-				times = append(times, tf(k))
+				times = append(times, timeFor(k))
 			}
 			return times
 		}
 	)
 	// [0, 2] with a gap of 1 ==> [0, 1, 2]
-	require.Equal(t, []time.Time{tf(2), tf(1), tf(0)},
-		timesInRange(tf(0), tf(2), w))
+	require.Equal(t, []time.Time{timeFor(2), timeFor(1), timeFor(0)},
+		timesInRange(timeFor(0), timeFor(2), w))
 
 	// [2, 1] with a gap of 1 ==> empty result
-	require.Empty(t, timesInRange(tf(2), tf(1), w))
+	require.Empty(t, timesInRange(timeFor(2), timeFor(1), w))
 
 	// [2, 2] with a gap of 1 ==> [2]
-	require.Equal(t, []time.Time{tf(2)},
-		timesInRange(tf(2), tf(2), w))
+	require.Equal(t, []time.Time{timeFor(2)},
+		timesInRange(timeFor(2), timeFor(2), w))
 
 	// [0, 9] with a gap of 3 ==> [9, 6, 3, 0]
-	require.Equal(t, []time.Time{tf(9), tf(6), tf(3), tf(0)},
-		timesInRange(tf(0), tf(9), 3*w))
+	require.Equal(t, []time.Time{timeFor(9), timeFor(6), timeFor(3), timeFor(0)},
+		timesInRange(timeFor(0), timeFor(9), 3*w))
 
 	// [1, 9] with a gap of 3 ==> [9, 6, 3]
-	require.Equal(t, []time.Time{tf(9), tf(6), tf(3)},
-		timesInRange(tf(1), tf(9), 3*w))
+	require.Equal(t, []time.Time{timeFor(9), timeFor(6), timeFor(3)},
+		timesInRange(timeFor(1), timeFor(9), 3*w))
 
 	// [1, 100] with a gap of 1 ==> [100, 99, ..., 1]
-	require.Equal(t, tfN(1, 100), timesInRange(tf(1), tf(100), w))
+	require.Equal(t, timesForN(1, 100), timesInRange(timeFor(1), timeFor(100), w))
 }


### PR DESCRIPTION
Changes:
- Rework commit log cleanup times calculation
- Add property test to ensure we don't cleanup commit logs for un-flushed data

/cc @xichen2020 @robskillington 
