### PR TITLE
Fix race condition in Terminate which fixes flaky integration test MixedModeReadWrite

### DIFF
--- a/storage/bootstrap.go
+++ b/storage/bootstrap.go
@@ -204,7 +204,10 @@ func (m *bootstrapManager) bootstrap() error {
 	// efficient way of bootstrapping database shards, be it sequential or parallel.
 	multiErr := xerrors.NewMultiError()
 
-	namespaces := m.database.GetOwnedNamespaces()
+	namespaces, err := m.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
 	for _, namespace := range namespaces {
 		rOpts := namespace.Options().RetentionOptions()
 		targetRanges := m.targetRanges(bootstrapStart, rOpts)

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -52,7 +52,7 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 	namespaces := []databaseNamespace{ns}
 
 	db := NewMockdatabase(ctrl)
-	db.EXPECT().GetOwnedNamespaces().Return(namespaces)
+	db.EXPECT().GetOwnedNamespaces().Return(namespaces, nil)
 
 	m := NewMockdatabaseMediator(ctrl)
 	m.EXPECT().DisableFileOps()

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -89,7 +89,9 @@ func (m *cleanupManager) Cleanup(t time.Time) error {
 			"encountered errors when cleaning up fileset files for %v: %v", t, err))
 	}
 
-	commitLogStart, commitLogTimes := m.commitLogTimes(t)
+	commitLogStart, commitLogTimes, err := m.commitLogTimes(t)
+	multiErr = multiErr.Add(fmt.Errorf(
+		"encountered errors when cleaning up commit logs: %v", err))
 	if err := m.cleanupCommitLogs(commitLogStart, commitLogTimes); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
 			"encountered errors when cleaning up commit logs for commitLogStart %v commitLogTimes %v: %v",
@@ -112,10 +114,11 @@ func (m *cleanupManager) Report() {
 }
 
 func (m *cleanupManager) cleanupFilesetFiles(t time.Time) error {
-	var (
-		multiErr   = xerrors.NewMultiError()
-		namespaces = m.database.GetOwnedNamespaces()
-	)
+	multiErr := xerrors.NewMultiError()
+	namespaces, err := m.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
 	for _, n := range namespaces {
 		earliestToRetain := retention.FlushTimeStart(n.Options().RetentionOptions(), t)
 		multiErr = multiErr.Add(n.CleanupFileset(earliestToRetain))
@@ -140,7 +143,7 @@ func (m *cleanupManager) commitLogTimeRange(t time.Time) (time.Time, time.Time) 
 
 // commitLogTimes returns the earliest time before which the commit logs are expired,
 // as well as a list of times we need to clean up commit log files for.
-func (m *cleanupManager) commitLogTimes(t time.Time) (time.Time, []time.Time) {
+func (m *cleanupManager) commitLogTimes(t time.Time) (time.Time, []time.Time, error) {
 	var (
 		blockSize        = m.opts.CommitLogOptions().BlockSize()
 		earliest, latest = m.commitLogTimeRange(t)
@@ -156,7 +159,10 @@ func (m *cleanupManager) commitLogTimes(t time.Time) (time.Time, []time.Time) {
 	// data loss.
 
 	candidateTimes := timesInRange(earliest, latest, blockSize)
-	namespaces := m.database.GetOwnedNamespaces()
+	namespaces, err := m.database.GetOwnedNamespaces()
+	if err != nil {
+		return time.Time{}, nil, err
+	}
 	cleanupTimes := filterTimes(candidateTimes, func(t time.Time) bool {
 		for _, ns := range namespaces {
 			ropts := ns.Options().RetentionOptions()
@@ -168,7 +174,7 @@ func (m *cleanupManager) commitLogTimes(t time.Time) (time.Time, []time.Time) {
 		return true
 	})
 
-	return earliest, cleanupTimes
+	return earliest, cleanupTimes, nil
 }
 
 // commitLogNamespaceBlockTimes returns the range of namespace block starts which for which the

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -93,6 +93,7 @@ func (m *cleanupManager) Cleanup(t time.Time) error {
 	if err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
 			"encountered errors when cleaning up commit logs: %v", err))
+		return multiErr.FinalError()
 	}
 
 	if err := m.cleanupCommitLogs(commitLogStart, commitLogTimes); err != nil {

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -90,8 +90,11 @@ func (m *cleanupManager) Cleanup(t time.Time) error {
 	}
 
 	commitLogStart, commitLogTimes, err := m.commitLogTimes(t)
-	multiErr = multiErr.Add(fmt.Errorf(
-		"encountered errors when cleaning up commit logs: %v", err))
+	if err != nil {
+		multiErr = multiErr.Add(fmt.Errorf(
+			"encountered errors when cleaning up commit logs: %v", err))
+	}
+
 	if err := m.cleanupCommitLogs(commitLogStart, commitLogTimes); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
 			"encountered errors when cleaning up commit logs for commitLogStart %v commitLogTimes %v: %v",

--- a/storage/cleanup_test.go
+++ b/storage/cleanup_test.go
@@ -309,7 +309,8 @@ func TestCleanupManagerCommitLogTimesAllFlushed(t *testing.T) {
 		ns.EXPECT().NeedsFlush(timeFor(10), timeFor(20)).Return(false),
 	)
 
-	earliest, times := mgr.commitLogTimes(currentTime)
+	earliest, times, err := mgr.commitLogTimes(currentTime)
+	require.NoError(t, err)
 	require.Equal(t, timeFor(10), earliest)
 	require.Equal(t, 3, len(times))
 	require.True(t, contains(times, timeFor(10)))
@@ -330,7 +331,8 @@ func TestCleanupManagerCommitLogTimesMiddlePendingFlush(t *testing.T) {
 		ns.EXPECT().NeedsFlush(timeFor(10), timeFor(20)).Return(false),
 	)
 
-	earliest, times := mgr.commitLogTimes(currentTime)
+	earliest, times, err := mgr.commitLogTimes(currentTime)
+	require.NoError(t, err)
 	require.Equal(t, timeFor(10), earliest)
 	require.Equal(t, 2, len(times))
 	require.True(t, contains(times, timeFor(10)))
@@ -350,7 +352,8 @@ func TestCleanupManagerCommitLogTimesStartPendingFlush(t *testing.T) {
 		ns.EXPECT().NeedsFlush(timeFor(10), timeFor(20)).Return(false),
 	)
 
-	earliest, times := mgr.commitLogTimes(currentTime)
+	earliest, times, err := mgr.commitLogTimes(currentTime)
+	require.NoError(t, err)
 	require.Equal(t, timeFor(10), earliest)
 	require.Equal(t, 2, len(times))
 	require.True(t, contains(times, timeFor(20)))
@@ -370,7 +373,8 @@ func TestCleanupManagerCommitLogTimesAllPendingFlush(t *testing.T) {
 		ns.EXPECT().NeedsFlush(timeFor(10), timeFor(20)).Return(true),
 	)
 
-	earliest, times := mgr.commitLogTimes(currentTime)
+	earliest, times, err := mgr.commitLogTimes(currentTime)
+	require.NoError(t, err)
 	require.Equal(t, timeFor(10), earliest)
 	require.Equal(t, 0, len(times))
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -168,12 +168,14 @@ func NewDatabase(
 		return nil, err
 	}
 
-	// wait till first value is received
+	// Wait till first namespaces value is received and set the value.
+	// Its important that this happens before the mediator is started to prevent
+	// a race condition where the namespaces haven't been initialized yet and
+	// GetOwnedNamespaces() returns an empty slice which makes the cleanup logic
+	// in the background Tick think it can clean up files that it shouldn't.
 	logger.Info("resolving namespaces with namespace watch")
 	<-watch.C()
 	d.nsWatch = newDatabaseNamespaceWatch(d, watch, databaseIOpts)
-
-	// update with initial values
 	nsMap := watch.Get()
 	if err := d.UpdateOwnedNamespaces(nsMap); err != nil {
 		return nil, err

--- a/storage/database.go
+++ b/storage/database.go
@@ -149,11 +149,6 @@ func NewDatabase(
 	}
 
 	databaseIOpts := iopts.SetMetricsScope(scope)
-	mediator, err := newMediator(d, opts.SetInstrumentOptions(databaseIOpts))
-	if err != nil {
-		return nil, err
-	}
-	d.mediator = mediator
 
 	// initialize namespaces
 	nsInit := opts.NamespaceInitializer()
@@ -180,6 +175,12 @@ func NewDatabase(
 	if err := d.UpdateOwnedNamespaces(nsMap); err != nil {
 		return nil, err
 	}
+
+	mediator, err := newMediator(d, opts.SetInstrumentOptions(databaseIOpts))
+	if err != nil {
+		return nil, err
+	}
+	d.mediator = mediator
 
 	return d, nil
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -393,13 +393,13 @@ func (d *db) terminateWithLock() error {
 	}
 	d.state = databaseClosed
 
-	// stop listening for namespace changes
-	if err := d.nsWatch.Close(); err != nil {
+	// close the mediator
+	if err := d.mediator.Close(); err != nil {
 		return err
 	}
 
-	// close the mediator
-	if err := d.mediator.Close(); err != nil {
+	// stop listening for namespace changes
+	if err := d.nsWatch.Close(); err != nil {
 		return err
 	}
 

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -140,7 +140,7 @@ func newMockdatabase(ctrl *gomock.Controller, ns ...databaseNamespace) *Mockdata
 	db := NewMockdatabase(ctrl)
 	db.EXPECT().Options().Return(testDatabaseOptions()).AnyTimes()
 	if len(ns) != 0 {
-		db.EXPECT().GetOwnedNamespaces().Return(ns).AnyTimes()
+		db.EXPECT().GetOwnedNamespaces().Return(ns, nil).AnyTimes()
 	}
 	return db
 }

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -410,9 +410,6 @@ func TestGetOwnedNamespacesErrorIfClosed(t *testing.T) {
 		close(mapCh)
 	}()
 
-	dbAddNewMockNamespace(ctrl, d, "testns1")
-	dbAddNewMockNamespace(ctrl, d, "testns2")
-
 	require.NoError(t, d.Open())
 	require.NoError(t, d.Terminate())
 

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -401,6 +401,25 @@ func TestDatabaseNamespaces(t *testing.T) {
 	assert.Equal(t, "testns2", result[1].ID().String())
 }
 
+func TestGetOwnedNamespacesErrorIfClosed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d, mapCh := newTestDatabase(t, ctrl, bootstrapped)
+	defer func() {
+		close(mapCh)
+	}()
+
+	dbAddNewMockNamespace(ctrl, d, "testns1")
+	dbAddNewMockNamespace(ctrl, d, "testns2")
+
+	require.NoError(t, d.Open())
+	require.NoError(t, d.Terminate())
+
+	_, err := d.GetOwnedNamespaces()
+	require.Equal(t, errDatabaseIsClosed, err)
+}
+
 func TestDatabaseAssignShardSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/storage/flush.go
+++ b/storage/flush.go
@@ -82,11 +82,12 @@ func (m *flushManager) Flush(curr time.Time) error {
 		m.Unlock()
 	}()
 
-	multiErr := xerrors.NewMultiError()
 	namespaces, err := m.database.GetOwnedNamespaces()
 	if err != nil {
 		return err
 	}
+
+	multiErr := xerrors.NewMultiError()
 	for _, ns := range namespaces {
 		flushTimes := m.namespaceFlushTimes(ns, curr)
 		multiErr = multiErr.Add(m.flushNamespaceWithTimes(ns, flushTimes, flush))

--- a/storage/flush.go
+++ b/storage/flush.go
@@ -82,10 +82,11 @@ func (m *flushManager) Flush(curr time.Time) error {
 		m.Unlock()
 	}()
 
-	var (
-		multiErr   = xerrors.NewMultiError()
-		namespaces = m.database.GetOwnedNamespaces()
-	)
+	multiErr := xerrors.NewMultiError()
+	namespaces, err := m.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
 	for _, ns := range namespaces {
 		flushTimes := m.namespaceFlushTimes(ns, curr)
 		multiErr = multiErr.Add(m.flushNamespaceWithTimes(ns, flushTimes, flush))

--- a/storage/flush_test.go
+++ b/storage/flush_test.go
@@ -79,7 +79,7 @@ func TestFlushManagerFlushAlreadyInProgress(t *testing.T) {
 	testOpts := testDatabaseOptions().SetPersistManager(mockPersistManager)
 	db := newMockdatabase(ctrl)
 	db.EXPECT().Options().Return(testOpts).AnyTimes()
-	db.EXPECT().GetOwnedNamespaces().Return(nil).AnyTimes()
+	db.EXPECT().GetOwnedNamespaces().Return(nil, nil).AnyTimes()
 
 	fm := newFlushManager(db, tally.NoopScope).(*flushManager)
 	fm.pm = mockPersistManager
@@ -118,7 +118,7 @@ func TestFlushManagerFlushDoneError(t *testing.T) {
 	testOpts := testDatabaseOptions().SetPersistManager(mockPersistManager)
 	db := newMockdatabase(ctrl)
 	db.EXPECT().Options().Return(testOpts).AnyTimes()
-	db.EXPECT().GetOwnedNamespaces().Return(nil).AnyTimes()
+	db.EXPECT().GetOwnedNamespaces().Return(nil, nil).AnyTimes()
 
 	fm := newFlushManager(db, tally.NoopScope).(*flushManager)
 	fm.pm = mockPersistManager

--- a/storage/mediator.go
+++ b/storage/mediator.go
@@ -162,7 +162,6 @@ func (m *mediator) Close() error {
 	m.state = mediatorClosed
 	close(m.closedCh)
 	m.databaseRepairer.Stop()
-
 	return nil
 }
 

--- a/storage/mediator_test.go
+++ b/storage/mediator_test.go
@@ -42,7 +42,7 @@ func TestDatabaseMediatorOpenClose(t *testing.T) {
 
 	db := NewMockdatabase(ctrl)
 	db.EXPECT().Options().Return(opts).AnyTimes()
-	db.EXPECT().GetOwnedNamespaces().Return(nil).AnyTimes()
+	db.EXPECT().GetOwnedNamespaces().Return(nil, nil).AnyTimes()
 	m, err := newMediator(db, opts)
 	require.NoError(t, err)
 

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -368,7 +368,10 @@ func (r *dbRepairer) Repair() error {
 	}()
 
 	multiErr := xerrors.NewMultiError()
-	namespaces := r.database.GetOwnedNamespaces()
+	namespaces, err := r.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
 	for _, n := range namespaces {
 		iter := r.namespaceRepairTimeRanges(n).Iter()
 		for iter.Next() {

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -24,8 +24,6 @@
 package storage
 
 import (
-	time0 "time"
-
 	gomock "github.com/golang/mock/gomock"
 	clock "github.com/m3db/m3db/clock"
 	context "github.com/m3db/m3db/context"
@@ -46,6 +44,7 @@ import (
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
 	time "github.com/m3db/m3x/time"
+	time0 "time"
 )
 
 // Mock of Database interface
@@ -418,10 +417,11 @@ func (_mr *_MockdatabaseRecorder) Truncate(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate", arg0)
 }
 
-func (_m *Mockdatabase) GetOwnedNamespaces() []databaseNamespace {
+func (_m *Mockdatabase) GetOwnedNamespaces() ([]databaseNamespace, error) {
 	ret := _m.ctrl.Call(_m, "GetOwnedNamespaces")
 	ret0, _ := ret[0].([]databaseNamespace)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockdatabaseRecorder) GetOwnedNamespaces() *gomock.Call {
@@ -650,8 +650,8 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(start time0.Time, end time0.Time) bool {
-	ret := _m.ctrl.Call(_m, "NeedsFlush", start, end)
+func (_m *MockdatabaseNamespace) NeedsFlush(alignedInclusiveStart time0.Time, alignedInclusiveEnd time0.Time) bool {
+	ret := _m.ctrl.Call(_m, "NeedsFlush", alignedInclusiveStart, alignedInclusiveEnd)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
@@ -975,16 +975,6 @@ func NewMockdatabaseFlushManager(ctrl *gomock.Controller) *MockdatabaseFlushMana
 
 func (_m *MockdatabaseFlushManager) EXPECT() *_MockdatabaseFlushManagerRecorder {
 	return _m.recorder
-}
-
-func (_m *MockdatabaseFlushManager) NeedsFlush(startInclusive time0.Time, endInclusive time0.Time) bool {
-	ret := _m.ctrl.Call(_m, "NeedsFlush", startInclusive, endInclusive)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockdatabaseFlushManagerRecorder) NeedsFlush(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0, arg1)
 }
 
 func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {

--- a/storage/tick.go
+++ b/storage/tick.go
@@ -115,7 +115,10 @@ func (mgr *tickManager) Tick(softDeadline time.Duration, forceType forceType) er
 
 	// Now we acquired the token, reset the cancellable
 	mgr.c.Reset()
-	namespaces := mgr.database.GetOwnedNamespaces()
+	namespaces, err := mgr.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
 	if len(namespaces) == 0 {
 		return errEmptyNamespaces
 	}

--- a/storage/types.go
+++ b/storage/types.go
@@ -133,7 +133,7 @@ type database interface {
 	Database
 
 	// GetOwnedNamespaces returns the namespaces this database owns.
-	GetOwnedNamespaces() []databaseNamespace
+	GetOwnedNamespaces() ([]databaseNamespace, error)
 
 	// UpdateOwnedNamespaces updates the namespaces this database owns.
 	UpdateOwnedNamespaces(namespaces namespace.Map) error


### PR DESCRIPTION
The test was flaky because after the Database had shutdown, background goroutines would continue running (sometime between the call to Terminate() completing and the actual process exiting) and when they called GetOwnedNamespaces() they would receive an empty list.

The empty list is bad, because when the list of namespaces is empty, the logic in [this function](https://github.com/m3db/m3db/blob/master/storage/cleanup.go#L143) allows M3DB to delete all commitlog files which triggers data loss / test failure.