### PR TITLE
Avoid redundant series pool creation

### DIFF
--- a/storage/block/block.go
+++ b/storage/block/block.go
@@ -287,22 +287,16 @@ func (b *dbBlock) resetMergeTargetWithLock() {
 }
 
 type databaseSeriesBlocks struct {
-	opts  Options
 	elems map[time.Time]DatabaseBlock
 	min   time.Time
 	max   time.Time
 }
 
 // NewDatabaseSeriesBlocks creates a databaseSeriesBlocks instance.
-func NewDatabaseSeriesBlocks(capacity int, opts Options) DatabaseSeriesBlocks {
+func NewDatabaseSeriesBlocks(capacity int) DatabaseSeriesBlocks {
 	return &databaseSeriesBlocks{
-		opts:  opts,
 		elems: make(map[time.Time]DatabaseBlock, capacity),
 	}
-}
-
-func (dbb *databaseSeriesBlocks) Options() Options {
-	return dbb.opts
 }
 
 func (dbb *databaseSeriesBlocks) Len() int {

--- a/storage/block/block_test.go
+++ b/storage/block/block_test.go
@@ -39,8 +39,7 @@ func testDatabaseBlock(ctrl *gomock.Controller) *dbBlock {
 }
 
 func testDatabaseSeriesBlocks() *databaseSeriesBlocks {
-	opts := NewOptions()
-	return NewDatabaseSeriesBlocks(0, opts).(*databaseSeriesBlocks)
+	return NewDatabaseSeriesBlocks(0).(*databaseSeriesBlocks)
 }
 
 func testDatabaseSeriesBlocksWithTimes(times []time.Time) *databaseSeriesBlocks {

--- a/storage/block/types.go
+++ b/storage/block/types.go
@@ -255,9 +255,6 @@ type DatabaseShardBlockRetrieverManager interface {
 
 // DatabaseSeriesBlocks represents a collection of data blocks.
 type DatabaseSeriesBlocks interface {
-	// Options returns the blocks options.
-	Options() Options
-
 	// Len returns the number of blocks contained in the collection.
 	Len() int
 

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -188,7 +188,7 @@ func (s *commitLogSource) Read(
 	for shard, unmergedShard := range unmerged {
 		shardResult := result.NewShardResult(len(unmergedShard), s.opts.ResultOptions())
 		for _, unmergedBlocks := range unmergedShard {
-			blocks := block.NewDatabaseSeriesBlocks(len(unmergedBlocks.encoders), blopts)
+			blocks := block.NewDatabaseSeriesBlocks(len(unmergedBlocks.encoders))
 			for start, unmergedBlock := range unmergedBlocks.encoders {
 				block := blocksPool.Get()
 				if len(unmergedBlock) == 0 {

--- a/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -381,7 +381,6 @@ func requireShardResults(
 			otherAllBlocks := otherBlocks.Blocks.AllBlocks()
 			require.Equal(t, len(allBlocks), len(otherAllBlocks))
 
-			blopts := blocks.Blocks.Options()
 			readerIteratorPool := blopts.ReaderIteratorPool()
 			for start, block := range allBlocks {
 				otherBlock, ok := otherAllBlocks[start]

--- a/storage/bootstrap/result/result.go
+++ b/storage/bootstrap/result/result.go
@@ -128,10 +128,9 @@ func (sr *shardResult) AddSeries(id ts.ID, rawSeries block.DatabaseSeriesBlocks)
 
 func (sr *shardResult) newBlocks(id ts.ID) DatabaseSeriesBlocks {
 	size := sr.opts.NewBlocksLen()
-	blopts := sr.opts.DatabaseBlockOptions()
 	return DatabaseSeriesBlocks{
 		ID:     id,
-		Blocks: block.NewDatabaseSeriesBlocks(size, blopts),
+		Blocks: block.NewDatabaseSeriesBlocks(size),
 	}
 }
 

--- a/storage/bootstrap/result/result_test.go
+++ b/storage/bootstrap/result/result_test.go
@@ -260,13 +260,13 @@ func TestShardResultAddSeries(t *testing.T) {
 		id     string
 		series block.DatabaseSeriesBlocks
 	}{
-		{"foo", block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions())},
-		{"bar", block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions())},
+		{"foo", block.NewDatabaseSeriesBlocks(0)},
+		{"bar", block.NewDatabaseSeriesBlocks(0)},
 	}
 	for _, input := range inputs {
 		sr.AddSeries(ts.StringID(input.id), input.series)
 	}
-	moreSeries := block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions())
+	moreSeries := block.NewDatabaseSeriesBlocks(0)
 	block := opts.DatabaseBlockOptions().DatabaseBlockPool().Get()
 	block.Reset(start, ts.Segment{})
 	moreSeries.AddBlock(block)
@@ -283,8 +283,8 @@ func TestShardResultAddResult(t *testing.T) {
 	sr.AddResult(nil)
 	require.True(t, sr.IsEmpty())
 	other := NewShardResult(0, opts)
-	other.AddSeries(ts.StringID("foo"), block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions()))
-	other.AddSeries(ts.StringID("bar"), block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions()))
+	other.AddSeries(ts.StringID("foo"), block.NewDatabaseSeriesBlocks(0))
+	other.AddSeries(ts.StringID("bar"), block.NewDatabaseSeriesBlocks(0))
 	sr.AddResult(other)
 	require.Len(t, sr.AllSeries(), 2)
 }
@@ -295,8 +295,8 @@ func TestShardResultNumSeries(t *testing.T) {
 	sr.AddResult(nil)
 	require.True(t, sr.IsEmpty())
 	other := NewShardResult(0, opts)
-	other.AddSeries(ts.StringID("foo"), block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions()))
-	other.AddSeries(ts.StringID("bar"), block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions()))
+	other.AddSeries(ts.StringID("foo"), block.NewDatabaseSeriesBlocks(0))
+	other.AddSeries(ts.StringID("bar"), block.NewDatabaseSeriesBlocks(0))
 	sr.AddResult(other)
 	require.Equal(t, int64(2), sr.NumSeries())
 }
@@ -308,8 +308,8 @@ func TestShardResultRemoveSeries(t *testing.T) {
 		id     string
 		series block.DatabaseSeriesBlocks
 	}{
-		{"foo", block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions())},
-		{"bar", block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions())},
+		{"foo", block.NewDatabaseSeriesBlocks(0)},
+		{"bar", block.NewDatabaseSeriesBlocks(0)},
 	}
 	for _, input := range inputs {
 		sr.AddSeries(ts.StringID(input.id), input.series)

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -189,8 +189,6 @@ func newDatabaseNamespace(
 
 	iops := opts.InstrumentOptions()
 	logger := iops.Logger().WithFields(xlog.NewLogField("namespace", id.String()))
-	iops = iops.SetLogger(logger)
-	opts = opts.SetInstrumentOptions(iops)
 
 	scope := iops.MetricsScope().SubScope("database").
 		Tagged(map[string]string{

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -189,6 +189,8 @@ func newDatabaseNamespace(
 
 	iops := opts.InstrumentOptions()
 	logger := iops.Logger().WithFields(xlog.NewLogField("namespace", id.String()))
+	iops = iops.SetLogger(logger)
+	opts = opts.SetInstrumentOptions(iops)
 
 	scope := iops.MetricsScope().SubScope("database").
 		Tagged(map[string]string{

--- a/storage/options.go
+++ b/storage/options.go
@@ -165,7 +165,7 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 		poolOpts:                       poolOpts,
 		contextPool:                    context.NewPool(poolOpts, poolOpts),
 		seriesOpts:                     seriesOpts,
-		seriesPool:                     series.NewDatabaseSeriesPool(seriesOpts, poolOpts),
+		seriesPool:                     series.NewDatabaseSeriesPool(poolOpts),
 		bytesPool:                      bytesPool,
 		encoderPool:                    encoding.NewEncoderPool(poolOpts),
 		segmentReaderPool:              xio.NewSegmentReaderPool(poolOpts),
@@ -214,7 +214,6 @@ func (o *options) SetClockOptions(value clock.Options) Options {
 	opts.clockOpts = value
 	opts.commitLogOpts = opts.commitLogOpts.SetClockOptions(value)
 	opts.seriesOpts = NewSeriesOptionsFromOptions(&opts, nil)
-	opts.seriesPool = series.NewDatabaseSeriesPool(opts.seriesOpts, opts.poolOpts)
 	return &opts
 }
 
@@ -227,7 +226,6 @@ func (o *options) SetInstrumentOptions(value instrument.Options) Options {
 	opts.instrumentOpts = value
 	opts.commitLogOpts = opts.commitLogOpts.SetInstrumentOptions(value)
 	opts.seriesOpts = NewSeriesOptionsFromOptions(&opts, nil)
-	opts.seriesPool = series.NewDatabaseSeriesPool(opts.seriesOpts, opts.poolOpts)
 	return &opts
 }
 
@@ -249,7 +247,6 @@ func (o *options) SetDatabaseBlockOptions(value block.Options) Options {
 	opts := *o
 	opts.blockOpts = value
 	opts.seriesOpts = NewSeriesOptionsFromOptions(&opts, nil)
-	opts.seriesPool = series.NewDatabaseSeriesPool(opts.seriesOpts, opts.poolOpts)
 	return &opts
 }
 
@@ -384,7 +381,6 @@ func (o *options) SetEncodingM3TSZPooled() Options {
 		SetBytesPool(bytesPool)
 
 	opts.seriesOpts = NewSeriesOptionsFromOptions(&opts, nil)
-	opts.seriesPool = series.NewDatabaseSeriesPool(opts.seriesOpts, opts.poolOpts)
 	return &opts
 }
 

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -121,11 +121,10 @@ type dbBuffer struct {
 
 type databaseBufferDrainFn func(b block.DatabaseBlock)
 
-func newDatabaseBuffer(drainFn databaseBufferDrainFn, opts Options) databaseBuffer {
+func newDatabaseBuffer(drainFn databaseBufferDrainFn) databaseBuffer {
 	b := &dbBuffer{
 		drainFn: drainFn,
 	}
-	b.Reset(opts)
 	return b
 }
 

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -121,6 +121,8 @@ type dbBuffer struct {
 
 type databaseBufferDrainFn func(b block.DatabaseBlock)
 
+// NB(prateek): databaseBuffer.Reset(...) must be called upon the returned
+// object prior to use.
 func newDatabaseBuffer(drainFn databaseBufferDrainFn) databaseBuffer {
 	b := &dbBuffer{
 		drainFn: drainFn,

--- a/storage/series/buffer_test.go
+++ b/storage/series/buffer_test.go
@@ -73,7 +73,8 @@ func TestBufferWriteTooFuture(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 
 	ctx := context.NewContext()
 	defer ctx.Close()
@@ -90,7 +91,8 @@ func TestBufferWriteTooPast(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 
 	ctx := context.NewContext()
 	defer ctx.Close()
@@ -107,7 +109,8 @@ func TestBufferWriteRead(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 
 	data := []value{
 		{curr.Add(secs(1)), 1, xtime.Second, nil},
@@ -138,7 +141,8 @@ func TestBufferReadOnlyMatchingBuckets(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 
 	data := []value{
 		{curr.Add(mins(1)), 1, xtime.Second, nil},
@@ -182,7 +186,8 @@ func TestBufferDrain(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(drainFn, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(drainFn).(*dbBuffer)
+	buffer.Reset(opts)
 
 	data := []value{
 		{curr, 1, xtime.Second, nil},
@@ -232,7 +237,8 @@ func TestBufferResetUndrainedBucketDrainsBucket(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(drainFn, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(drainFn).(*dbBuffer)
+	buffer.Reset(opts)
 
 	data := []value{
 		{curr.Add(mins(1)), 1, xtime.Second, nil},
@@ -271,7 +277,8 @@ func TestBufferWriteOutOfOrder(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 
 	data := []value{
 		{curr, 1, xtime.Second, nil},
@@ -456,7 +463,8 @@ func TestBufferFetchBlocks(t *testing.T) {
 	ctx := opts.ContextPool().Get()
 	defer ctx.Close()
 
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 	buffer.buckets[0] = *b
 
 	for i := 1; i < 3; i++ {
@@ -483,7 +491,8 @@ func TestBufferFetchBlocksMetadata(t *testing.T) {
 	start := b.start.Add(-time.Second)
 	end := b.start.Add(time.Second)
 
-	buffer := newDatabaseBuffer(nil, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(nil).(*dbBuffer)
+	buffer.Reset(opts)
 	buffer.buckets[0] = *b
 
 	expectedSize := int64(b.streamsLen())
@@ -514,7 +523,8 @@ func TestBufferReadEncodedValidAfterDrain(t *testing.T) {
 	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
 		return curr
 	}))
-	buffer := newDatabaseBuffer(drainFn, opts).(*dbBuffer)
+	buffer := newDatabaseBuffer(drainFn).(*dbBuffer)
+	buffer.Reset(opts)
 
 	// Perform out of order writes that will create two in order encoders
 	data := []value{

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -71,12 +71,18 @@ type dbSeries struct {
 
 // NewDatabaseSeries creates a new database series
 func NewDatabaseSeries(id ts.ID, opts Options) DatabaseSeries {
-	return newDatabaseSeries(id, opts)
+	var (
+		s                  = newDatabaseSeries(id, opts)
+		seriesBootstrapped = false
+		blockRetriever     QueryableBlockRetriever
+	)
+	s.Reset(id, seriesBootstrapped, blockRetriever, opts)
+	return s
 }
 
 // newPooledDatabaseSeries creates a new pooled database series
-func newPooledDatabaseSeries(pool DatabaseSeriesPool, opts Options) DatabaseSeries {
-	series := newDatabaseSeries(nil, opts)
+func newPooledDatabaseSeries(pool DatabaseSeriesPool) DatabaseSeries {
+	series := newDatabaseSeries(nil, nil)
 	series.pool = pool
 	return series
 }
@@ -85,10 +91,10 @@ func newDatabaseSeries(id ts.ID, opts Options) *dbSeries {
 	series := &dbSeries{
 		id:     id,
 		opts:   opts,
-		blocks: block.NewDatabaseSeriesBlocks(0, opts.DatabaseBlockOptions()),
+		blocks: block.NewDatabaseSeriesBlocks(0),
 		bs:     bootstrapNotStarted,
 	}
-	series.buffer = newDatabaseBuffer(series.bufferDrained, opts)
+	series.buffer = newDatabaseBuffer(series.bufferDrained)
 	return series
 }
 

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -72,7 +72,7 @@ type dbSeries struct {
 // NewDatabaseSeries creates a new database series
 func NewDatabaseSeries(id ts.ID, opts Options) DatabaseSeries {
 	var (
-		s                  = newDatabaseSeries(id, opts)
+		s                  = newDatabaseSeries()
 		seriesBootstrapped = false
 		blockRetriever     QueryableBlockRetriever
 	)
@@ -82,15 +82,15 @@ func NewDatabaseSeries(id ts.ID, opts Options) DatabaseSeries {
 
 // newPooledDatabaseSeries creates a new pooled database series
 func newPooledDatabaseSeries(pool DatabaseSeriesPool) DatabaseSeries {
-	series := newDatabaseSeries(nil, nil)
+	series := newDatabaseSeries()
 	series.pool = pool
 	return series
 }
 
-func newDatabaseSeries(id ts.ID, opts Options) *dbSeries {
+// NB(prateek): dbSeries.Reset(...) must be called upon the returned
+// object prior to use.
+func newDatabaseSeries() *dbSeries {
 	series := &dbSeries{
-		id:     id,
-		opts:   opts,
 		blocks: block.NewDatabaseSeriesBlocks(0),
 		bs:     bootstrapNotStarted,
 	}

--- a/storage/series/series_pool.go
+++ b/storage/series/series_pool.go
@@ -27,10 +27,10 @@ type databaseSeriesPool struct {
 }
 
 // NewDatabaseSeriesPool creates a new database series pool
-func NewDatabaseSeriesPool(seriesOpts Options, opts pool.ObjectPoolOptions) DatabaseSeriesPool {
+func NewDatabaseSeriesPool(opts pool.ObjectPoolOptions) DatabaseSeriesPool {
 	p := &databaseSeriesPool{pool: pool.NewObjectPool(opts)}
 	p.pool.Init(func() interface{} {
-		return newPooledDatabaseSeries(p, seriesOpts)
+		return newPooledDatabaseSeries(p)
 	})
 	return p
 }

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -305,9 +305,7 @@ func TestSeriesBootstrapWithError(t *testing.T) {
 	series.buffer = buffer
 
 	errBlockStart := bufferMin
-	blopts := opts.DatabaseBlockOptions()
-
-	blocks := block.NewDatabaseSeriesBlocks(0, blopts)
+	blocks := block.NewDatabaseSeriesBlocks(0)
 
 	// Add block that buffer will fail to bootstrap
 	bl := block.NewMockDatabaseBlock(ctrl)


### PR DESCRIPTION
Observed latest builds deployed to prod were using more memory than previous builds. 

## Heap profiles

<details>
<summary>(1) master build - total size 118GB</summary>

```
❯ echo top | go tool pprof -inuse_space old-m3dbnode-build old-heap-dump
Entering interactive mode (type "help" for commands)
(pprof) 103.58GB of 117.49GB total (88.15%)
Dropped 1126 nodes (cum <= 0.59GB)
Showing top 10 nodes out of 92 (cum >= 8.75GB)
      flat  flat%   sum%        cum   cum%
   25.16GB 21.41% 21.41%    25.60GB 21.79%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.NewDatabaseBlock
   19.17GB 16.31% 37.73%    19.17GB 16.31%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.(*databaseSeriesBlocks).AddBlock
   16.31GB 13.88% 51.61%    16.31GB 13.88%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.(*seeker).readIndex
   15.87GB 13.51% 65.12%    15.87GB 13.51%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/context.NewPool.func1
    9.13GB  7.77% 72.89%     9.13GB  7.77%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/pool.(*bytesPool).Init.func1
    5.14GB  4.38% 77.27%     6.93GB  5.90%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseBuffer
    4.98GB  4.24% 81.50%     6.61GB  5.63%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/encoding/m3tsz.NewEncoder
    3.09GB  2.63% 84.13%     3.84GB  3.27%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/checked.NewBytes
    2.90GB  2.47% 86.60%     2.90GB  2.47%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.newSeeker
    1.83GB  1.55% 88.15%     8.75GB  7.45%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseSeries
```
</details>


<details>
<summary>(2) new build (w/o the fix) - total size 121GB</summary>

```
❯ echo top | go tool pprof -inuse_space new-m3dbnode-build new-heap-dump
Entering interactive mode (type "help" for commands)
(pprof) 106.14GB of 121.62GB total (87.27%)
Dropped 916 nodes (cum <= 0.61GB)
Showing top 10 nodes out of 105 (cum >= 2.85GB)
      flat  flat%   sum%        cum   cum%
   25.08GB 20.63% 20.63%    25.37GB 20.86%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.NewDatabaseBlock
   16.85GB 13.86% 34.48%    16.85GB 13.86%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/context.NewPool.func1
   16.23GB 13.34% 47.83%    16.23GB 13.34%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.(*seeker).readIndex
   13.78GB 11.33% 59.16%    13.78GB 11.33%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/pool.(*bytesPool).Init.func1
   10.51GB  8.64% 67.80%    10.51GB  8.64%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.(*databaseSeriesBlocks).AddBlock
    6.77GB  5.57% 73.37%     9.51GB  7.82%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseBuffer
    6.54GB  5.38% 78.75%     8.71GB  7.16%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/encoding/m3tsz.NewEncoder
    4.61GB  3.79% 82.54%     5.79GB  4.76%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/checked.NewBytes
    2.90GB  2.39% 84.93%    12.42GB 10.21%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseSeries
    2.85GB  2.34% 87.27%     2.85GB  2.35%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.newSeeker
```

</details>

<details>
<summary>(3) new build (w/ the fix) - total size 113GB</summary>

```
❯ echo top | go tool pprof -inuse_space fixed-m3dbnode-build fixed-heap-dump
Entering interactive mode (type "help" for commands)
(pprof) 98.10GB of 113.08GB total (86.75%)
Dropped 843 nodes (cum <= 0.57GB)
Showing top 10 nodes out of 100 (cum >= 8.06GB)
      flat  flat%   sum%        cum   cum%
   25.84GB 22.85% 22.85%    26.13GB 23.11%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.NewDatabaseBlock
   15.80GB 13.97% 36.83%    15.80GB 13.97%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/context.NewPool.func1
   15.62GB 13.82% 50.64%    15.62GB 13.82%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.(*seeker).readIndex
   14.12GB 12.49% 63.13%    14.12GB 12.49%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/pool.(*bytesPool).Init.func1
    9.83GB  8.69% 71.82%     9.83GB  8.69%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/block.(*databaseSeriesBlocks).AddBlock
    4.59GB  4.06% 75.88%     6.57GB  5.81%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseBuffer
    4.41GB  3.90% 79.78%     5.86GB  5.18%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/encoding/m3tsz.NewEncoder
    3.72GB  3.29% 83.07%     4.65GB  4.11%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3x/checked.NewBytes
    2.68GB  2.37% 85.44%     2.68GB  2.37%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/persist/fs.newSeeker
    1.49GB  1.31% 86.75%     8.06GB  7.13%  code.uber.internal/infra/statsdex/vendor/github.com/m3db/m3db/storage/series.newDatabaseSeries
```

</details>

## Summary Table

|                                                     |  master |  new    |  fixed  | 
|-----------------------------------------------------|---------|---------|---------| 
| m3db/storage/block.NewDatabaseBlock                 | 25.16GB | 25.08GB | 25.84GB | 
| m3db/storage/block.(*databaseSeriesBlocks).AddBlock | 19.17GB | 10.51GB | 9.83GB  | 
| m3db/persist/fs.(*seeker).readIndex                 | 16.31GB | 16.23GB | 15.62GB | 
| m3db/context.NewPool.func1                          | 15.87GB | 16.85GB | 15.80GB | 
| m3x/pool.(*bytesPool).Init.func1                    | 9.13GB  | 13.78GB | 14.12GB | 
| m3db/storage/series.newDatabaseBuffer               | 5.14GB  | 6.77GB  | 4.59GB  | 
| m3db/encoding/m3tsz.NewEncoder                      | 4.98GB  | 6.54GB  | 4.41GB  | 
| m3x/checked.NewBytes                                | 3.09GB  | 4.61GB  | 3.72GB  | 
| m3db/persist/fs.newSeeker                           | 2.90GB  | 2.85GB  | 2.68GB  | 
| m3db/storage/series.newDatabaseSeries               | 1.83GB  | 2.90GB  | 1.49GB  | 

## Explanation of differences
- First off, observe the difference in `m3db/storage/block.(*databaseSeriesBlocks).AddBlock`. We're saving straight up 9GB in both (2) and (3) over (1). ...

- Between (2) & (3), we're saving a 1-2GB in a few different places (`m3db/storage/series.newDatabaseBuffer`, `m3db/encoding/m3tsz.NewEncoder`, `m3db/storage/series.newDatabaseSeries`). The only change between these two builds is captured in this PR - i.e. avoiding updating instrument options. We observe this because, under the hood, setting instrument options creates a new series pool [relevant code](https://github.com/m3db/m3db/blob/fa5ee9e50605d345af6dc283b3778eea50a2912e/storage/options.go#L225-L231). 

- `m3x/pool.(*bytesPool).Init.func1` between 1 & 2/3 ...