### PR TITLE
Revert the seen series store to a bitset for the commit log

### DIFF
--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -110,7 +110,7 @@ func writeCommitLogData(
 				ID:          point.ID,
 				UniqueIndex: series.uniqueIndex,
 			}
-			require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
+			require.NoError(t, commitLog.Write(ctx, cId, point.Datapoint, xtime.Second, nil))
 		}
 	}
 }

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -42,18 +42,7 @@ var (
 )
 
 type commitLogSeriesState struct {
-	uniqueIndex            uint64
-	currCommitLogUnixNanos int64
-}
-
-// CurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (s *commitLogSeriesState) CurrentCommitLogStart() int64 {
-	return s.currCommitLogUnixNanos
-}
-
-// SetCurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (s *commitLogSeriesState) SetCurrentCommitLogStart(unixNanos int64) {
-	s.currCommitLogUnixNanos = unixNanos
+	uniqueIndex uint64
 }
 
 func newCommitLogSeriesStates(
@@ -120,10 +109,6 @@ func writeCommitLogData(
 				Shard:       shardSet.Lookup(point.ID),
 				ID:          point.ID,
 				UniqueIndex: series.uniqueIndex,
-				WriteState: commitlog.SeriesWriteState{
-					CurrentCommitLogStart: series.CurrentCommitLogStart(),
-					Store: series,
-				},
 			}
 			require.NoError(t, commitLog.WriteBehind(ctx, cId, point.Datapoint, xtime.Second, nil))
 		}

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+const (
+	wordSize      = uint(64)
+	logWordSize   = uint(6) // lg(wordSize)
+	totalCapacity = ^uint(0)
+)
+
+type bitSet struct {
+	values []uint64
+}
+
+func newBitSet(size uint) *bitSet {
+	return &bitSet{values: make([]uint64, bitSetIndexOf(size)+1)}
+}
+
+func (b *bitSet) test(i uint) bool {
+	idx := bitSetIndexOf(i)
+	if idx >= len(b.values) {
+		return false
+	}
+	return b.values[idx]&(1<<(i&(wordSize-1))) != 0
+}
+
+func (b *bitSet) set(i uint) {
+	idx := bitSetIndexOf(i)
+	currLen := len(b.values)
+	if idx >= currLen {
+		newValues := make([]uint64, 2*(idx+1))
+		copy(newValues, b.values)
+		b.values = newValues
+	}
+	b.values[idx] |= 1 << (i & (wordSize - 1))
+}
+
+func (b *bitSet) clearAll() {
+	for i := range b.values {
+		b.values[i] = 0
+	}
+}
+
+func bitSetIndexOf(i uint) int {
+	return int(i >> logWordSize)
+}

--- a/persist/fs/commitlog/bitset.go
+++ b/persist/fs/commitlog/bitset.go
@@ -21,9 +21,8 @@
 package commitlog
 
 const (
-	wordSize      = uint(64)
-	logWordSize   = uint(6) // lg(wordSize)
-	totalCapacity = ^uint(0)
+	wordSize    = uint(64)
+	logWordSize = uint(6) // lg(wordSize)
 )
 
 type bitSet struct {

--- a/persist/fs/commitlog/bitset_bench_test.go
+++ b/persist/fs/commitlog/bitset_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/persist/fs/commitlog/bitset_bench_test.go
+++ b/persist/fs/commitlog/bitset_bench_test.go
@@ -20,45 +20,15 @@
 
 package commitlog
 
-const (
-	wordSize    = uint(64)
-	logWordSize = uint(6) // lg(wordSize)
-	wordMask    = wordSize - 1
-)
+import "testing"
 
-type bitSet struct {
-	values []uint64
-}
-
-func newBitSet(size uint) *bitSet {
-	return &bitSet{values: make([]uint64, bitSetIndexOf(size)+1)}
-}
-
-func (b *bitSet) test(i uint) bool {
-	idx := bitSetIndexOf(i)
-	if idx >= len(b.values) {
-		return false
+// go test -bench=LemireCreate
+// see http://lemire.me/blog/2016/09/22/swift-versus-java-the-bitset-performance-test/
+func BenchmarkLemireCreate(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bitmap := newBitSet(0) // we force dynamic memory allocation
+		for v := uint(0); v <= 100000000; v += 100 {
+			bitmap.set(v)
+		}
 	}
-	return b.values[idx]&(1<<(i&wordMask)) != 0
-}
-
-func (b *bitSet) set(i uint) {
-	idx := bitSetIndexOf(i)
-	currLen := len(b.values)
-	if idx >= currLen {
-		newValues := make([]uint64, 2*(idx+1))
-		copy(newValues, b.values)
-		b.values = newValues
-	}
-	b.values[idx] |= 1 << (i & wordMask)
-}
-
-func (b *bitSet) clearAll() {
-	for i := range b.values {
-		b.values[i] = 0
-	}
-}
-
-func bitSetIndexOf(i uint) int {
-	return int(i >> logWordSize)
 }

--- a/persist/fs/commitlog/bitset_prop_test.go
+++ b/persist/fs/commitlog/bitset_prop_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/persist/fs/commitlog/bitset_prop_test.go
+++ b/persist/fs/commitlog/bitset_prop_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/commands"
+	"github.com/leanovate/gopter/gen"
+)
+
+const (
+	bitSetPropTestMaxInitLength  = 4194304
+	bitSetPropTestMaxValueLength = bitSetPropTestMaxInitLength * 4
+)
+
+func TestBitSetProp(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 48
+	properties := gopter.NewProperties(parameters)
+
+	prop := commands.Prop(&commands.ProtoCommands{
+		NewSystemUnderTestFunc: func(initialState commands.State) commands.SystemUnderTest {
+			return initialState
+		},
+		DestroySystemUnderTestFunc: func(sut commands.SystemUnderTest) {
+			state := sut.(bitSetTestState)
+			state.set.clearAll()
+		},
+		InitialStateGen: gen.
+			UIntRange(0, bitSetPropTestMaxInitLength).
+			MapResult(func(r *gopter.GenResult) *gopter.GenResult {
+				iface, ok := r.Retrieve()
+				if !ok {
+					return gopter.NewEmptyResult(reflect.PtrTo(reflect.TypeOf(bitSetTestState{})))
+				}
+				v, ok := iface.(uint)
+				if !ok {
+					return gopter.NewEmptyResult(reflect.PtrTo(reflect.TypeOf(bitSetTestState{})))
+				}
+				state := bitSetTestState{
+					set:     newBitSet(v),
+					currSet: make(map[uint]struct{}),
+				}
+				return gopter.NewGenResult(state, gopter.NoShrinker)
+			}),
+		GenCommandFunc: func(state commands.State) gopter.Gen {
+			return gen.OneGenOf(genBitSetTestCommand,
+				genBitSetSetCommand, genBitSetClearAllCommand)
+		},
+	})
+	properties.Property("BitSet set/test/clearAll", prop)
+	properties.TestingRun(t)
+}
+
+type bitSetTestState struct {
+	set     *bitSet
+	currSet map[uint]struct{}
+}
+
+var genBitSetTestCommand = gen.
+	UIntRange(0, bitSetPropTestMaxValueLength).
+	Map(func(v uint) commands.Command {
+		return &commands.ProtoCommand{
+			Name: "Test",
+			RunFunc: func(q commands.SystemUnderTest) commands.Result {
+				state := q.(bitSetTestState)
+				return state.set.test(v)
+			},
+			NextStateFunc: func(state commands.State) commands.State {
+				return state
+			},
+			PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+				actual := result.(bool)
+				_, expected := state.(bitSetTestState).currSet[v]
+				if actual == expected {
+					return &gopter.PropResult{Status: gopter.PropTrue}
+				}
+				return &gopter.PropResult{
+					Status: gopter.PropFalse,
+					Error:  fmt.Errorf("expected %d to be true when testing value", v),
+				}
+			},
+		}
+	})
+
+var genBitSetSetCommand = gen.
+	UIntRange(0, bitSetPropTestMaxValueLength).
+	Map(func(v uint) commands.Command {
+		return &commands.ProtoCommand{
+			Name: "Set",
+			RunFunc: func(q commands.SystemUnderTest) commands.Result {
+				state := q.(bitSetTestState)
+				state.set.set(v)
+				if !state.set.test(v) {
+					return fmt.Errorf("not set, expected set after setting %v", v)
+				}
+				return nil
+			},
+			NextStateFunc: func(state commands.State) commands.State {
+				s := state.(bitSetTestState)
+				s.currSet[v] = struct{}{}
+				return s
+			},
+			PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+				if result == nil {
+					return &gopter.PropResult{Status: gopter.PropTrue}
+				}
+				return &gopter.PropResult{
+					Status: gopter.PropFalse,
+					Error:  result.(error),
+				}
+			},
+		}
+	})
+
+var genBitSetClearAllCommand = gen.Const(&commands.ProtoCommand{
+	Name: "ClearAll",
+	RunFunc: func(q commands.SystemUnderTest) commands.Result {
+		s := q.(bitSetTestState)
+		s.set.clearAll()
+		return nil
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		s := state.(bitSetTestState)
+		for k := range s.currSet {
+			delete(s.currSet, k)
+		}
+		return s
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		s := state.(bitSetTestState)
+		for i := range s.set.values {
+			if s.set.values[i] != 0 {
+				return &gopter.PropResult{
+					Status: gopter.PropError,
+					Error:  fmt.Errorf("set expected to be empty after clearAll"),
+				}
+			}
+		}
+		return &gopter.PropResult{Status: gopter.PropTrue}
+	},
+})

--- a/persist/fs/commitlog/bitset_test.go
+++ b/persist/fs/commitlog/bitset_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/persist/fs/commitlog/bitset_test.go
+++ b/persist/fs/commitlog/bitset_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/commands"
+	"github.com/leanovate/gopter/gen"
+)
+
+const (
+	bitSetPropTestMaxInitLength  = 4194304
+	bitSetPropTestMaxValueLength = bitSetPropTestMaxInitLength * 4
+)
+
+func TestBitSetProp(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	parameters.MinSuccessfulTests = 48
+	properties := gopter.NewProperties(parameters)
+
+	prop := commands.Prop(&commands.ProtoCommands{
+		NewSystemUnderTestFunc: func(initialState commands.State) commands.SystemUnderTest {
+			return initialState
+		},
+		DestroySystemUnderTestFunc: func(sut commands.SystemUnderTest) {
+			state := sut.(bitSetTestState)
+			state.set.clearAll()
+		},
+		InitialStateGen: gen.
+			UIntRange(0, bitSetPropTestMaxInitLength).
+			MapResult(func(r *gopter.GenResult) *gopter.GenResult {
+				iface, ok := r.Retrieve()
+				if !ok {
+					return gopter.NewEmptyResult(reflect.PtrTo(reflect.TypeOf(bitSetTestState{})))
+				}
+				v, ok := iface.(uint)
+				if !ok {
+					return gopter.NewEmptyResult(reflect.PtrTo(reflect.TypeOf(bitSetTestState{})))
+				}
+				state := bitSetTestState{
+					set:     newBitSet(v),
+					currSet: make(map[uint]struct{}),
+				}
+				return gopter.NewGenResult(state, gopter.NoShrinker)
+			}),
+		InitialPreConditionFunc: func(state commands.State) bool {
+			return true
+		},
+		GenCommandFunc: func(state commands.State) gopter.Gen {
+			return gen.OneGenOf(genBitSetTestCommand,
+				genBitSetSetCommand, genBitSetClearAllCommand)
+		},
+	})
+	properties.Property("BitSet set/test/clearAll", prop)
+	properties.TestingRun(t)
+}
+
+type bitSetTestState struct {
+	set     *bitSet
+	currSet map[uint]struct{}
+}
+
+var genBitSetTestCommand = gen.
+	UIntRange(0, bitSetPropTestMaxValueLength).
+	Map(func(v uint) commands.Command {
+		return &commands.ProtoCommand{
+			Name: "Test",
+			PreConditionFunc: func(state commands.State) bool {
+				return true
+			},
+			RunFunc: func(q commands.SystemUnderTest) commands.Result {
+				state := q.(bitSetTestState)
+				return state.set.test(v)
+			},
+			NextStateFunc: func(state commands.State) commands.State {
+				return state
+			},
+			PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+				actual := result.(bool)
+				_, expected := state.(bitSetTestState).currSet[v]
+				if actual == expected {
+					return &gopter.PropResult{Status: gopter.PropTrue}
+				}
+				return &gopter.PropResult{
+					Status: gopter.PropFalse,
+					Error:  fmt.Errorf("expected %d to be true when testing value", v),
+				}
+			},
+		}
+	})
+
+var genBitSetSetCommand = gen.
+	UIntRange(0, bitSetPropTestMaxValueLength).
+	Map(func(v uint) commands.Command {
+		return &commands.ProtoCommand{
+			Name: "Set",
+			PreConditionFunc: func(state commands.State) bool {
+				return true
+			},
+			RunFunc: func(q commands.SystemUnderTest) commands.Result {
+				state := q.(bitSetTestState)
+				state.set.set(v)
+				if !state.set.test(v) {
+					return fmt.Errorf("not set, expected set after setting %v", v)
+				}
+				return nil
+			},
+			NextStateFunc: func(state commands.State) commands.State {
+				s := state.(bitSetTestState)
+				s.currSet[v] = struct{}{}
+				return s
+			},
+			PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+				if result == nil {
+					return &gopter.PropResult{Status: gopter.PropTrue}
+				}
+				return &gopter.PropResult{
+					Status: gopter.PropFalse,
+					Error:  result.(error),
+				}
+			},
+		}
+	})
+
+var genBitSetClearAllCommand = gen.Const(&commands.ProtoCommand{
+	Name: "ClearAll",
+	PreConditionFunc: func(state commands.State) bool {
+		return true
+	},
+	RunFunc: func(q commands.SystemUnderTest) commands.Result {
+		s := q.(bitSetTestState)
+		s.set.clearAll()
+		return nil
+	},
+	NextStateFunc: func(state commands.State) commands.State {
+		s := state.(bitSetTestState)
+		for k := range s.currSet {
+			delete(s.currSet, k)
+		}
+		return s
+	},
+	PostConditionFunc: func(state commands.State, result commands.Result) *gopter.PropResult {
+		s := state.(bitSetTestState)
+		for i := range s.set.values {
+			if s.set.values[i] != 0 {
+				return &gopter.PropResult{
+					Status: gopter.PropFalse,
+					Error:  fmt.Errorf("set expected to be empty after clearAll"),
+				}
+			}
+		}
+		return &gopter.PropResult{Status: gopter.PropTrue}
+	},
+})

--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -67,8 +67,6 @@ type commitLog struct {
 
 	log xlog.Logger
 
-	strategy Strategy
-
 	newCommitLogWriterFn newCommitLogWriterFn
 	writeFn              writeCommitLogFn
 	commitLogFailFn      commitLogFailFn
@@ -348,7 +346,8 @@ func (l *commitLog) writeWait(
 	unit xtime.Unit,
 	annotation ts.Annotation,
 ) error {
-	if l.RLock(); l.closed {
+	l.RLock()
+	if l.closed {
 		l.RUnlock()
 		return errCommitLogClosed
 	}
@@ -399,7 +398,8 @@ func (l *commitLog) writeBehind(
 	unit xtime.Unit,
 	annotation ts.Annotation,
 ) error {
-	if l.RLock(); l.closed {
+	l.RLock()
+	if l.closed {
 		l.RUnlock()
 		return errCommitLogClosed
 	}

--- a/persist/fs/commitlog/commit_log_mock.go
+++ b/persist/fs/commitlog/commit_log_mock.go
@@ -24,6 +24,8 @@
 package commitlog
 
 import (
+	time0 "time"
+
 	gomock "github.com/golang/mock/gomock"
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
@@ -33,7 +35,6 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	time "github.com/m3db/m3x/time"
-	time0 "time"
 )
 
 // Mock of CommitLog interface
@@ -168,45 +169,6 @@ func (_m *MockIterator) Close() {
 
 func (_mr *_MockIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
-}
-
-// Mock of SeriesWriteState interface
-type MockSeriesWriteState struct {
-	ctrl     *gomock.Controller
-	recorder *_MockSeriesWriteStateRecorder
-}
-
-// Recorder for MockSeriesWriteState (not exported)
-type _MockSeriesWriteStateRecorder struct {
-	mock *MockSeriesWriteState
-}
-
-func NewMockSeriesWriteState(ctrl *gomock.Controller) *MockSeriesWriteState {
-	mock := &MockSeriesWriteState{ctrl: ctrl}
-	mock.recorder = &_MockSeriesWriteStateRecorder{mock}
-	return mock
-}
-
-func (_m *MockSeriesWriteState) EXPECT() *_MockSeriesWriteStateRecorder {
-	return _m.recorder
-}
-
-func (_m *MockSeriesWriteState) CurrentCommitLogStart() int64 {
-	ret := _m.ctrl.Call(_m, "CurrentCommitLogStart")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-func (_mr *_MockSeriesWriteStateRecorder) CurrentCommitLogStart() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CurrentCommitLogStart")
-}
-
-func (_m *MockSeriesWriteState) SetCurrentCommitLogStart(unixNanoseconds int64) {
-	_m.ctrl.Call(_m, "SetCurrentCommitLogStart", unixNanoseconds)
-}
-
-func (_mr *_MockSeriesWriteStateRecorder) SetCurrentCommitLogStart(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetCurrentCommitLogStart", arg0)
 }
 
 // Mock of Options interface

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -102,22 +102,6 @@ type testWrite struct {
 	expectedErr error
 }
 
-type testWriteStateStore struct {
-	currCommitLogUnixNanos int64
-}
-
-func newTestWriteState() SeriesWriteState {
-	return SeriesWriteState{
-		CurrentCommitLogStart: -1,
-		Store: &testWriteStateStore{currCommitLogUnixNanos: -1},
-	}
-}
-
-// SetCurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (s *testWriteStateStore) SetCurrentCommitLogStart(unixNanos int64) {
-	s.currCommitLogUnixNanos = unixNanos
-}
-
 func testSeries(
 	uniqueIndex uint64,
 	id string,
@@ -128,7 +112,6 @@ func testSeries(
 		Namespace:   ts.StringID("testNS"),
 		ID:          ts.StringID(id),
 		Shard:       shard,
-		WriteState:  newTestWriteState(),
 	}
 }
 

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -47,6 +47,7 @@ type overrides struct {
 	clock            *mclock.Mock
 	flushInterval    *time.Duration
 	backlogQueueSize *int
+	strategy         Strategy
 }
 
 func newTestOptions(
@@ -84,6 +85,8 @@ func newTestOptions(
 	if overrides.backlogQueueSize != nil {
 		opts = opts.SetBacklogQueueSize(*overrides.backlogQueueSize)
 	}
+
+	opts = opts.SetStrategy(overrides.strategy)
 
 	return opts, scope
 }
@@ -198,18 +201,10 @@ func newTestCommitLog(t *testing.T, opts Options) *commitLog {
 	return commitLog
 }
 
-type writeCommitLogFn func(
-	ctx context.Context,
-	series Series,
-	datapoint ts.Datapoint,
-	unit xtime.Unit,
-	annotation ts.Annotation,
-) error
-
 func writeCommitLogs(
 	t *testing.T,
 	scope tally.TestScope,
-	writeFn writeCommitLogFn,
+	commitLog CommitLog,
 	writes []testWrite,
 ) *sync.WaitGroup {
 	wg := sync.WaitGroup{}
@@ -247,7 +242,7 @@ func writeCommitLogs(
 
 			series := write.series
 			datapoint := ts.Datapoint{Timestamp: write.t, Value: write.v}
-			err := writeFn(ctx, series, datapoint, write.u, write.a)
+			err := commitLog.Write(ctx, series, datapoint, write.u, write.a)
 
 			if write.expectedErr != nil {
 				assert.True(t, strings.Contains(fmt.Sprintf("%v", err), fmt.Sprintf("%v", write.expectedErr)))
@@ -311,7 +306,9 @@ func setupCloseOnFail(t *testing.T, l *commitLog) *sync.WaitGroup {
 }
 
 func TestCommitLogWrite(t *testing.T) {
-	opts, scope := newTestOptions(t, overrides{})
+	opts, scope := newTestOptions(t, overrides{
+		strategy: StrategyWriteWait,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := newTestCommitLog(t, opts)
@@ -322,7 +319,7 @@ func TestCommitLogWrite(t *testing.T) {
 	}
 
 	// Call write sync
-	writeCommitLogs(t, scope, commitLog.Write, writes).Wait()
+	writeCommitLogs(t, scope, commitLog, writes).Wait()
 
 	// Close the commit log and consequently flush
 	assert.NoError(t, commitLog.Close())
@@ -332,7 +329,9 @@ func TestCommitLogWrite(t *testing.T) {
 }
 
 func TestCommitLogWriteBehind(t *testing.T) {
-	opts, scope := newTestOptions(t, overrides{})
+	opts, scope := newTestOptions(t, overrides{
+		strategy: StrategyWriteBehind,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := newTestCommitLog(t, opts)
@@ -344,7 +343,7 @@ func TestCommitLogWriteBehind(t *testing.T) {
 	}
 
 	// Call write behind
-	writeCommitLogs(t, scope, commitLog.WriteBehind, writes)
+	writeCommitLogs(t, scope, commitLog, writes)
 
 	// Close the commit log and consequently flush
 	assert.NoError(t, commitLog.Close())
@@ -369,10 +368,6 @@ func TestCommitLogWriteErrorOnClosed(t *testing.T) {
 	err := commitLog.Write(ctx, series, datapoint, xtime.Millisecond, nil)
 	assert.Error(t, err)
 	assert.Equal(t, errCommitLogClosed, err)
-
-	err = commitLog.WriteBehind(ctx, series, datapoint, xtime.Millisecond, nil)
-	assert.Error(t, err)
-	assert.Equal(t, errCommitLogClosed, err)
 }
 
 func TestCommitLogWriteErrorOnFull(t *testing.T) {
@@ -382,6 +377,7 @@ func TestCommitLogWriteErrorOnFull(t *testing.T) {
 	opts, _ := newTestOptions(t, overrides{
 		backlogQueueSize: &backlogQueueSize,
 		flushInterval:    &flushInterval,
+		strategy:         StrategyWriteBehind,
 	})
 	defer cleanup(t, opts)
 
@@ -397,7 +393,7 @@ func TestCommitLogWriteErrorOnFull(t *testing.T) {
 	defer ctx.Close()
 
 	for {
-		if err := commitLog.WriteBehind(ctx, series, dp, unit, nil); err != nil {
+		if err := commitLog.Write(ctx, series, dp, unit, nil); err != nil {
 			// Ensure queue full error
 			assert.Equal(t, ErrCommitLogQueueFull, err)
 			break
@@ -418,7 +414,10 @@ func TestCommitLogWriteErrorOnFull(t *testing.T) {
 
 func TestCommitLogExpiresWriter(t *testing.T) {
 	clock := mclock.NewMock()
-	opts, scope := newTestOptions(t, overrides{clock: clock})
+	opts, scope := newTestOptions(t, overrides{
+		clock:    clock,
+		strategy: StrategyWriteWait,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := newTestCommitLog(t, opts)
@@ -438,7 +437,7 @@ func TestCommitLogExpiresWriter(t *testing.T) {
 		clock.Add(write.t.Sub(clock.Now()))
 
 		// Write entry
-		wg := writeCommitLogs(t, scope, commitLog.Write, []testWrite{write})
+		wg := writeCommitLogs(t, scope, commitLog, []testWrite{write})
 
 		// Flush until finished, this is required as timed flusher not active when clock is mocked
 		flushUntilDone(commitLog, wg)
@@ -458,7 +457,9 @@ func TestCommitLogExpiresWriter(t *testing.T) {
 }
 
 func TestCommitLogFailOnWriteError(t *testing.T) {
-	opts, scope := newTestOptions(t, overrides{})
+	opts, scope := newTestOptions(t, overrides{
+		strategy: StrategyWriteBehind,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := NewCommitLog(opts).(*commitLog)
@@ -483,7 +484,6 @@ func TestCommitLogFailOnWriteError(t *testing.T) {
 
 	commitLog.newCommitLogWriterFn = func(
 		_ flushFn,
-		_ tally.Scope,
 		_ Options,
 	) commitLogWriter {
 		return writer
@@ -497,7 +497,7 @@ func TestCommitLogFailOnWriteError(t *testing.T) {
 		{testSeries(0, "foo.bar", 127), time.Now(), 123.456, xtime.Millisecond, nil, nil},
 	}
 
-	writeCommitLogs(t, scope, commitLog.WriteBehind, writes)
+	writeCommitLogs(t, scope, commitLog, writes)
 
 	wg.Wait()
 
@@ -508,7 +508,9 @@ func TestCommitLogFailOnWriteError(t *testing.T) {
 }
 
 func TestCommitLogFailOnOpenError(t *testing.T) {
-	opts, scope := newTestOptions(t, overrides{})
+	opts, scope := newTestOptions(t, overrides{
+		strategy: StrategyWriteBehind,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := NewCommitLog(opts).(*commitLog)
@@ -529,7 +531,6 @@ func TestCommitLogFailOnOpenError(t *testing.T) {
 
 	commitLog.newCommitLogWriterFn = func(
 		_ flushFn,
-		_ tally.Scope,
 		_ Options,
 	) commitLogWriter {
 		return writer
@@ -550,7 +551,7 @@ func TestCommitLogFailOnOpenError(t *testing.T) {
 		{testSeries(0, "foo.bar", 127), time.Now(), 123.456, xtime.Millisecond, nil, nil},
 	}
 
-	writeCommitLogs(t, scope, commitLog.WriteBehind, writes)
+	writeCommitLogs(t, scope, commitLog, writes)
 
 	wg.Wait()
 
@@ -565,7 +566,9 @@ func TestCommitLogFailOnOpenError(t *testing.T) {
 }
 
 func TestCommitLogFailOnFlushError(t *testing.T) {
-	opts, scope := newTestOptions(t, overrides{})
+	opts, scope := newTestOptions(t, overrides{
+		strategy: StrategyWriteBehind,
+	})
 	defer cleanup(t, opts)
 
 	commitLog := NewCommitLog(opts).(*commitLog)
@@ -583,7 +586,6 @@ func TestCommitLogFailOnFlushError(t *testing.T) {
 
 	commitLog.newCommitLogWriterFn = func(
 		_ flushFn,
-		_ tally.Scope,
 		_ Options,
 	) commitLogWriter {
 		return writer
@@ -597,7 +599,7 @@ func TestCommitLogFailOnFlushError(t *testing.T) {
 		{testSeries(0, "foo.bar", 127), time.Now(), 123.456, xtime.Millisecond, nil, nil},
 	}
 
-	writeCommitLogs(t, scope, commitLog.WriteBehind, writes)
+	writeCommitLogs(t, scope, commitLog, writes)
 
 	wg.Wait()
 

--- a/persist/fs/commitlog/read_write_prop_test.go
+++ b/persist/fs/commitlog/read_write_prop_test.go
@@ -337,7 +337,6 @@ func genWrite() gopter.Gen {
 				Namespace:   ts.StringID(ns),
 				Shard:       shard,
 				UniqueIndex: uniqueID(id),
-				WriteState:  newTestWriteState(),
 			},
 			datapoint: ts.Datapoint{
 				Timestamp: t,

--- a/persist/fs/commitlog/read_write_prop_test.go
+++ b/persist/fs/commitlog/read_write_prop_test.go
@@ -49,7 +49,7 @@ func TestCommitLogReadWrite(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(baseTestPath)
 
-	opts := NewOptions()
+	opts := NewOptions().SetStrategy(StrategyWriteBehind)
 	fsOpts := opts.FilesystemOptions().SetFilePathPrefix(baseTestPath)
 	opts = opts.SetFilesystemOptions(fsOpts).SetFlushInterval(time.Millisecond)
 
@@ -65,7 +65,7 @@ func TestCommitLogReadWrite(t *testing.T) {
 
 	ctx := context.NewContext()
 	for _, w := range writes {
-		require.NoError(t, cl.WriteBehind(ctx, w.series, w.datapoint, w.unit, w.annotation))
+		require.NoError(t, cl.Write(ctx, w.series, w.datapoint, w.unit, w.annotation))
 	}
 	ctx.Close()
 	require.NoError(t, cl.Close())
@@ -202,7 +202,7 @@ var genWriteBehindCommand = genWrite().
 				s := q.(*clState)
 				ctx := context.NewContext()
 				defer ctx.Close()
-				return s.cLog.WriteBehind(ctx, w.series, w.datapoint, w.unit, w.annotation)
+				return s.cLog.Write(ctx, w.series, w.datapoint, w.unit, w.annotation)
 			},
 			NextStateFunc: func(state commands.State) commands.State {
 				s := state.(*clState)
@@ -249,7 +249,9 @@ func genState(basePath string, t *testing.T) gopter.Gen {
 }
 
 func newInitState(dir string, t *testing.T) *clState {
-	opts := NewOptions().SetFlushInterval(defaultTestFlushInterval)
+	opts := NewOptions().
+		SetStrategy(StrategyWriteBehind).
+		SetFlushInterval(defaultTestFlushInterval)
 	fsOpts := opts.FilesystemOptions().SetFilePathPrefix(dir)
 	opts = opts.SetFilesystemOptions(fsOpts)
 	return &clState{

--- a/persist/fs/commitlog/types.go
+++ b/persist/fs/commitlog/types.go
@@ -62,15 +62,6 @@ type CommitLog interface {
 		annotation ts.Annotation,
 	) error
 
-	// WriteBehind will write an entry in the commit log for a given series without waiting for completion
-	WriteBehind(
-		ctx context.Context,
-		series Series,
-		datapoint ts.Datapoint,
-		unit xtime.Unit,
-		annotation ts.Annotation,
-	) error
-
 	// Iter returns an iterator for accessing commit logs
 	Iter() (Iterator, error)
 

--- a/persist/fs/commitlog/types.go
+++ b/persist/fs/commitlog/types.go
@@ -106,33 +106,6 @@ type Series struct {
 
 	// Shard is the shard the series belongs to
 	Shard uint32
-
-	// WriteState provides series write state for a
-	// series that is written to the commit log journal
-	WriteState SeriesWriteState
-}
-
-// SeriesWriteState is a snapshot of the current series
-// write state for the commit log journal with a store
-// that can update the attributes of the write state
-type SeriesWriteState struct {
-	// CurrentCommitLogStart is the unix nanoseconds
-	// for when the series was last written
-	CurrentCommitLogStart int64
-	// Store is the store for the series write state
-	// source of truth
-	Store SeriesWriteStateStore
-}
-
-// SeriesWriteStateStore provides series write state for a
-// series that is written to the commit log journal
-type SeriesWriteStateStore interface {
-	// SetCurrentCommitLogStart sets the unix nanoseconds
-	// for when the series was last written
-	// Note: provider does not need to provide volatility protection
-	// (thread safety) as access is synchronized to both the accessor
-	// and setter.
-	SetCurrentCommitLogStart(unixNanoseconds int64)
 }
 
 // Options represents the options for the commit log

--- a/persist/fs/commitlog/writer.go
+++ b/persist/fs/commitlog/writer.go
@@ -111,6 +111,7 @@ func newCommitLogWriter(
 		chunkReserveHeader: make([]byte, chunkHeaderLen),
 		buffer:             bufio.NewWriterSize(nil, opts.FlushSize()),
 		sizeBuffer:         make([]byte, binary.MaxVarintLen64),
+		seen:               newBitSet(defaultBitSetLength),
 		logEncoder:         msgpack.NewEncoder(),
 		metadataEncoder:    msgpack.NewEncoder(),
 	}

--- a/persist/fs/commitlog/writer.go
+++ b/persist/fs/commitlog/writer.go
@@ -86,7 +86,6 @@ type writer struct {
 	newDirectoryMode   os.FileMode
 	nowFn              clock.NowFn
 	start              time.Time
-	startNanos         int64
 	duration           time.Duration
 	chunkWriter        *chunkWriter
 	chunkReserveHeader []byte

--- a/storage/database.go
+++ b/storage/database.go
@@ -55,9 +55,6 @@ var (
 
 	// errDuplicateNamespace raised when trying to create a database with duplicate namespaces
 	errDuplicateNamespaces = errors.New("database contains duplicate namespaces")
-
-	// errCommitLogStrategyUnknown raised when trying to use an unknown commit log strategy
-	errCommitLogStrategyUnknown = errors.New("database commit log strategy is unknown")
 )
 
 type databaseState int
@@ -72,15 +69,6 @@ const (
 type increasingIndex interface {
 	nextIndex() uint64
 }
-
-// writeCommitLogFn is a method for writing to the commit log
-type writeCommitLogFn func(
-	ctx context.Context,
-	series commitlog.Series,
-	datapoint ts.Datapoint,
-	unit xtime.Unit,
-	annotation ts.Annotation,
-) error
 
 type db struct {
 	sync.RWMutex

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -134,10 +134,9 @@ func newDatabaseShardMetrics(scope tally.Scope) dbShardMetrics {
 }
 
 type dbShardEntry struct {
-	series                 series.DatabaseSeries
-	index                  uint64
-	curWriters             int32
-	currCommitLogUnixNanos int64
+	series     series.DatabaseSeries
+	index      uint64
+	curWriters int32
 }
 
 func (entry *dbShardEntry) writerCount() int32 {
@@ -150,16 +149,6 @@ func (entry *dbShardEntry) incrementWriterCount() {
 
 func (entry *dbShardEntry) decrementWriterCount() {
 	atomic.AddInt32(&entry.curWriters, -1)
-}
-
-// CurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (entry *dbShardEntry) CurrentCommitLogStart() int64 {
-	return entry.currCommitLogUnixNanos
-}
-
-// SetCurrentCommitLogStart implements the commitlog.SeriesWriteState interface
-func (entry *dbShardEntry) SetCurrentCommitLogStart(unixNanos int64) {
-	entry.currCommitLogUnixNanos = unixNanos
 }
 
 type dbShardEntryWorkFn func(entry *dbShardEntry) bool
@@ -522,7 +511,6 @@ func (s *dbShard) Write(
 
 	var (
 		commitLogSeriesID          ts.ID
-		commitLogSeriesWriteState  commitlog.SeriesWriteState
 		commitLogSeriesUniqueIndex uint64
 	)
 	if writable {
@@ -535,10 +523,6 @@ func (s *dbShard) Write(
 		// as the commit log need to use the reference without the
 		// overhead of ownership tracking. This makes taking a ref here safe.
 		commitLogSeriesID = entry.series.ID()
-		commitLogSeriesWriteState = commitlog.SeriesWriteState{
-			CurrentCommitLogStart: entry.CurrentCommitLogStart(),
-			Store: entry,
-		}
 		commitLogSeriesUniqueIndex = entry.index
 		entry.decrementWriterCount()
 		if err != nil {
@@ -564,10 +548,6 @@ func (s *dbShard) Write(
 		// and adding ownership tracking to use it in the commit log
 		// (i.e. registering a dependency on the context) is too expensive.
 		commitLogSeriesID = result.copiedID
-		commitLogSeriesWriteState = commitlog.SeriesWriteState{
-			CurrentCommitLogStart: result.entry.CurrentCommitLogStart(),
-			Store: result.entry,
-		}
 		commitLogSeriesUniqueIndex = result.entry.index
 	}
 
@@ -577,7 +557,6 @@ func (s *dbShard) Write(
 		Namespace:   s.namespace,
 		ID:          commitLogSeriesID,
 		Shard:       s.shard,
-		WriteState:  commitLogSeriesWriteState,
 	}
 
 	datapoint := ts.Datapoint{

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -87,7 +87,7 @@ type dbShard struct {
 	shard                    uint32
 	increasingIndex          increasingIndex
 	seriesPool               series.DatabaseSeriesPool
-	writeCommitLogFn         writeCommitLogFn
+	commitLogWriter          commitLogWriter
 	insertQueue              *dbShardInsertQueue
 	lookup                   map[ts.Hash]*list.Element
 	list                     *list.List
@@ -169,7 +169,7 @@ func newDatabaseShard(
 	shard uint32,
 	blockRetriever block.DatabaseBlockRetriever,
 	increasingIndex increasingIndex,
-	writeCommitLogFn writeCommitLogFn,
+	commitLogWriter commitLogWriter,
 	needsBootstrap bool,
 	opts Options,
 ) databaseShard {
@@ -184,7 +184,7 @@ func newDatabaseShard(
 		shard:                 shard,
 		increasingIndex:       increasingIndex,
 		seriesPool:            opts.DatabaseSeriesPool(),
-		writeCommitLogFn:      writeCommitLogFn,
+		commitLogWriter:       commitLogWriter,
 		lookup:                make(map[ts.Hash]*list.Element),
 		list:                  list.New(),
 		filesetBeforeFn:       fs.FilesetBefore,
@@ -564,7 +564,8 @@ func (s *dbShard) Write(
 		Value:     value,
 	}
 
-	return s.writeCommitLogFn(ctx, series, datapoint, unit, annotation)
+	return s.commitLogWriter.Write(ctx, series, datapoint,
+		unit, annotation)
 }
 
 func (s *dbShard) ReadEncoded(


### PR DESCRIPTION
Reverting the seen series storage for a given commit log to be a bitset.  This bitset implementation is a derivation of the previously used bitset library.  It makes it both a little simpler and also enforces that the growth of the bitset is 2x required length, instead of dependent on the library version.

Even with the changes to fix the memory locality when testing whether a series has already been written to the current commit log, the updating of that data still has very poor memory locality as the source of truth still sits on the heap across a large part of the memory of the process.  The bitset implementation originally set in place allows for much better locality with the caches close to the CPU, even if it is not as clean as keeping the relevant data next to the series themselves.

cc @xichen2020 @prateek @martin-mao 