### PR TITLE
Improve the memory locality for the commit log writer

### DIFF
--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -119,7 +119,10 @@ func writeCommitLogData(
 				Shard:       shardSet.Lookup(point.ID),
 				ID:          point.ID,
 				UniqueIndex: series.uniqueIndex,
-				WriteState:  series,
+				WriteState: commitlog.SeriesWriteState{
+					CurrentCommitLogStart: series.CurrentCommitLogStart(),
+					Store: series,
+				},
 			}
 			require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
 		}

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -102,21 +102,19 @@ type testWrite struct {
 	expectedErr error
 }
 
-type testWriteState struct {
+type testWriteStateStore struct {
 	currCommitLogUnixNanos int64
 }
 
 func newTestWriteState() SeriesWriteState {
-	return &testWriteState{currCommitLogUnixNanos: -1}
-}
-
-// CurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (s *testWriteState) CurrentCommitLogStart() int64 {
-	return s.currCommitLogUnixNanos
+	return SeriesWriteState{
+		CurrentCommitLogStart: -1,
+		Store: &testWriteStateStore{currCommitLogUnixNanos: -1},
+	}
 }
 
 // SetCurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (s *testWriteState) SetCurrentCommitLogStart(unixNanos int64) {
+func (s *testWriteStateStore) SetCurrentCommitLogStart(unixNanos int64) {
 	s.currCommitLogUnixNanos = unixNanos
 }
 

--- a/persist/fs/commitlog/types.go
+++ b/persist/fs/commitlog/types.go
@@ -112,16 +112,21 @@ type Series struct {
 	WriteState SeriesWriteState
 }
 
-// SeriesWriteState provides series write state for a
-// series that is written to the commit log journal
-type SeriesWriteState interface {
-	// CurrentCommitLogStart returns the unix nanoseconds
-	// from when the series was last written
-	// Note: provider does not need to provide volatility protection
-	// (thread safety) as access is synchronized to both the accessor
-	// and setter.
-	CurrentCommitLogStart() int64
+// SeriesWriteState is a snapshot of the current series
+// write state for the commit log journal with a store
+// that can update the attributes of the write state
+type SeriesWriteState struct {
+	// CurrentCommitLogStart is the unix nanoseconds
+	// for when the series was last written
+	CurrentCommitLogStart int64
+	// Store is the store for the series write state
+	// source of truth
+	Store SeriesWriteStateStore
+}
 
+// SeriesWriteStateStore provides series write state for a
+// series that is written to the commit log journal
+type SeriesWriteStateStore interface {
 	// SetCurrentCommitLogStart sets the unix nanoseconds
 	// for when the series was last written
 	// Note: provider does not need to provide volatility protection

--- a/persist/fs/commitlog/writer.go
+++ b/persist/fs/commitlog/writer.go
@@ -166,7 +166,7 @@ func (w *writer) Write(
 	logEntry.Create = w.nowFn().UnixNano()
 	logEntry.Index = series.UniqueIndex
 
-	seen := w.startNanos == series.WriteState.CurrentCommitLogStart()
+	seen := w.startNanos == series.WriteState.CurrentCommitLogStart
 	if !seen {
 		// If "idx" likely hasn't been written to commit log
 		// yet we need to include series metadata
@@ -195,7 +195,7 @@ func (w *writer) Write(
 
 	if !seen {
 		// Record we have seen this series at the current seenIdx
-		series.WriteState.SetCurrentCommitLogStart(w.startNanos)
+		series.WriteState.Store.SetCurrentCommitLogStart(w.startNanos)
 	}
 	return nil
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -539,7 +539,10 @@ func (s *dbShard) Write(
 		// as the commit log need to use the reference without the
 		// overhead of ownership tracking. This makes taking a ref here safe.
 		commitLogSeriesID = entry.series.ID()
-		commitLogSeriesWriteState = entry
+		commitLogSeriesWriteState = commitlog.SeriesWriteState{
+			CurrentCommitLogStart: entry.CurrentCommitLogStart(),
+			Store: entry,
+		}
 		commitLogSeriesUniqueIndex = entry.index
 		entry.decrementWriterCount()
 		if err != nil {
@@ -565,7 +568,10 @@ func (s *dbShard) Write(
 		// and adding ownership tracking to use it in the commit log
 		// (i.e. registering a dependency on the context) is too expensive.
 		commitLogSeriesID = result.copiedID
-		commitLogSeriesWriteState = result.entry
+		commitLogSeriesWriteState = commitlog.SeriesWriteState{
+			CurrentCommitLogStart: result.entry.CurrentCommitLogStart(),
+			Store: result.entry,
+		}
 		commitLogSeriesUniqueIndex = result.entry.index
 	}
 


### PR DESCRIPTION
This change passes the current commit log start for a series all the way to the commit log writer using the stack rather than accessing the heap which can be from all different parts of memory (bad CPU cache locality) because the current commit log start entry for a series piece is placed all over the process' heap.

cc @prateek @xichen2020 @martin-mao 