### PR TITLE
DTest updates for kv backed namespaces 

### DIFF
--- a/tools/dtest/config/config.go
+++ b/tools/dtest/config/config.go
@@ -103,6 +103,18 @@ func New(m3emConfigPath string) (*Configuration, error) {
 	return &conf, nil
 }
 
+// Zone returns the zone configured for kv, and the instances if they are all the same;
+// it returns an error if they're not.
+func (c *Configuration) Zone() (string, error) {
+	kvZone := c.KV.Zone
+	for _, inst := range c.DTest.Instances {
+		if kvZone != inst.Zone {
+			return "", fmt.Errorf("instance has zone %s which differs from kv zone %s", kvZone, inst.Zone)
+		}
+	}
+	return kvZone, nil
+}
+
 // Nodes returns a slice of m3emnode.Nodes per the config provided
 func (c *Configuration) Nodes(opts node.Options, numNodes int) ([]m3emnode.Node, error) {
 	// use all nodes if numNodes is zero

--- a/tools/dtest/config/opts.go
+++ b/tools/dtest/config/opts.go
@@ -40,7 +40,7 @@ func (a *Args) RegisterFlags(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
 	pf.StringVarP(&a.NodeBuildPath, "m3db-build", "b", "", "M3DB Binary")
 	pf.StringVarP(&a.NodeConfigPath, "m3db-config", "f", "", "M3DB Configuration File")
-	pf.StringVarP(&a.DTestConfigPath, "m3em-config", "c", "", "DTest Configuration File")
+	pf.StringVarP(&a.DTestConfigPath, "dtest-config", "d", "", "DTest Configuration File")
 	pf.BoolVarP(&a.SessionOverride, "session-override", "o", false, "Session Override")
 	pf.StringVarP(&a.SessionToken, "session-token", "t", "dtest", "Session Token")
 	pf.IntVarP(&a.NumNodes, "num-nodes", "n", 0, "Num Nodes to use in DTest")

--- a/tools/dtest/tests/add_down_node_bring_up.go
+++ b/tools/dtest/tests/add_down_node_bring_up.go
@@ -19,7 +19,7 @@ var (
 		(4) Add the one unused node to the cluster placement, and start it's process.
 		(5) Wait until all the shards in the cluster placement are marked as available.
 `,
-		Example: `./dtest add_down_node_bring_up --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest add_down_node_bring_up --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     addDownNodeAndBringUpDTest,
 	}
 )

--- a/tools/dtest/tests/add_up_node_remove.go
+++ b/tools/dtest/tests/add_up_node_remove.go
@@ -22,7 +22,7 @@ var (
 		(6) Wait until any shard on the node is marked as available.
 		(7) Remove the node from the cluster placement.
 `,
-		Example: `./dtest add_up_node_remove --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest add_up_node_remove --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     addUpNodeRemoveDTest,
 	}
 )
@@ -81,7 +81,7 @@ func addUpNodeRemoveDTest(cmd *cobra.Command, args []string) {
 
 	// wait until any shard is bootstrapped (i.e. marked available on new node)
 	logger.Infof("waiting till any shards are bootstrapped on new node")
-	timeout := dt.BootstrapTimeout() / 10
+	timeout := dt.BootstrapTimeout()
 	anyBootstrapped := xclock.WaitUntil(func() bool { return dt.AnyInstanceShardHasState(spare.ID(), shard.Available) }, timeout)
 	panicIf(!anyBootstrapped, "all shards not available")
 

--- a/tools/dtest/tests/dtest.go
+++ b/tools/dtest/tests/dtest.go
@@ -68,5 +68,11 @@ func panicIfErr(err error, msg string) {
 func newLogger(cmd *cobra.Command) xlog.Logger {
 	logger := xlog.NewLogger(os.Stdout)
 	logger.Infof("============== %v ==============", cmd.Name())
+	desc := cmd.Long
+	if desc == "" {
+		desc = cmd.Short
+	}
+	logger.Infof("Test description: %v", desc)
+	logger.Infof("============================")
 	return logger
 }

--- a/tools/dtest/tests/remove_down_node.go
+++ b/tools/dtest/tests/remove_down_node.go
@@ -18,7 +18,7 @@ var removeDownNodeTestCmd = &cobra.Command{
 	(5) The node from (4) is removed from the cluster placement.
 	(6) Wait until all shard in the cluster placement are marked as available.
 `,
-	Example: `./dtest remove_down_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+	Example: `./dtest remove_down_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 	Run:     removeDownNodeDTest,
 }
 

--- a/tools/dtest/tests/remove_up_node.go
+++ b/tools/dtest/tests/remove_up_node.go
@@ -17,7 +17,7 @@ var removeUpNodeTestCmd = &cobra.Command{
 	(4) Remove any one node from the cluster placement.
 	(5) Wait until all the shards in the placement are marked as available.
 `,
-	Example: `./dtest remove_up_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+	Example: `./dtest remove_up_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 	Run:     removeUpNodeDTest,
 }
 

--- a/tools/dtest/tests/replace_down_node.go
+++ b/tools/dtest/tests/replace_down_node.go
@@ -19,7 +19,7 @@ var (
 		(5) The node from (4) is replaced with the unused node, in the cluster placement.
 		(6) Wait until all the shards in the cluster placement are marked as available.
 `,
-		Example: `./dtest replace_down_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest replace_down_node --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     replaceDownNodeDTest,
 	}
 )

--- a/tools/dtest/tests/replace_up_node.go
+++ b/tools/dtest/tests/replace_up_node.go
@@ -19,7 +19,7 @@ var (
 		(5) The joining node's process is started.
 		(6) Wait until all shards in the cluster placement are available.
 `,
-		Example: `./dtest replace_up_node --m3db-build  path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest replace_up_node --m3db-build  path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     replaceUpNodeDTest,
 	}
 )

--- a/tools/dtest/tests/replace_up_node_remove.go
+++ b/tools/dtest/tests/replace_up_node_remove.go
@@ -22,7 +22,7 @@ var (
 		(6) Wait until any shard on the joining node is marked as available.
 		(7) Remove the joining node from the cluster placement.
 `,
-		Example: `./dtest replace_up_node_remove --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest replace_up_node_remove --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     replaceUpNodeRemoveDTest,
 	}
 )
@@ -81,7 +81,7 @@ func replaceUpNodeRemoveDTest(cmd *cobra.Command, args []string) {
 	// wait until any shard is bootstrapped (i.e. marked available on new node)
 	replacementNode := replacementNodes[0]
 	logger.Infof("waiting till any shards are bootstrapped on node: %v", replacementNode.ID())
-	timeout := dt.BootstrapTimeout() / 10
+	timeout := dt.BootstrapTimeout()
 	anyBootstrapped := xclock.WaitUntil(func() bool { return dt.AnyInstanceShardHasState(replacementNode.ID(), shard.Available) }, timeout)
 	panicIf(!anyBootstrapped, "all shards not available")
 

--- a/tools/dtest/tests/replace_up_node_remove_unseeded.go
+++ b/tools/dtest/tests/replace_up_node_remove_unseeded.go
@@ -21,7 +21,7 @@ var (
 		(5) Wait until any shard on the joining node is marked as available.
 		(6) Remove the joining node from the cluster placement.
 `,
-		Example: `./dtest replace_up_node_remove_unseeded --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+		Example: `./dtest replace_up_node_remove_unseeded --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 		Run:     replaceUpNodeRemoveUnseededDTest,
 	}
 )
@@ -76,7 +76,7 @@ func replaceUpNodeRemoveUnseededDTest(cmd *cobra.Command, args []string) {
 	// wait until any shard is bootstrapped (i.e. marked available on new node)
 	replacementNode := replacementNodes[0]
 	logger.Infof("waiting till any shards are bootstrapped on node: %v", replacementNode.ID())
-	timeout := dt.BootstrapTimeout() / 10
+	timeout := dt.BootstrapTimeout()
 	anyBootstrapped := xclock.WaitUntil(func() bool { return dt.AnyInstanceShardHasState(replacementNode.ID(), shard.Available) }, timeout)
 	panicIf(!anyBootstrapped, "all shards not available")
 

--- a/tools/dtest/tests/seeded_bootstrap.go
+++ b/tools/dtest/tests/seeded_bootstrap.go
@@ -15,7 +15,7 @@ var seededBootstrapTestCmd = &cobra.Command{
 	(2) Seed the nodes used in (1), with initial data on their respective file-systems.
 	(3) Start the nodes from (1), and wait until they are bootstrapped.
 `,
-	Example: `./dtest seeded_bootstrap --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+	Example: `./dtest seeded_bootstrap --m3db-build path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 	Run:     seededBootstrapDTest,
 }
 

--- a/tools/dtest/tests/simple_bootstrap.go
+++ b/tools/dtest/tests/simple_bootstrap.go
@@ -14,7 +14,7 @@ var simpleBootstrapTestCmd = &cobra.Command{
 	(1) Create a new cluster placement using all of the provided nodes.
 	(2) The nodes from (1) are started, and wait until they are bootstrapped.
 `,
-	Example: `./dtest simple --m3db-build  path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --m3em-config path/to/dtest.yaml`,
+	Example: `./dtest simple --m3db-build  path/to/m3dbnode --m3db-config path/to/m3dbnode.yaml --dtest-config path/to/dtest.yaml`,
 	Run:     simpleBootstrapDTest,
 }
 


### PR DESCRIPTION
This PR fixes existing dtests for namespace isolation changes. Opened #355 to add dtests for new code-paths. 

/cc @robskillington 