### PR TITLE
[travis] Add go 1.8 and 1.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.8
+  - 1.7.6
+  - 1.8.3
   - 1.9
 install: make install-ci
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.7
+  - 1.8
+  - 1.9
 install: make install-ci
 env:
  # Set higher timeouts for Travis


### PR DESCRIPTION
This PR adds Go 1.8 and 1.9 to the versions of Go we test against in Travis.

Update: Go 1.9 changed the internal representation of `time.Time` such that `Time` values, even if they represent the same instant, are unlikely to be equal according to `reflect.DeepEqual` which the `testify` package uses under the hood to test if two values are equal. There's an [open PR](https://github.com/stretchr/testify/pull/394) to address this problem by first checking if the values being compared have an `Equal` method before falling back to comparing basic types. Admittedly the PR hasn't gotten much traction though the development of packages such as https://github.com/google/go-cmp, which aim to provide a more powerful alternative to `reflect.DeepEqual`, may help the cause. 

With that being said, I started updating the tests which compare times using `assert.Equal` to instead use `assert.True` and call the `Equal` method on the values being compared, when I noticed we have a more insidious problem: we use `time.Time` as keys in maps (a grep of `map[time.Time]` revealed 60 such occurrences). [According to the spec](https://golang.org/ref/spec#Comparison_operators) struct values are compared by all of their fields and not by an `Equal` method if one is defined, so all of such maps are likely to break in Go 1.9. 

One possible solution is that we can convert all maps with `time.Time` keys to instead use `int64` and then use the `Unix` or `UnixNano` functions to convert the times into seconds or nanoseconds from the Unix epoch respectively. Admittedly, this will take a non-trivial amount of refactoring, though we would perhaps be helped by defining a common `TimeMap` type which would do the conversions for us automatically.