### PR TITLE
Reorder travis targets to better parallelise 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TEST_TIMEOUT_SCALE=20
     - PACKAGE=github.com/m3db/m3db
   matrix:
-    - MAKE_TARGET="lint metalint test-ci-unit"
+    - MAKE_TARGET="test-ci-unit"
     - MAKE_TARGET="test-ci-integration"
-    - MAKE_TARGET="services tools"
+    - MAKE_TARGET="lint metalint services tools"
 script: "make $MAKE_TARGET"


### PR DESCRIPTION
Changing parallelisation of targets to give unit tests more individual time. E.g. run that drove this – 

<img width="1012" alt="screen shot 2017-10-21 at 15 02 07" src="https://user-images.githubusercontent.com/199982/31855073-2d4d376a-b671-11e7-98a4-30dae97b4d96.png">

/cc @robskillington @richardartoul @jskelcy 