### PR TITLE
[WIP] softread

### DIFF
--- a/generated/thrift/rpc.thrift
+++ b/generated/thrift/rpc.thrift
@@ -73,6 +73,7 @@ struct FetchRequest {
 	4: required string id
 	5: optional TimeType rangeType = TimeType.UNIX_SECONDS
 	6: optional TimeType resultTimeType = TimeType.UNIX_SECONDS
+	7: optional bool softRead
 }
 
 struct FetchResult {

--- a/generated/thrift/rpc.thrift
+++ b/generated/thrift/rpc.thrift
@@ -98,6 +98,7 @@ struct FetchBatchRawRequest {
 	3: required binary nameSpace
 	4: required list<binary> ids
 	5: optional TimeType rangeTimeType = TimeType.UNIX_SECONDS
+	6: optional bool softRead
 }
 
 struct FetchBatchRawResult {

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -1284,12 +1284,14 @@ func (p *WriteRequest) String() string {
 //  - NameSpace
 //  - Ids
 //  - RangeTimeType
+//  - SoftRead
 type FetchBatchRawRequest struct {
 	RangeStart    int64    `thrift:"rangeStart,1,required" db:"rangeStart" json:"rangeStart"`
 	RangeEnd      int64    `thrift:"rangeEnd,2,required" db:"rangeEnd" json:"rangeEnd"`
 	NameSpace     []byte   `thrift:"nameSpace,3,required" db:"nameSpace" json:"nameSpace"`
 	Ids           [][]byte `thrift:"ids,4,required" db:"ids" json:"ids"`
 	RangeTimeType TimeType `thrift:"rangeTimeType,5" db:"rangeTimeType" json:"rangeTimeType,omitempty"`
+	SoftRead      *bool    `thrift:"softRead,6" db:"softRead" json:"softRead,omitempty"`
 }
 
 func NewFetchBatchRawRequest() *FetchBatchRawRequest {
@@ -1319,8 +1321,21 @@ var FetchBatchRawRequest_RangeTimeType_DEFAULT TimeType = 0
 func (p *FetchBatchRawRequest) GetRangeTimeType() TimeType {
 	return p.RangeTimeType
 }
+
+var FetchBatchRawRequest_SoftRead_DEFAULT bool
+
+func (p *FetchBatchRawRequest) GetSoftRead() bool {
+	if !p.IsSetSoftRead() {
+		return FetchBatchRawRequest_SoftRead_DEFAULT
+	}
+	return *p.SoftRead
+}
 func (p *FetchBatchRawRequest) IsSetRangeTimeType() bool {
 	return p.RangeTimeType != FetchBatchRawRequest_RangeTimeType_DEFAULT
+}
+
+func (p *FetchBatchRawRequest) IsSetSoftRead() bool {
+	return p.SoftRead != nil
 }
 
 func (p *FetchBatchRawRequest) Read(iprot thrift.TProtocol) error {
@@ -1364,6 +1379,10 @@ func (p *FetchBatchRawRequest) Read(iprot thrift.TProtocol) error {
 			issetIds = true
 		case 5:
 			if err := p.ReadField5(iprot); err != nil {
+				return err
+			}
+		case 6:
+			if err := p.ReadField6(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1452,6 +1471,15 @@ func (p *FetchBatchRawRequest) ReadField5(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *FetchBatchRawRequest) ReadField6(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 6: ", err)
+	} else {
+		p.SoftRead = &v
+	}
+	return nil
+}
+
 func (p *FetchBatchRawRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("FetchBatchRawRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1470,6 +1498,9 @@ func (p *FetchBatchRawRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField5(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField6(oprot); err != nil {
 			return err
 		}
 	}
@@ -1552,6 +1583,21 @@ func (p *FetchBatchRawRequest) writeField5(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:rangeTimeType: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *FetchBatchRawRequest) writeField6(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSoftRead() {
+		if err := oprot.WriteFieldBegin("softRead", thrift.BOOL, 6); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:softRead: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.SoftRead)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.softRead (6) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:softRead: ", p), err)
 		}
 	}
 	return err

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -437,6 +437,7 @@ func (p *WriteBatchRawErrors) Error() string {
 //  - ID
 //  - RangeType
 //  - ResultTimeType
+//  - SoftRead
 type FetchRequest struct {
 	RangeStart     int64    `thrift:"rangeStart,1,required" db:"rangeStart" json:"rangeStart"`
 	RangeEnd       int64    `thrift:"rangeEnd,2,required" db:"rangeEnd" json:"rangeEnd"`
@@ -444,6 +445,7 @@ type FetchRequest struct {
 	ID             string   `thrift:"id,4,required" db:"id" json:"id"`
 	RangeType      TimeType `thrift:"rangeType,5" db:"rangeType" json:"rangeType,omitempty"`
 	ResultTimeType TimeType `thrift:"resultTimeType,6" db:"resultTimeType" json:"resultTimeType,omitempty"`
+	SoftRead       *bool    `thrift:"softRead,7" db:"softRead" json:"softRead,omitempty"`
 }
 
 func NewFetchRequest() *FetchRequest {
@@ -481,12 +483,25 @@ var FetchRequest_ResultTimeType_DEFAULT TimeType = 0
 func (p *FetchRequest) GetResultTimeType() TimeType {
 	return p.ResultTimeType
 }
+
+var FetchRequest_SoftRead_DEFAULT bool
+
+func (p *FetchRequest) GetSoftRead() bool {
+	if !p.IsSetSoftRead() {
+		return FetchRequest_SoftRead_DEFAULT
+	}
+	return *p.SoftRead
+}
 func (p *FetchRequest) IsSetRangeType() bool {
 	return p.RangeType != FetchRequest_RangeType_DEFAULT
 }
 
 func (p *FetchRequest) IsSetResultTimeType() bool {
 	return p.ResultTimeType != FetchRequest_ResultTimeType_DEFAULT
+}
+
+func (p *FetchRequest) IsSetSoftRead() bool {
+	return p.SoftRead != nil
 }
 
 func (p *FetchRequest) Read(iprot thrift.TProtocol) error {
@@ -534,6 +549,10 @@ func (p *FetchRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 6:
 			if err := p.ReadField6(iprot); err != nil {
+				return err
+			}
+		case 7:
+			if err := p.ReadField7(iprot); err != nil {
 				return err
 			}
 		default:
@@ -619,6 +638,15 @@ func (p *FetchRequest) ReadField6(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *FetchRequest) ReadField7(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 7: ", err)
+	} else {
+		p.SoftRead = &v
+	}
+	return nil
+}
+
 func (p *FetchRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("FetchRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -640,6 +668,9 @@ func (p *FetchRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField6(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField7(oprot); err != nil {
 			return err
 		}
 	}
@@ -729,6 +760,21 @@ func (p *FetchRequest) writeField6(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:resultTimeType: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *FetchRequest) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSoftRead() {
+		if err := oprot.WriteFieldBegin("softRead", thrift.BOOL, 7); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 7:softRead: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.SoftRead)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.softRead (7) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 7:softRead: ", p), err)
 		}
 	}
 	return err

--- a/generated/thrift/rpc/tchan-rpc.go
+++ b/generated/thrift/rpc/tchan-rpc.go
@@ -87,8 +87,11 @@ func (c *tchanClusterClient) Fetch(ctx thrift.Context, req *FetchRequest) (*Fetc
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetch", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetch")
 		}
 	}
 
@@ -100,8 +103,11 @@ func (c *tchanClusterClient) Health(ctx thrift.Context) (*HealthResult_, error) 
 	args := ClusterHealthArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "health", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for health")
 		}
 	}
 
@@ -115,8 +121,11 @@ func (c *tchanClusterClient) Truncate(ctx thrift.Context, req *TruncateRequest) 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "truncate", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for truncate")
 		}
 	}
 
@@ -130,8 +139,11 @@ func (c *tchanClusterClient) Write(ctx thrift.Context, req *WriteRequest) error 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "write", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for write")
 		}
 	}
 
@@ -314,8 +326,11 @@ func (c *tchanNodeClient) Fetch(ctx thrift.Context, req *FetchRequest) (*FetchRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetch", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetch")
 		}
 	}
 
@@ -329,8 +344,11 @@ func (c *tchanNodeClient) FetchBatchRaw(ctx thrift.Context, req *FetchBatchRawRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBatchRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBatchRaw")
 		}
 	}
 
@@ -344,8 +362,11 @@ func (c *tchanNodeClient) FetchBlocksMetadataRaw(ctx thrift.Context, req *FetchB
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBlocksMetadataRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBlocksMetadataRaw")
 		}
 	}
 
@@ -359,8 +380,11 @@ func (c *tchanNodeClient) FetchBlocksRaw(ctx thrift.Context, req *FetchBlocksRaw
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "fetchBlocksRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for fetchBlocksRaw")
 		}
 	}
 
@@ -372,8 +396,11 @@ func (c *tchanNodeClient) GetPersistRateLimit(ctx thrift.Context) (*NodePersistR
 	args := NodeGetPersistRateLimitArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "getPersistRateLimit", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for getPersistRateLimit")
 		}
 	}
 
@@ -385,8 +412,11 @@ func (c *tchanNodeClient) GetWriteNewSeriesAsync(ctx thrift.Context) (*NodeWrite
 	args := NodeGetWriteNewSeriesAsyncArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "getWriteNewSeriesAsync", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for getWriteNewSeriesAsync")
 		}
 	}
 
@@ -398,8 +428,11 @@ func (c *tchanNodeClient) GetWriteNewSeriesBackoffDuration(ctx thrift.Context) (
 	args := NodeGetWriteNewSeriesBackoffDurationArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "getWriteNewSeriesBackoffDuration", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for getWriteNewSeriesBackoffDuration")
 		}
 	}
 
@@ -411,8 +444,11 @@ func (c *tchanNodeClient) GetWriteNewSeriesLimitPerShardPerSecond(ctx thrift.Con
 	args := NodeGetWriteNewSeriesLimitPerShardPerSecondArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "getWriteNewSeriesLimitPerShardPerSecond", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for getWriteNewSeriesLimitPerShardPerSecond")
 		}
 	}
 
@@ -424,8 +460,11 @@ func (c *tchanNodeClient) Health(ctx thrift.Context) (*NodeHealthResult_, error)
 	args := NodeHealthArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "health", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for health")
 		}
 	}
 
@@ -437,8 +476,11 @@ func (c *tchanNodeClient) Repair(ctx thrift.Context) error {
 	args := NodeRepairArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "repair", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for repair")
 		}
 	}
 
@@ -452,8 +494,11 @@ func (c *tchanNodeClient) SetPersistRateLimit(ctx thrift.Context, req *NodeSetPe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "setPersistRateLimit", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for setPersistRateLimit")
 		}
 	}
 
@@ -467,8 +512,11 @@ func (c *tchanNodeClient) SetWriteNewSeriesAsync(ctx thrift.Context, req *NodeSe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "setWriteNewSeriesAsync", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for setWriteNewSeriesAsync")
 		}
 	}
 
@@ -482,8 +530,11 @@ func (c *tchanNodeClient) SetWriteNewSeriesBackoffDuration(ctx thrift.Context, r
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "setWriteNewSeriesBackoffDuration", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for setWriteNewSeriesBackoffDuration")
 		}
 	}
 
@@ -497,8 +548,11 @@ func (c *tchanNodeClient) SetWriteNewSeriesLimitPerShardPerSecond(ctx thrift.Con
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "setWriteNewSeriesLimitPerShardPerSecond", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for setWriteNewSeriesLimitPerShardPerSecond")
 		}
 	}
 
@@ -512,8 +566,11 @@ func (c *tchanNodeClient) Truncate(ctx thrift.Context, req *TruncateRequest) (*T
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "truncate", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for truncate")
 		}
 	}
 
@@ -527,8 +584,11 @@ func (c *tchanNodeClient) Write(ctx thrift.Context, req *WriteRequest) error {
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "write", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for write")
 		}
 	}
 
@@ -542,8 +602,11 @@ func (c *tchanNodeClient) WriteBatchRaw(ctx thrift.Context, req *WriteBatchRawRe
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "writeBatchRaw", &args, &resp)
 	if err == nil && !success {
-		if e := resp.Err; e != nil {
-			err = e
+		switch {
+		case resp.Err != nil:
+			err = resp.Err
+		default:
+			err = fmt.Errorf("received no result or unknown exception for writeBatchRaw")
 		}
 	}
 

--- a/network/server/tchannelthrift/node/service_test.go
+++ b/network/server/tchannelthrift/node/service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3db/storage"
 	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/ts"
 	xio "github.com/m3db/m3db/x/io"
 	xtime "github.com/m3db/m3x/time"
@@ -116,8 +117,11 @@ func TestServiceFetch(t *testing.T) {
 		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 	}
 
+	readOpts := read.ReadOptions{
+		SoftRead: true,
+	}
 	mockDB.EXPECT().
-		ReadEncoded(ctx, ts.NewIDMatcher(nsID), ts.NewIDMatcher("foo"), start, end).
+		ReadEncoded(ctx, ts.NewIDMatcher(nsID), ts.NewIDMatcher("foo"), start, end, readOpts).
 		Return([][]xio.SegmentReader{
 			[]xio.SegmentReader{enc.Stream()},
 		}, nil)
@@ -186,8 +190,11 @@ func TestServiceFetchBatchRaw(t *testing.T) {
 
 		streams[id] = enc.Stream()
 
+		readOpts := read.ReadOptions{
+			SoftRead: false,
+		}
 		mockDB.EXPECT().
-			ReadEncoded(ctx, ts.NewIDMatcher(nsID), ts.NewIDMatcher(id), start, end).
+			ReadEncoded(ctx, ts.NewIDMatcher(nsID), ts.NewIDMatcher(id), start, end, readOpts).
 			Return([][]xio.SegmentReader{
 				[]xio.SegmentReader{enc.Stream()},
 			}, nil)

--- a/network/server/tchannelthrift/node/service_test.go
+++ b/network/server/tchannelthrift/node/service_test.go
@@ -117,8 +117,8 @@ func TestServiceFetch(t *testing.T) {
 		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 	}
 
-	readOpts := read.ReadOptions{
-		SoftRead: true,
+	readOpts := read.Options{
+		SoftRead: false,
 	}
 	mockDB.EXPECT().
 		ReadEncoded(ctx, ts.NewIDMatcher(nsID), ts.NewIDMatcher("foo"), start, end, readOpts).
@@ -190,7 +190,7 @@ func TestServiceFetchBatchRaw(t *testing.T) {
 
 		streams[id] = enc.Stream()
 
-		readOpts := read.ReadOptions{
+		readOpts := read.Options{
 			SoftRead: false,
 		}
 		mockDB.EXPECT().

--- a/retention/retention_mock.go
+++ b/retention/retention_mock.go
@@ -24,9 +24,8 @@
 package retention
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
+	time "time"
 )
 
 // Mock of Options interface

--- a/storage/block/block_mock.go
+++ b/storage/block/block_mock.go
@@ -566,16 +566,6 @@ func (_m *MockDatabaseSeriesBlocks) EXPECT() *_MockDatabaseSeriesBlocksRecorder 
 	return _m.recorder
 }
 
-func (_m *MockDatabaseSeriesBlocks) Options() Options {
-	ret := _m.ctrl.Call(_m, "Options")
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-func (_mr *_MockDatabaseSeriesBlocksRecorder) Options() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
-}
-
 func (_m *MockDatabaseSeriesBlocks) Len() int {
 	ret := _m.ctrl.Call(_m, "Len")
 	ret0, _ := ret[0].(int)

--- a/storage/bootstrap/bootstrap_mock.go
+++ b/storage/bootstrap/bootstrap_mock.go
@@ -24,10 +24,9 @@
 package bootstrap
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	result "github.com/m3db/m3db/storage/bootstrap/result"
 	namespace "github.com/m3db/m3db/storage/namespace"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Process interface

--- a/storage/database.go
+++ b/storage/database.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3db/x/counter"
 	xio "github.com/m3db/m3db/x/io"
@@ -466,6 +467,7 @@ func (d *db) ReadEncoded(
 	namespace ts.ID,
 	id ts.ID,
 	start, end time.Time,
+	readOpts read.ReadOptions,
 ) ([][]xio.SegmentReader, error) {
 	n, err := d.namespaceFor(namespace)
 	if err != nil {
@@ -473,7 +475,7 @@ func (d *db) ReadEncoded(
 		return nil, err
 	}
 
-	return n.ReadEncoded(ctx, id, start, end)
+	return n.ReadEncoded(ctx, id, start, end, readOpts)
 }
 
 func (d *db) FetchBlocks(

--- a/storage/database.go
+++ b/storage/database.go
@@ -467,7 +467,7 @@ func (d *db) ReadEncoded(
 	namespace ts.ID,
 	id ts.ID,
 	start, end time.Time,
-	readOpts read.ReadOptions,
+	readOpts read.Options,
 ) ([][]xio.SegmentReader, error) {
 	n, err := d.namespaceFor(namespace)
 	if err != nil {

--- a/storage/database_test.go
+++ b/storage/database_test.go
@@ -235,7 +235,7 @@ func TestDatabaseReadEncodedNamespaceNotOwned(t *testing.T) {
 	defer func() {
 		close(mapCh)
 	}()
-	readOptions := read.ReadOptions{
+	readOptions := read.Options{
 		SoftRead: true,
 	}
 	_, err := d.ReadEncoded(ctx, ts.StringID("nonexistent"), ts.StringID("foo"), time.Now(), time.Now(), readOptions)
@@ -259,7 +259,7 @@ func TestDatabaseReadEncodedNamespaceOwned(t *testing.T) {
 	end := time.Now()
 	start := end.Add(-time.Hour)
 	mockNamespace := NewMockdatabaseNamespace(ctrl)
-	readOpts := read.ReadOptions{
+	readOpts := read.Options{
 		SoftRead: true,
 	}
 	mockNamespace.EXPECT().ReadEncoded(ctx, id, start, end, readOpts).Return(nil, nil)

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -36,6 +36,7 @@ import (
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3db/x/io"
@@ -409,6 +410,7 @@ func (n *dbNamespace) ReadEncoded(
 	ctx context.Context,
 	id ts.ID,
 	start, end time.Time,
+	readOpts read.ReadOptions,
 ) ([][]xio.SegmentReader, error) {
 	callStart := n.nowFn()
 	shard, err := n.readableShardFor(id)
@@ -416,7 +418,7 @@ func (n *dbNamespace) ReadEncoded(
 		n.metrics.read.ReportError(n.nowFn().Sub(callStart))
 		return nil, err
 	}
-	res, err := shard.ReadEncoded(ctx, id, start, end)
+	res, err := shard.ReadEncoded(ctx, id, start, end, readOpts)
 	n.metrics.read.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
 	return res, err
 }

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -410,7 +410,7 @@ func (n *dbNamespace) ReadEncoded(
 	ctx context.Context,
 	id ts.ID,
 	start, end time.Time,
-	readOpts read.ReadOptions,
+	readOpts read.Options,
 ) ([][]xio.SegmentReader, error) {
 	callStart := n.nowFn()
 	shard, err := n.readableShardFor(id)

--- a/storage/namespace/namespace_mock.go
+++ b/storage/namespace/namespace_mock.go
@@ -24,10 +24,12 @@
 package namespace
 
 import (
+	gomock "github.com/golang/mock/gomock"
+	client "github.com/m3db/m3cluster/client"
 	retention "github.com/m3db/m3db/retention"
 	ts "github.com/m3db/m3db/ts"
-
-	gomock "github.com/golang/mock/gomock"
+	instrument "github.com/m3db/m3x/instrument"
+	time "time"
 )
 
 // Mock of Options interface
@@ -427,4 +429,115 @@ func (_m *MockInitializer) Init() (Registry, error) {
 
 func (_mr *_MockInitializerRecorder) Init() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init")
+}
+
+// Mock of DynamicOptions interface
+type MockDynamicOptions struct {
+	ctrl     *gomock.Controller
+	recorder *_MockDynamicOptionsRecorder
+}
+
+// Recorder for MockDynamicOptions (not exported)
+type _MockDynamicOptionsRecorder struct {
+	mock *MockDynamicOptions
+}
+
+func NewMockDynamicOptions(ctrl *gomock.Controller) *MockDynamicOptions {
+	mock := &MockDynamicOptions{ctrl: ctrl}
+	mock.recorder = &_MockDynamicOptionsRecorder{mock}
+	return mock
+}
+
+func (_m *MockDynamicOptions) EXPECT() *_MockDynamicOptionsRecorder {
+	return _m.recorder
+}
+
+func (_m *MockDynamicOptions) Validate() error {
+	ret := _m.ctrl.Call(_m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) Validate() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Validate")
+}
+
+func (_m *MockDynamicOptions) SetInstrumentOptions(value instrument.Options) DynamicOptions {
+	ret := _m.ctrl.Call(_m, "SetInstrumentOptions", value)
+	ret0, _ := ret[0].(DynamicOptions)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) SetInstrumentOptions(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetInstrumentOptions", arg0)
+}
+
+func (_m *MockDynamicOptions) InstrumentOptions() instrument.Options {
+	ret := _m.ctrl.Call(_m, "InstrumentOptions")
+	ret0, _ := ret[0].(instrument.Options)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) InstrumentOptions() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InstrumentOptions")
+}
+
+func (_m *MockDynamicOptions) SetConfigServiceClient(c client.Client) DynamicOptions {
+	ret := _m.ctrl.Call(_m, "SetConfigServiceClient", c)
+	ret0, _ := ret[0].(DynamicOptions)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) SetConfigServiceClient(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetConfigServiceClient", arg0)
+}
+
+func (_m *MockDynamicOptions) ConfigServiceClient() client.Client {
+	ret := _m.ctrl.Call(_m, "ConfigServiceClient")
+	ret0, _ := ret[0].(client.Client)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) ConfigServiceClient() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigServiceClient")
+}
+
+func (_m *MockDynamicOptions) SetNamespaceRegistryKey(k string) DynamicOptions {
+	ret := _m.ctrl.Call(_m, "SetNamespaceRegistryKey", k)
+	ret0, _ := ret[0].(DynamicOptions)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) SetNamespaceRegistryKey(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetNamespaceRegistryKey", arg0)
+}
+
+func (_m *MockDynamicOptions) NamespaceRegistryKey() string {
+	ret := _m.ctrl.Call(_m, "NamespaceRegistryKey")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) NamespaceRegistryKey() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NamespaceRegistryKey")
+}
+
+func (_m *MockDynamicOptions) SetInitTimeout(value time.Duration) DynamicOptions {
+	ret := _m.ctrl.Call(_m, "SetInitTimeout", value)
+	ret0, _ := ret[0].(DynamicOptions)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) SetInitTimeout(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetInitTimeout", arg0)
+}
+
+func (_m *MockDynamicOptions) InitTimeout() time.Duration {
+	ret := _m.ctrl.Call(_m, "InitTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+func (_mr *_MockDynamicOptionsRecorder) InitTimeout() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InitTimeout")
 }

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -138,7 +138,7 @@ func TestNamespaceReadEncodedShardNotOwned(t *testing.T) {
 	for i := range ns.shards {
 		ns.shards[i] = nil
 	}
-	readOptions := read.ReadOptions{
+	readOptions := read.Options{
 		SoftRead: false,
 	}
 	_, err := ns.ReadEncoded(ctx, ts.StringID("foo"), time.Now(), time.Now(), readOptions)
@@ -158,7 +158,7 @@ func TestNamespaceReadEncodedShardOwned(t *testing.T) {
 
 	ns := newTestNamespace(t)
 	shard := NewMockdatabaseShard(ctrl)
-	readOpts := read.ReadOptions{
+	readOpts := read.Options{
 		SoftRead: false,
 	}
 	shard.EXPECT().ReadEncoded(ctx, id, start, end, readOpts).Return(nil, nil)

--- a/storage/namespace_test.go
+++ b/storage/namespace_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3db/x/metrics"
@@ -137,7 +138,10 @@ func TestNamespaceReadEncodedShardNotOwned(t *testing.T) {
 	for i := range ns.shards {
 		ns.shards[i] = nil
 	}
-	_, err := ns.ReadEncoded(ctx, ts.StringID("foo"), time.Now(), time.Now())
+	readOptions := read.ReadOptions{
+		SoftRead: false,
+	}
+	_, err := ns.ReadEncoded(ctx, ts.StringID("foo"), time.Now(), time.Now(), readOptions)
 	require.Error(t, err)
 }
 
@@ -154,15 +158,18 @@ func TestNamespaceReadEncodedShardOwned(t *testing.T) {
 
 	ns := newTestNamespace(t)
 	shard := NewMockdatabaseShard(ctrl)
-	shard.EXPECT().ReadEncoded(ctx, id, start, end).Return(nil, nil)
+	readOpts := read.ReadOptions{
+		SoftRead: false,
+	}
+	shard.EXPECT().ReadEncoded(ctx, id, start, end, readOpts).Return(nil, nil)
 	ns.shards[testShardIDs[0].ID()] = shard
 
 	shard.EXPECT().IsBootstrapped().Return(true)
-	_, err := ns.ReadEncoded(ctx, id, start, end)
+	_, err := ns.ReadEncoded(ctx, id, start, end, readOpts)
 	require.NoError(t, err)
 
 	shard.EXPECT().IsBootstrapped().Return(false)
-	_, err = ns.ReadEncoded(ctx, id, start, end)
+	_, err = ns.ReadEncoded(ctx, id, start, end, readOpts)
 	require.Error(t, err)
 	require.True(t, xerrors.IsRetryableError(err))
 	require.Equal(t, errShardNotBootstrappedToRead, xerrors.GetInnerRetryableError(err))

--- a/storage/read/types.go
+++ b/storage/read/types.go
@@ -1,5 +1,6 @@
 package read
 
-type ReadOptions struct {
+// Options is a collection of options spanning the context of a request
+type Options struct {
 	SoftRead bool
 }

--- a/storage/read/types.go
+++ b/storage/read/types.go
@@ -1,0 +1,5 @@
+package read
+
+type ReadOptions struct {
+	SoftRead bool
+}

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3db/context"
 	"github.com/m3db/m3db/persist"
 	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/ts"
 	xio "github.com/m3db/m3db/x/io"
 	xerrors "github.com/m3db/m3x/errors"
@@ -234,6 +235,7 @@ func (s *dbSeries) Write(
 func (s *dbSeries) ReadEncoded(
 	ctx context.Context,
 	start, end time.Time,
+	opts read.ReadOptions,
 ) ([][]xio.SegmentReader, error) {
 	if end.Before(start) {
 		return nil, xerrors.NewInvalidParamsError(errSeriesReadInvalidRange)
@@ -272,7 +274,9 @@ func (s *dbSeries) ReadEncoded(
 				if stream != nil {
 					results = append(results, []xio.SegmentReader{stream})
 					// NB(r): Mark this block as read now
-					block.SetLastReadTime(now)
+					if opts.SoftRead == false {
+						block.SetLastReadTime(now)
+					}
 				}
 			}
 		}

--- a/storage/series/series.go
+++ b/storage/series/series.go
@@ -235,7 +235,7 @@ func (s *dbSeries) Write(
 func (s *dbSeries) ReadEncoded(
 	ctx context.Context,
 	start, end time.Time,
-	opts read.ReadOptions,
+	opts read.Options,
 ) ([][]xio.SegmentReader, error) {
 	if end.Before(start) {
 		return nil, xerrors.NewInvalidParamsError(errSeriesReadInvalidRange)
@@ -273,8 +273,7 @@ func (s *dbSeries) ReadEncoded(
 				}
 				if stream != nil {
 					results = append(results, []xio.SegmentReader{stream})
-					// NB(r): Mark this block as read now
-					if opts.SoftRead == false {
+					if !opts.SoftRead {
 						block.SetLastReadTime(now)
 					}
 				}

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -24,16 +24,16 @@
 package series
 
 import (
-	time "time"
+	time0 "time"
 
+	gomock "github.com/golang/mock/gomock"
 	context "github.com/m3db/m3db/context"
 	persist "github.com/m3db/m3db/persist"
 	block "github.com/m3db/m3db/storage/block"
+	read "github.com/m3db/m3db/storage/read"
 	ts "github.com/m3db/m3db/ts"
 	io "github.com/m3db/m3db/x/io"
-	time0 "github.com/m3db/m3x/time"
-
-	gomock "github.com/golang/mock/gomock"
+	time "github.com/m3db/m3x/time"
 )
 
 // Mock of DatabaseSeries interface
@@ -75,7 +75,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time.Time) []block.FetchBlockResult {
+func (_m *MockDatabaseSeries) FetchBlocks(_param0 context.Context, _param1 []time0.Time) []block.FetchBlockResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", _param0, _param1)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	return ret0
@@ -85,7 +85,7 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocks(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1)
 }
 
-func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time.Time, _param2 time.Time, _param3 block.FetchBlocksMetadataOptions) block.FetchBlocksMetadataResult {
+func (_m *MockDatabaseSeries) FetchBlocksMetadata(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 block.FetchBlocksMetadataOptions) block.FetchBlocksMetadataResult {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResult)
 	return ret0
@@ -95,7 +95,7 @@ func (_mr *_MockDatabaseSeriesRecorder) FetchBlocksMetadata(arg0, arg1, arg2, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocksMetadata", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time.Time, _param2 persist.Fn) error {
+func (_m *MockDatabaseSeries) Flush(_param0 context.Context, _param1 time0.Time, _param2 persist.Fn) error {
 	ret := _m.ctrl.Call(_m, "Flush", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -135,15 +135,15 @@ func (_mr *_MockDatabaseSeriesRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time.Time, _param2 time.Time) ([][]io.SegmentReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadEncoded", _param0, _param1, _param2)
+func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 read.ReadOptions) ([][]io.SegmentReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadEncoded", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2)
+func (_mr *_MockDatabaseSeriesRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockDatabaseSeries) Reset(_param0 ts.ID, _param1 bool, _param2 QueryableBlockRetriever, _param3 Options) {
@@ -165,7 +165,7 @@ func (_mr *_MockDatabaseSeriesRecorder) Tick() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick")
 }
 
-func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time.Time, _param2 float64, _param3 time0.Unit, _param4 []byte) error {
+func (_m *MockDatabaseSeries) Write(_param0 context.Context, _param1 time0.Time, _param2 float64, _param3 time.Unit, _param4 []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/storage/series/series_mock.go
+++ b/storage/series/series_mock.go
@@ -135,7 +135,7 @@ func (_mr *_MockDatabaseSeriesRecorder) IsEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsEmpty")
 }
 
-func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 read.ReadOptions) ([][]io.SegmentReader, error) {
+func (_m *MockDatabaseSeries) ReadEncoded(_param0 context.Context, _param1 time0.Time, _param2 time0.Time, _param3 read.Options) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -159,7 +159,7 @@ func TestSeriesWriteFlushRead(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	readOpts := read.ReadOptions{
+	readOpts := read.Options{
 		SoftRead: false,
 	}
 	// Test fine grained range
@@ -183,7 +183,7 @@ func TestSeriesReadEndBeforeStart(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	readOpts := read.ReadOptions{
+	readOpts := read.Options{
 		SoftRead: false,
 	}
 	results, err := series.ReadEncoded(ctx, time.Now(), time.Now().Add(-1*time.Second), readOpts)
@@ -517,7 +517,7 @@ func TestSeriesOutOfOrderWritesAndRotate(t *testing.T) {
 		now = now.Add(blockSize)
 	}
 
-	readOpts := block.ReadOptions{
+	readOpts := read.Options{
 		SoftRead: false,
 	}
 	encoded, err := series.ReadEncoded(ctx, qStart, qEnd, readOpts)

--- a/storage/series/types.go
+++ b/storage/series/types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3db/persist"
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/ts"
 	xio "github.com/m3db/m3db/x/io"
 	"github.com/m3db/m3x/instrument"
@@ -56,6 +57,7 @@ type DatabaseSeries interface {
 	ReadEncoded(
 		ctx context.Context,
 		start, end time.Time,
+		readOpts read.ReadOptions,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks returns data blocks given a list of block start times

--- a/storage/series/types.go
+++ b/storage/series/types.go
@@ -57,7 +57,7 @@ type DatabaseSeries interface {
 	ReadEncoded(
 		ctx context.Context,
 		start, end time.Time,
-		readOpts read.ReadOptions,
+		readOpts read.Options,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks returns data blocks given a list of block start times

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -576,7 +576,7 @@ func (s *dbShard) ReadEncoded(
 	ctx context.Context,
 	id ts.ID,
 	start, end time.Time,
-	opts read.ReadOptions,
+	opts read.Options,
 ) ([][]xio.SegmentReader, error) {
 	s.RLock()
 	entry, _, err := s.lookupEntryWithLock(id)

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3db/storage/block"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
@@ -575,6 +576,7 @@ func (s *dbShard) ReadEncoded(
 	ctx context.Context,
 	id ts.ID,
 	start, end time.Time,
+	opts read.ReadOptions,
 ) ([][]xio.SegmentReader, error) {
 	s.RLock()
 	entry, _, err := s.lookupEntryWithLock(id)
@@ -585,7 +587,7 @@ func (s *dbShard) ReadEncoded(
 	if err != nil {
 		return nil, err
 	}
-	return entry.series.ReadEncoded(ctx, start, end)
+	return entry.series.ReadEncoded(ctx, start, end, opts)
 }
 
 // lookupEntryWithLock returns the entry for a given id while holding a read lock or a write lock.

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -148,7 +148,7 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.Options) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -333,7 +333,7 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.Options) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -597,7 +597,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.Options) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
@@ -824,7 +824,7 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.Options) ([][]io.SegmentReader, error) {
 	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -36,6 +36,7 @@ import (
 	bootstrap "github.com/m3db/m3db/storage/bootstrap"
 	result "github.com/m3db/m3db/storage/bootstrap/result"
 	namespace "github.com/m3db/m3db/storage/namespace"
+	read "github.com/m3db/m3db/storage/read"
 	repair "github.com/m3db/m3db/storage/repair"
 	series "github.com/m3db/m3db/storage/series"
 	ts "github.com/m3db/m3db/ts"
@@ -43,8 +44,8 @@ import (
 	io "github.com/m3db/m3db/x/io"
 	instrument "github.com/m3db/m3x/instrument"
 	pool "github.com/m3db/m3x/pool"
-	time "github.com/m3db/m3x/time"
-	time0 "time"
+	time0 "github.com/m3db/m3x/time"
+	time "time"
 )
 
 // Mock of Database interface
@@ -137,7 +138,7 @@ func (_mr *_MockDatabaseRecorder) Terminate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Terminate")
 }
 
-func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockDatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -147,18 +148,18 @@ func (_mr *_MockDatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
+func (_m *MockDatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockDatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockDatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -169,7 +170,7 @@ func (_mr *_MockDatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockDatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -322,7 +323,7 @@ func (_mr *_MockdatabaseRecorder) Terminate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Terminate")
 }
 
-func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *Mockdatabase) Write(ctx context.Context, namespace ts.ID, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, namespace, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -332,18 +333,18 @@ func (_mr *_MockdatabaseRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end)
+func (_m *Mockdatabase) ReadEncoded(ctx context.Context, namespace ts.ID, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, namespace, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockdatabaseRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *Mockdatabase) FetchBlocks(ctx context.Context, namespace ts.ID, shard uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, namespace, shard, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -354,7 +355,7 @@ func (_mr *_MockdatabaseRecorder) FetchBlocks(arg0, arg1, arg2, arg3, arg4 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *Mockdatabase) FetchBlocksMetadata(ctx context.Context, namespace ts.ID, shard uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, namespace, shard, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -578,7 +579,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) AssignShardSet(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignShardSet", arg0)
 }
 
-func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time0.Duration) {
+func (_m *MockdatabaseNamespace) Tick(c context.Cancellable, softDeadline time.Duration) {
 	_m.ctrl.Call(_m, "Tick", c, softDeadline)
 }
 
@@ -586,7 +587,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Tick(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseNamespace) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -596,18 +597,18 @@ func (_mr *_MockdatabaseNamespaceRecorder) Write(arg0, arg1, arg2, arg3, arg4, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
+func (_m *MockdatabaseNamespace) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
+func (_mr *_MockdatabaseNamespaceRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, shardID, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -618,7 +619,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) FetchBlocks(arg0, arg1, arg2, arg3 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time0.Time, end time0.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
+func (_m *MockdatabaseNamespace) FetchBlocksMetadata(ctx context.Context, shardID uint32, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, shardID, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -640,7 +641,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Bootstrap(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) Flush(blockStart time0.Time, flush persist.Flush) error {
+func (_m *MockdatabaseNamespace) Flush(blockStart time.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -650,7 +651,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Flush(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) NeedsFlush(alignedInclusiveStart time0.Time, alignedInclusiveEnd time0.Time) bool {
+func (_m *MockdatabaseNamespace) NeedsFlush(alignedInclusiveStart time.Time, alignedInclusiveEnd time.Time) bool {
 	ret := _m.ctrl.Call(_m, "NeedsFlush", alignedInclusiveStart, alignedInclusiveEnd)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -660,7 +661,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) NeedsFlush(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeedsFlush", arg0, arg1)
 }
 
-func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time0.Time) error {
+func (_m *MockdatabaseNamespace) CleanupFileset(earliestToRetain time.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -681,7 +682,7 @@ func (_mr *_MockdatabaseNamespaceRecorder) Truncate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Truncate")
 }
 
-func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time.Range) error {
+func (_m *MockdatabaseNamespace) Repair(repairer databaseShardRepairer, tr time0.Range) error {
 	ret := _m.ctrl.Call(_m, "Repair", repairer, tr)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -803,7 +804,7 @@ func (_mr *_MockdatabaseShardRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time0.Duration) tickResult {
+func (_m *MockdatabaseShard) Tick(c context.Cancellable, softDeadline time.Duration) tickResult {
 	ret := _m.ctrl.Call(_m, "Tick", c, softDeadline)
 	ret0, _ := ret[0].(tickResult)
 	return ret0
@@ -813,7 +814,7 @@ func (_mr *_MockdatabaseShardRecorder) Tick(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tick", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time0.Time, value float64, unit time.Unit, annotation []byte) error {
+func (_m *MockdatabaseShard) Write(ctx context.Context, id ts.ID, timestamp time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", ctx, id, timestamp, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -823,18 +824,18 @@ func (_mr *_MockdatabaseShardRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time0.Time, end time0.Time) ([][]io.SegmentReader, error) {
-	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end)
+func (_m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ts.ID, start time.Time, end time.Time, readOpts read.ReadOptions) ([][]io.SegmentReader, error) {
+	ret := _m.ctrl.Call(_m, "ReadEncoded", ctx, id, start, end, readOpts)
 	ret0, _ := ret[0].([][]io.SegmentReader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3)
+func (_mr *_MockdatabaseShardRecorder) ReadEncoded(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadEncoded", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time0.Time) ([]block.FetchBlockResult, error) {
+func (_m *MockdatabaseShard) FetchBlocks(ctx context.Context, id ts.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	ret := _m.ctrl.Call(_m, "FetchBlocks", ctx, id, starts)
 	ret0, _ := ret[0].([]block.FetchBlockResult)
 	ret1, _ := ret[1].(error)
@@ -845,7 +846,7 @@ func (_mr *_MockdatabaseShardRecorder) FetchBlocks(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchBlocks", arg0, arg1, arg2)
 }
 
-func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time0.Time, end time0.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64) {
+func (_m *MockdatabaseShard) FetchBlocksMetadata(ctx context.Context, start time.Time, end time.Time, limit int64, pageToken int64, opts block.FetchBlocksMetadataOptions) (block.FetchBlocksMetadataResults, *int64) {
 	ret := _m.ctrl.Call(_m, "FetchBlocksMetadata", ctx, start, end, limit, pageToken, opts)
 	ret0, _ := ret[0].(block.FetchBlocksMetadataResults)
 	ret1, _ := ret[1].(*int64)
@@ -866,7 +867,7 @@ func (_mr *_MockdatabaseShardRecorder) Bootstrap(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Bootstrap", arg0)
 }
 
-func (_m *MockdatabaseShard) Flush(blockStart time0.Time, flush persist.Flush) error {
+func (_m *MockdatabaseShard) Flush(blockStart time.Time, flush persist.Flush) error {
 	ret := _m.ctrl.Call(_m, "Flush", blockStart, flush)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -876,7 +877,7 @@ func (_mr *_MockdatabaseShardRecorder) Flush(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Flush", arg0, arg1)
 }
 
-func (_m *MockdatabaseShard) FlushState(blockStart time0.Time) fileOpState {
+func (_m *MockdatabaseShard) FlushState(blockStart time.Time) fileOpState {
 	ret := _m.ctrl.Call(_m, "FlushState", blockStart)
 	ret0, _ := ret[0].(fileOpState)
 	return ret0
@@ -886,7 +887,7 @@ func (_mr *_MockdatabaseShardRecorder) FlushState(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushState", arg0)
 }
 
-func (_m *MockdatabaseShard) CleanupFileset(earliestToRetain time0.Time) error {
+func (_m *MockdatabaseShard) CleanupFileset(earliestToRetain time.Time) error {
 	ret := _m.ctrl.Call(_m, "CleanupFileset", earliestToRetain)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -896,7 +897,7 @@ func (_mr *_MockdatabaseShardRecorder) CleanupFileset(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CleanupFileset", arg0)
 }
 
-func (_m *MockdatabaseShard) Repair(ctx context.Context, tr time.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShard) Repair(ctx context.Context, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -977,7 +978,7 @@ func (_m *MockdatabaseFlushManager) EXPECT() *_MockdatabaseFlushManagerRecorder 
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFlushManager) Flush(t time0.Time) error {
+func (_m *MockdatabaseFlushManager) Flush(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1016,7 +1017,7 @@ func (_m *MockdatabaseCleanupManager) EXPECT() *_MockdatabaseCleanupManagerRecor
 	return _m.recorder
 }
 
-func (_m *MockdatabaseCleanupManager) Cleanup(t time0.Time) error {
+func (_m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1055,7 +1056,7 @@ func (_m *MockdatabaseFileSystemManager) EXPECT() *_MockdatabaseFileSystemManage
 	return _m.recorder
 }
 
-func (_m *MockdatabaseFileSystemManager) Cleanup(t time0.Time) error {
+func (_m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Cleanup", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1065,7 +1066,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Cleanup(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Cleanup", arg0)
 }
 
-func (_m *MockdatabaseFileSystemManager) Flush(t time0.Time) error {
+func (_m *MockdatabaseFileSystemManager) Flush(t time.Time) error {
 	ret := _m.ctrl.Call(_m, "Flush", t)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1105,7 +1106,7 @@ func (_mr *_MockdatabaseFileSystemManagerRecorder) Status() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
 }
 
-func (_m *MockdatabaseFileSystemManager) Run(t time0.Time, runType runType, forceType forceType) bool {
+func (_m *MockdatabaseFileSystemManager) Run(t time.Time, runType runType, forceType forceType) bool {
 	ret := _m.ctrl.Call(_m, "Run", t, runType, forceType)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -1154,7 +1155,7 @@ func (_mr *_MockdatabaseShardRepairerRecorder) Options() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
-func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (_m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ts.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	ret := _m.ctrl.Call(_m, "Repair", ctx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
@@ -1241,7 +1242,7 @@ func (_m *MockdatabaseTickManager) EXPECT() *_MockdatabaseTickManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockdatabaseTickManager) Tick(softDeadline time0.Duration, forceType forceType) error {
+func (_m *MockdatabaseTickManager) Tick(softDeadline time.Duration, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1318,7 +1319,7 @@ func (_mr *_MockdatabaseMediatorRecorder) EnableFileOps() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableFileOps")
 }
 
-func (_m *MockdatabaseMediator) Tick(softDeadline time0.Duration, runType runType, forceType forceType) error {
+func (_m *MockdatabaseMediator) Tick(softDeadline time.Duration, runType runType, forceType forceType) error {
 	ret := _m.ctrl.Call(_m, "Tick", softDeadline, runType, forceType)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1588,7 +1589,7 @@ func (_mr *_MockOptionsRecorder) ErrorCounterOptions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ErrorCounterOptions")
 }
 
-func (_m *MockOptions) SetErrorWindowForLoad(value time0.Duration) Options {
+func (_m *MockOptions) SetErrorWindowForLoad(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetErrorWindowForLoad", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1598,9 +1599,9 @@ func (_mr *_MockOptionsRecorder) SetErrorWindowForLoad(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetErrorWindowForLoad", arg0)
 }
 
-func (_m *MockOptions) ErrorWindowForLoad() time0.Duration {
+func (_m *MockOptions) ErrorWindowForLoad() time.Duration {
 	ret := _m.ctrl.Call(_m, "ErrorWindowForLoad")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
@@ -1708,7 +1709,7 @@ func (_mr *_MockOptionsRecorder) PersistManager() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PersistManager")
 }
 
-func (_m *MockOptions) SetTickInterval(value time0.Duration) Options {
+func (_m *MockOptions) SetTickInterval(value time.Duration) Options {
 	ret := _m.ctrl.Call(_m, "SetTickInterval", value)
 	ret0, _ := ret[0].(Options)
 	return ret0
@@ -1718,9 +1719,9 @@ func (_mr *_MockOptionsRecorder) SetTickInterval(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTickInterval", arg0)
 }
 
-func (_m *MockOptions) TickInterval() time0.Duration {
+func (_m *MockOptions) TickInterval() time.Duration {
 	ret := _m.ctrl.Call(_m, "TickInterval")
-	ret0, _ := ret[0].(time0.Duration)
+	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -89,7 +89,7 @@ type Database interface {
 		namespace ts.ID,
 		id ts.ID,
 		start, end time.Time,
-		readOpts read.ReadOptions,
+		readOpts read.Options,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.
@@ -192,7 +192,7 @@ type databaseNamespace interface {
 		ctx context.Context,
 		id ts.ID,
 		start, end time.Time,
-		readOpts read.ReadOptions,
+		readOpts read.Options,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.
@@ -271,7 +271,7 @@ type databaseShard interface {
 		ctx context.Context,
 		id ts.ID,
 		start, end time.Time,
-		readOpts read.ReadOptions,
+		readOpts read.Options,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.

--- a/storage/types.go
+++ b/storage/types.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/storage/bootstrap/result"
 	"github.com/m3db/m3db/storage/namespace"
+	"github.com/m3db/m3db/storage/read"
 	"github.com/m3db/m3db/storage/repair"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/ts"
@@ -88,6 +89,7 @@ type Database interface {
 		namespace ts.ID,
 		id ts.ID,
 		start, end time.Time,
+		readOpts read.ReadOptions,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.
@@ -190,6 +192,7 @@ type databaseNamespace interface {
 		ctx context.Context,
 		id ts.ID,
 		start, end time.Time,
+		readOpts read.ReadOptions,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.
@@ -268,6 +271,7 @@ type databaseShard interface {
 		ctx context.Context,
 		id ts.ID,
 		start, end time.Time,
+		readOpts read.ReadOptions,
 	) ([][]xio.SegmentReader, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block start times.


### PR DESCRIPTION
SoftRead allows for reads to not update the last read time of a block. This is helpful for building tooling around metric utilization without "dirtying" the metric utilization data.