### PR TITLE
Check checkpoint file writer error

### DIFF
--- a/persist/fs/commitlog/options.go
+++ b/persist/fs/commitlog/options.go
@@ -55,7 +55,7 @@ var (
 
 var (
 	errFlushIntervalNonNegative       = errors.New("flush interval must be non-negative")
-	errBlockSizePositive              = errors.New("block size must be a postive duration")
+	errBlockSizePositive              = errors.New("block size must be a positive duration")
 	errRetentionPeriodPositive        = errors.New("retention period must be a positive duration")
 	errRetentionGreaterEqualBlockSize = errors.New("retention period must be >= block size")
 )

--- a/persist/fs/write.go
+++ b/persist/fs/write.go
@@ -262,8 +262,11 @@ func (w *writer) writeCheckpointFile() error {
 	if err != nil {
 		return err
 	}
-	defer fd.Close()
-	return w.digestBuf.WriteDigestToFile(fd, w.digestFdWithDigestContents.Digest().Sum32())
+	if err := w.digestBuf.WriteDigestToFile(fd, w.digestFdWithDigestContents.Digest().Sum32()); err != nil {
+		fd.Close() // NB(prateek): skipping this error, failure to write takes precedence over failure to close the file
+		return err
+	}
+	return fd.Close()
 }
 
 func (w *writer) openWritable(filePath string) (*os.File, error) {

--- a/persist/fs/write.go
+++ b/persist/fs/write.go
@@ -262,8 +262,11 @@ func (w *writer) writeCheckpointFile() error {
 	if err != nil {
 		return err
 	}
-	if err := w.digestBuf.WriteDigestToFile(fd, w.digestFdWithDigestContents.Digest().Sum32()); err != nil {
-		fd.Close() // NB(prateek): skipping this error, failure to write takes precedence over failure to close the file
+	digestChecksum := w.digestFdWithDigestContents.Digest().Sum32()
+	if err := w.digestBuf.WriteDigestToFile(fd, digestChecksum); err != nil {
+		// NB(prateek): intentionally skipping fd.Close() error, as failure
+		// to write takes precedence over failure to close the file
+		fd.Close()
 		return err
 	}
 	return fd.Close()


### PR DESCRIPTION
- Catches an error we were dropping in the `persist/fs.Writer.Close()`

Making a test for this is more involved, opened #348 as a follow up. 

/cc @robskillington 