### PR TITLE
Update to dev branch of tchannel-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c208328e9cc17f460245c18c97f53d1b0349c3ac81543f1a45fe295382054d48
-updated: 2017-09-05T16:21:12.400276859-04:00
+hash: 1250a11856eea1d80a64b0cc96cafcc7d4dde19dfdb1f56d263219614a0f5540
+updated: 2017-10-02T14:04:49.164947784-04:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -199,7 +199,7 @@ imports:
 - name: github.com/pborman/getopt
   version: ec82d864f599c39673eef89f91b93fa5576567a1
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -247,14 +247,14 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 2605c407d7d219644d03a3680ad7df4779017782
+  version: 95078a8f10668bd1fa73ae46761cdc58d25436b8
   subpackages:
   - m3
   - m3/customtransports
   - m3/thrift
   - m3/thriftudp
 - name: github.com/uber/tchannel-go
-  version: 5d979b31a7405a676919fca637bb2f715fb9ed65
+  version: 1fcf82ec86967eb43ba0baa9b964f8eb226d242e
   subpackages:
   - internal/argreader
   - relay

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,7 +32,7 @@ import:
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 
 - package: github.com/uber/tchannel-go
-  version: 5d979b31a7405a676919fca637bb2f715fb9ed65
+  version: 1fcf82ec86967eb43ba0baa9b964f8eb226d242e
   subpackages:
   - thrift
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,6 +32,7 @@ import:
   version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 
 - package: github.com/uber/tchannel-go
+  # Must be this hash or higher to include TChannel connection health checks
   version: 1fcf82ec86967eb43ba0baa9b964f8eb226d242e
   subpackages:
   - thrift

--- a/persist/fs/write.go
+++ b/persist/fs/write.go
@@ -227,16 +227,12 @@ func (w *writer) close() error {
 		return err
 	}
 
-	if err := closeAll(
+	return closeAll(
 		w.infoFdWithDigest,
 		w.indexFdWithDigest,
 		w.dataFdWithDigest,
 		w.digestFdWithDigestContents,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 func (w *writer) Close() error {


### PR DESCRIPTION
I looked through the commits on the dev branch since the last hash we pinned. A lot of stuff looked like tweaks / bug fixes, but a few things stood out:

1. "Don't close connections on errors": https://github.com/uber/tchannel-go/commit/b9dc4c162aad44e2f01508cf0c6e81032675b4cf
2. "Close connections if the RelayHost returns a ProtocolError": https://github.com/uber/tchannel-go/commit/fef3a3f5eb009e12c7d4446979a425aa2435a760
3. "Set DiffServ (QoS) bit on Outbound connections": https://github.com/uber/tchannel-go/commit/6b8d075c6f47e574ee33513fe1375648fd9a0651