### PR TITLE
Rewire fs options to use different sizes for different file types

### DIFF
--- a/integration/disk_flush_helpers.go
+++ b/integration/disk_flush_helpers.go
@@ -123,7 +123,7 @@ func verifyFlushed(
 	seriesMaps map[time.Time]generate.SeriesBlock,
 ) {
 	fsOpts := opts.CommitLogOptions().FilesystemOptions()
-	reader := fs.NewReader(fsOpts.FilePathPrefix(), fsOpts.ReaderBufferSize(), opts.BytesPool(), nil)
+	reader := fs.NewReader(fsOpts.FilePathPrefix(), fsOpts.DataReaderBufferSize(), fsOpts.InfoReaderBufferSize(), opts.BytesPool(), nil)
 	iteratorPool := opts.ReaderIteratorPool()
 	for timestamp, seriesList := range seriesMaps {
 		verifyForTime(t, reader, shardSet, iteratorPool, timestamp, namespace, seriesList)

--- a/persist/fs/clone/cloner.go
+++ b/persist/fs/clone/cloner.go
@@ -22,7 +22,7 @@ func New(opts Options) FilesetCloner {
 }
 
 func (c *cloner) Clone(src FilesetID, dest FilesetID, destBlocksize time.Duration) error {
-	reader := fs.NewReader(src.PathPrefix, c.opts.BufferSize(), nil, msgpack.NewDecodingOptions())
+	reader := fs.NewReader(src.PathPrefix, c.opts.BufferSize(), c.opts.BufferSize(), nil, msgpack.NewDecodingOptions())
 	if err := reader.Open(ts.StringID(src.Namespace), src.Shard, src.Blockstart); err != nil {
 		return fmt.Errorf("unable to read source fileset: %v", err)
 	}

--- a/persist/fs/clone/cloner_test.go
+++ b/persist/fs/clone/cloner_test.go
@@ -59,9 +59,9 @@ func TestCloner(t *testing.T) {
 	require.NoError(t, cloner.Clone(src, dest, destBlockSize))
 
 	// verify the two are equal
-	r1 := fs.NewReader(src.PathPrefix, opts.BufferSize(), opts.BytesPool(), opts.DecodingOptions())
+	r1 := fs.NewReader(src.PathPrefix, opts.BufferSize(), opts.BufferSize(), opts.BytesPool(), opts.DecodingOptions())
 	require.NoError(t, r1.Open(ts.StringID(src.Namespace), src.Shard, src.Blockstart))
-	r2 := fs.NewReader(dest.PathPrefix, opts.BufferSize(), opts.BytesPool(), opts.DecodingOptions())
+	r2 := fs.NewReader(dest.PathPrefix, opts.BufferSize(), opts.BufferSize(), opts.BytesPool(), opts.DecodingOptions())
 	require.NoError(t, r2.Open(ts.StringID(dest.Namespace), dest.Shard, dest.Blockstart))
 	for {
 		t1, b1, c1, e1 := r1.Read()

--- a/persist/fs/options.go
+++ b/persist/fs/options.go
@@ -38,6 +38,9 @@ const (
 
 	// defaultInfoReaderBufferSize is the default buffer size for reading TSDB info, checkpoint and digest files
 	defaultInfoReaderBufferSize = 64
+
+	// defaultSeekReaderBufferSize is the default buffer size for fs seeker's data buffer
+	defaultSeekReaderBufferSize = 4096
 )
 
 var (
@@ -57,6 +60,7 @@ type options struct {
 	writerBufferSize     int
 	dataReaderBufferSize int
 	infoReaderBufferSize int
+	seekReaderBufferSize int
 }
 
 // NewOptions creates a new set of fs options
@@ -72,6 +76,7 @@ func NewOptions() Options {
 		writerBufferSize:     defaultWriterBufferSize,
 		dataReaderBufferSize: defaultDataReaderBufferSize,
 		infoReaderBufferSize: defaultInfoReaderBufferSize,
+		seekReaderBufferSize: defaultSeekReaderBufferSize,
 	}
 }
 
@@ -173,4 +178,14 @@ func (o *options) SetInfoReaderBufferSize(value int) Options {
 
 func (o *options) InfoReaderBufferSize() int {
 	return o.infoReaderBufferSize
+}
+
+func (o *options) SetSeekReaderBufferSize(value int) Options {
+	opts := *o
+	opts.seekReaderBufferSize = value
+	return &opts
+}
+
+func (o *options) SeekReaderBufferSize() int {
+	return o.seekReaderBufferSize
 }

--- a/persist/fs/options.go
+++ b/persist/fs/options.go
@@ -33,8 +33,11 @@ const (
 	// defaultWriterBufferSize is the default buffer size for writing TSDB files
 	defaultWriterBufferSize = 65536
 
-	// defaultReaderBufferSize is the default buffer size for reading TSDB files
-	defaultReaderBufferSize = 65536
+	// defaultDataReaderBufferSize is the default buffer size for reading TSDB data and index files
+	defaultDataReaderBufferSize = 65536
+
+	// defaultInfoReaderBufferSize is the default buffer size for reading TSDB info, checkpoint and digest files
+	defaultInfoReaderBufferSize = 64
 )
 
 var (
@@ -44,29 +47,31 @@ var (
 )
 
 type options struct {
-	clockOpts        clock.Options
-	instrumentOpts   instrument.Options
-	runtimeOptsMgr   runtime.OptionsManager
-	decodingOpts     msgpack.DecodingOptions
-	filePathPrefix   string
-	newFileMode      os.FileMode
-	newDirectoryMode os.FileMode
-	writerBufferSize int
-	readerBufferSize int
+	clockOpts            clock.Options
+	instrumentOpts       instrument.Options
+	runtimeOptsMgr       runtime.OptionsManager
+	decodingOpts         msgpack.DecodingOptions
+	filePathPrefix       string
+	newFileMode          os.FileMode
+	newDirectoryMode     os.FileMode
+	writerBufferSize     int
+	dataReaderBufferSize int
+	infoReaderBufferSize int
 }
 
 // NewOptions creates a new set of fs options
 func NewOptions() Options {
 	return &options{
-		clockOpts:        clock.NewOptions(),
-		instrumentOpts:   instrument.NewOptions(),
-		runtimeOptsMgr:   runtime.NewOptionsManager(runtime.NewOptions()),
-		decodingOpts:     msgpack.NewDecodingOptions(),
-		filePathPrefix:   defaultFilePathPrefix,
-		newFileMode:      defaultNewFileMode,
-		newDirectoryMode: defaultNewDirectoryMode,
-		writerBufferSize: defaultWriterBufferSize,
-		readerBufferSize: defaultReaderBufferSize,
+		clockOpts:            clock.NewOptions(),
+		instrumentOpts:       instrument.NewOptions(),
+		runtimeOptsMgr:       runtime.NewOptionsManager(runtime.NewOptions()),
+		decodingOpts:         msgpack.NewDecodingOptions(),
+		filePathPrefix:       defaultFilePathPrefix,
+		newFileMode:          defaultNewFileMode,
+		newDirectoryMode:     defaultNewDirectoryMode,
+		writerBufferSize:     defaultWriterBufferSize,
+		dataReaderBufferSize: defaultDataReaderBufferSize,
+		infoReaderBufferSize: defaultInfoReaderBufferSize,
 	}
 }
 
@@ -150,12 +155,22 @@ func (o *options) WriterBufferSize() int {
 	return o.writerBufferSize
 }
 
-func (o *options) SetReaderBufferSize(value int) Options {
+func (o *options) SetDataReaderBufferSize(value int) Options {
 	opts := *o
-	opts.readerBufferSize = value
+	opts.dataReaderBufferSize = value
 	return &opts
 }
 
-func (o *options) ReaderBufferSize() int {
-	return o.readerBufferSize
+func (o *options) DataReaderBufferSize() int {
+	return o.dataReaderBufferSize
+}
+
+func (o *options) SetInfoReaderBufferSize(value int) Options {
+	opts := *o
+	opts.infoReaderBufferSize = value
+	return &opts
+}
+
+func (o *options) InfoReaderBufferSize() int {
+	return o.infoReaderBufferSize
 }

--- a/persist/fs/read.go
+++ b/persist/fs/read.go
@@ -84,16 +84,17 @@ type reader struct {
 // read the index info.
 func NewReader(
 	filePathPrefix string,
-	bufferSize int,
+	dataBufferSize int,
+	infoBufferSize int,
 	bytesPool pool.CheckedBytesPool,
 	decodingOpts msgpack.DecodingOptions,
 ) FileSetReader {
 	return &reader{
 		filePathPrefix:             filePathPrefix,
-		infoFdWithDigest:           digest.NewFdWithDigestReader(bufferSize),
-		indexFdWithDigest:          digest.NewFdWithDigestReader(bufferSize),
-		dataFdWithDigest:           digest.NewFdWithDigestReader(bufferSize),
-		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(bufferSize),
+		infoFdWithDigest:           digest.NewFdWithDigestReader(infoBufferSize),
+		indexFdWithDigest:          digest.NewFdWithDigestReader(dataBufferSize),
+		dataFdWithDigest:           digest.NewFdWithDigestReader(dataBufferSize),
+		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(infoBufferSize),
 		prologue:                   make([]byte, markerLen+idxLen),
 		decoder:                    msgpack.NewDecoder(decodingOpts),
 		digestBuf:                  digest.NewBuffer(),

--- a/persist/fs/read_test.go
+++ b/persist/fs/read_test.go
@@ -56,7 +56,7 @@ func newTestReader(filePathPrefix string) FileSetReader {
 		return pool.NewBytesPool(s, nil)
 	})
 	bytesPool.Init()
-	return NewReader(filePathPrefix, testReaderBufferSize, bytesPool, nil)
+	return NewReader(filePathPrefix, testReaderBufferSize, testReaderBufferSize, bytesPool, nil)
 }
 
 func bytesRefd(data []byte) checked.Bytes {
@@ -289,7 +289,7 @@ func TestReadNoCheckpointFile(t *testing.T) {
 	require.True(t, FileExists(checkpointFile))
 	os.Remove(checkpointFile)
 
-	r := NewReader(filePathPrefix, testReaderBufferSize, nil, nil)
+	r := NewReader(filePathPrefix, testReaderBufferSize, testReaderBufferSize, nil, nil)
 	err = r.Open(testNs1ID, shard, testWriterStart)
 	require.Equal(t, errCheckpointFileNotFound, err)
 }
@@ -320,7 +320,7 @@ func testReadOpen(t *testing.T, fileData map[string][]byte) {
 		fd.Close()
 	}
 
-	r := NewReader(filePathPrefix, testReaderBufferSize, nil, nil)
+	r := NewReader(filePathPrefix, testReaderBufferSize, testReaderBufferSize, nil, nil)
 	require.Error(t, r.Open(testNs1ID, shard, time.Unix(1000, 0)))
 }
 

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -28,13 +28,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/m3db/m3db/digest"
 	"github.com/m3db/m3db/persist/encoding"
 	"github.com/m3db/m3db/persist/encoding/msgpack"
 	"github.com/m3db/m3db/ts"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/pool"
 	xtime "github.com/m3db/m3x/time"
-	"github.com/m3db/m3db/digest"
 )
 
 var (
@@ -78,13 +78,15 @@ type indexMapEntry struct {
 // NewSeeker returns a new seeker.
 func NewSeeker(
 	filePathPrefix string,
-	bufferSize int,
+	dataBufferSize int,
+	infoBufferSize int,
 	bytesPool pool.CheckedBytesPool,
 	decodingOpts msgpack.DecodingOptions,
 ) FileSetSeeker {
 	return newSeeker(seekerOpts{
 		filePathPrefix: filePathPrefix,
-		bufferSize:     bufferSize,
+		dataBufferSize: dataBufferSize,
+		infoBufferSize: infoBufferSize,
 		bytesPool:      bytesPool,
 		keepIndexIDs:   true,
 		keepUnreadBuf:  false,
@@ -94,7 +96,8 @@ func NewSeeker(
 
 type seekerOpts struct {
 	filePathPrefix string
-	bufferSize     int
+	infoBufferSize int
+	dataBufferSize int
 	bytesPool      pool.CheckedBytesPool
 	keepIndexIDs   bool
 	keepUnreadBuf  bool
@@ -117,10 +120,10 @@ type fileSetSeeker interface {
 func newSeeker(opts seekerOpts) fileSetSeeker {
 	return &seeker{
 		filePathPrefix:             opts.filePathPrefix,
-		infoFdWithDigest:           digest.NewFdWithDigestReader(opts.bufferSize),
-		indexFdWithDigest:          digest.NewFdWithDigestReader(opts.bufferSize),
-		dataReader:                 bufio.NewReaderSize(nil, opts.bufferSize),
-		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(opts.bufferSize),
+		infoFdWithDigest:           digest.NewFdWithDigestReader(opts.infoBufferSize),
+		indexFdWithDigest:          digest.NewFdWithDigestReader(opts.dataBufferSize),
+		dataReader:                 bufio.NewReaderSize(nil, opts.dataBufferSize),
+		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(opts.infoBufferSize),
 		keepIndexIDs:               opts.keepIndexIDs,
 		keepUnreadBuf:              opts.keepUnreadBuf,
 		prologue:                   make([]byte, markerLen+idxLen),

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -80,6 +80,7 @@ func NewSeeker(
 	filePathPrefix string,
 	dataBufferSize int,
 	infoBufferSize int,
+	seekBufferSize int,
 	bytesPool pool.CheckedBytesPool,
 	decodingOpts msgpack.DecodingOptions,
 ) FileSetSeeker {
@@ -87,6 +88,7 @@ func NewSeeker(
 		filePathPrefix: filePathPrefix,
 		dataBufferSize: dataBufferSize,
 		infoBufferSize: infoBufferSize,
+		seekBufferSize: seekBufferSize,
 		bytesPool:      bytesPool,
 		keepIndexIDs:   true,
 		keepUnreadBuf:  false,
@@ -98,6 +100,7 @@ type seekerOpts struct {
 	filePathPrefix string
 	infoBufferSize int
 	dataBufferSize int
+	seekBufferSize int
 	bytesPool      pool.CheckedBytesPool
 	keepIndexIDs   bool
 	keepUnreadBuf  bool
@@ -122,7 +125,7 @@ func newSeeker(opts seekerOpts) fileSetSeeker {
 		filePathPrefix:             opts.filePathPrefix,
 		infoFdWithDigest:           digest.NewFdWithDigestReader(opts.infoBufferSize),
 		indexFdWithDigest:          digest.NewFdWithDigestReader(opts.dataBufferSize),
-		dataReader:                 bufio.NewReaderSize(nil, opts.dataBufferSize),
+		dataReader:                 bufio.NewReaderSize(nil, opts.seekBufferSize),
 		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(opts.infoBufferSize),
 		keepIndexIDs:               opts.keepIndexIDs,
 		keepUnreadBuf:              opts.keepUnreadBuf,

--- a/persist/fs/seek_manager.go
+++ b/persist/fs/seek_manager.go
@@ -215,7 +215,8 @@ func (m *seekerManager) newOpenSeeker(
 
 	seeker := newSeeker(seekerOpts{
 		filePathPrefix: m.filePathPrefix,
-		bufferSize:     m.opts.ReaderBufferSize(),
+		dataBufferSize: m.opts.DataReaderBufferSize(),
+		infoBufferSize: m.opts.InfoReaderBufferSize(),
 		bytesPool:      m.bytesPool,
 		keepIndexIDs:   false,
 		keepUnreadBuf:  true,

--- a/persist/fs/seek_manager.go
+++ b/persist/fs/seek_manager.go
@@ -217,6 +217,7 @@ func (m *seekerManager) newOpenSeeker(
 		filePathPrefix: m.filePathPrefix,
 		dataBufferSize: m.opts.DataReaderBufferSize(),
 		infoBufferSize: m.opts.InfoReaderBufferSize(),
+		seekBufferSize: m.opts.SeekReaderBufferSize(),
 		bytesPool:      m.bytesPool,
 		keepIndexIDs:   false,
 		keepUnreadBuf:  true,

--- a/persist/fs/seek_test.go
+++ b/persist/fs/seek_test.go
@@ -43,7 +43,7 @@ func newTestSeeker(filePathPrefix string) FileSetSeeker {
 		return pool.NewBytesPool(s, nil)
 	})
 	bytesPool.Init()
-	return NewSeeker(filePathPrefix, testReaderBufferSize, bytesPool, nil)
+	return NewSeeker(filePathPrefix, testReaderBufferSize, testReaderBufferSize, bytesPool, nil)
 }
 
 func TestSeekEmptyIndex(t *testing.T) {

--- a/persist/fs/seek_test.go
+++ b/persist/fs/seek_test.go
@@ -43,7 +43,7 @@ func newTestSeeker(filePathPrefix string) FileSetSeeker {
 		return pool.NewBytesPool(s, nil)
 	})
 	bytesPool.Init()
-	return NewSeeker(filePathPrefix, testReaderBufferSize, testReaderBufferSize, bytesPool, nil)
+	return NewSeeker(filePathPrefix, testReaderBufferSize, testReaderBufferSize, testReaderBufferSize, bytesPool, nil)
 }
 
 func TestSeekEmptyIndex(t *testing.T) {

--- a/persist/fs/types.go
+++ b/persist/fs/types.go
@@ -197,6 +197,12 @@ type Options interface {
 
 	// DataReaderBufferSize returns the buffer size for reading TSDB data and index files
 	DataReaderBufferSize() int
+
+	// SetSeekReaderBufferSize size sets the buffer size for seeking TSDB files
+	SetSeekReaderBufferSize(value int) Options
+
+	// SeekReaderBufferSize size returns the buffer size for seeking TSDB files
+	SeekReaderBufferSize() int
 }
 
 // BlockRetrieverOptions represents the options for block retrieval

--- a/persist/fs/types.go
+++ b/persist/fs/types.go
@@ -186,11 +186,17 @@ type Options interface {
 	// WriterBufferSize returns the buffer size for writing TSDB files
 	WriterBufferSize() int
 
-	// SetReaderBufferSize sets the buffer size for reading TSDB files
-	SetReaderBufferSize(value int) Options
+	// SetInfoReaderBufferSize sets the buffer size for reading TSDB info, digest and checkpoint files
+	SetInfoReaderBufferSize(value int) Options
 
-	// ReaderBufferSize returns the buffer size for reading TSDB files
-	ReaderBufferSize() int
+	// InfoReaderBufferSize returns the buffer size for reading TSDB info, digest and checkpoint files
+	InfoReaderBufferSize() int
+
+	// SetDataReaderBufferSize sets the buffer size for reading TSDB data and index files
+	SetDataReaderBufferSize(value int) Options
+
+	// DataReaderBufferSize returns the buffer size for reading TSDB data and index files
+	DataReaderBufferSize() int
 }
 
 // BlockRetrieverOptions represents the options for block retrieval

--- a/storage/bootstrap/bootstrapper/fs/source_test.go
+++ b/storage/bootstrap/bootstrapper/fs/source_test.go
@@ -391,7 +391,8 @@ func TestReadValidateError(t *testing.T) {
 	src := newFileSystemSource(dir, NewOptions()).(*fileSystemSource)
 	src.newReaderFn = func(
 		filePathPrefix string,
-		readerBufferSize int,
+		dataReaderBufferSize int,
+		infoReaderBufferSize int,
 		b pool.CheckedBytesPool,
 		decodingOpts msgpack.DecodingOptions,
 	) fs.FileSetReader {
@@ -441,7 +442,8 @@ func TestReadDeleteOnError(t *testing.T) {
 	src := newFileSystemSource(dir, NewOptions()).(*fileSystemSource)
 	src.newReaderFn = func(
 		filePathPrefix string,
-		readerBufferSize int,
+		dataReaderBufferSize int,
+		infoReaderBufferSize int,
 		b pool.CheckedBytesPool,
 		decodingOpts msgpack.DecodingOptions,
 	) fs.FileSetReader {

--- a/tools/read_index_ids/main/main.go
+++ b/tools/read_index_ids/main/main.go
@@ -47,7 +47,7 @@ func main() {
 	})
 	bytesPool.Init()
 
-	seeker := fs.NewSeeker(*optPathPrefix, defaultDataBufferReadSize, defaultDataBufferReadSize, defaultSeekBufferReadSize, bytesPool, nil)
+	seeker := fs.NewSeeker(*optPathPrefix, defaultDataBufferReadSize, defaultInfoBufferReadSize, defaultSeekBufferReadSize, bytesPool, nil)
 
 	err := seeker.Open(ts.StringID(*optNamespace), *optShard, time.Unix(0, *optBlockstart))
 	if err != nil {

--- a/tools/read_index_ids/main/main.go
+++ b/tools/read_index_ids/main/main.go
@@ -16,6 +16,7 @@ import (
 const (
 	defaultDataBufferReadSize = 65536
 	defaultInfoBufferReadSize = 64
+	defaultSeekBufferReadSize = 4096
 	defaultBufferCapacity     = 1024 * 1024 * 1024
 	defaultBufferPoolCount    = 10
 )
@@ -46,7 +47,7 @@ func main() {
 	})
 	bytesPool.Init()
 
-	seeker := fs.NewSeeker(*optPathPrefix, defaultDataBufferReadSize, defaultInfoBufferReadSize, bytesPool, nil)
+	seeker := fs.NewSeeker(*optPathPrefix, defaultDataBufferReadSize, defaultDataBufferReadSize, defaultSeekBufferReadSize, bytesPool, nil)
 
 	err := seeker.Open(ts.StringID(*optNamespace), *optShard, time.Unix(0, *optBlockstart))
 	if err != nil {

--- a/tools/read_index_ids/main/main.go
+++ b/tools/read_index_ids/main/main.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	defaultBufferReadSize  = 10
-	defaultBufferCapacity  = 1024 * 1024 * 1024
-	defaultBufferPoolCount = 10
+	defaultDataBufferReadSize = 65536
+	defaultInfoBufferReadSize = 64
+	defaultBufferCapacity     = 1024 * 1024 * 1024
+	defaultBufferPoolCount    = 10
 )
 
 func main() {
@@ -45,7 +46,7 @@ func main() {
 	})
 	bytesPool.Init()
 
-	seeker := fs.NewSeeker(*optPathPrefix, defaultBufferReadSize, bytesPool, nil)
+	seeker := fs.NewSeeker(*optPathPrefix, defaultDataBufferReadSize, defaultInfoBufferReadSize, bytesPool, nil)
 
 	err := seeker.Open(ts.StringID(*optNamespace), *optShard, time.Unix(0, *optBlockstart))
 	if err != nil {


### PR DESCRIPTION
We were using a single buffer size for readers of all the different file types, despite 3/5 files being significantly smaller than the other two. This PR addresses that.

/cc @robskillington @richardartoul 