### PR TITLE
Support Go 1.9.X

### DIFF
--- a/.metalinter.json
+++ b/.metalinter.json
@@ -1,8 +1,18 @@
 {
   "Linters": {
-    "unused":   "unused -tags integration:PATH:LINE:COL:MESSAGE",
-    "gosimple": "gosimple -tags integration:PATH:LINE:COL:MESSAGE",
-    "maptime": "maptime:PATH:LINE:COL:MESSAGE" },
+    "unused": {
+      "Command": "unused -tags integration",
+      "Pattern": "PATH:LINE:COL:MESSAGE"
+    },
+    "gosimple": {
+      "Command": "gosimple -tags integration",
+      "Pattern": "PATH:LINE:COL:MESSAGE"
+    },
+    "maptime": {
+      "Command": "maptime -tags integration",
+      "Pattern": "PATH:LINE:COL:MESSAGE"
+    }
+  },
   "Enable":
     [ "deadcode"
     , "varcheck"

--- a/.metalinter.json
+++ b/.metalinter.json
@@ -1,7 +1,8 @@
 {
   "Linters": {
     "unused":   "unused -tags integration:PATH:LINE:COL:MESSAGE",
-    "gosimple": "gosimple -tags integration:PATH:LINE:COL:MESSAGE" },
+    "gosimple": "gosimple -tags integration:PATH:LINE:COL:MESSAGE",
+    "maptime": "maptime:PATH:LINE:COL:MESSAGE" },
   "Enable":
     [ "deadcode"
     , "varcheck"
@@ -11,6 +12,7 @@
     , "unconvert"
     , "misspell"
     , "gosimple"
-    , "unused"  ],
+    , "unused"
+    , "maptime" ],
   "Deadline": "3m",
   "EnableGC": true }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.7.6
   - 1.8.3
+  - 1.9.2
 sudo: required
 dist: trusty
 install: make install-ci

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ lint:
 	$(lint_check)
 
 .PHONY: metalint
-metalint: install-metalinter
+metalint: install-metalinter install-linter-maptime
 	@($(metalint_check) $(metalint_config) $(metalint_exclude) \
 		&& echo "metalinted successfully!") || (echo "metalinter failed" && exit 1)
 

--- a/client/session_fetch_bulk_blocks_test.go
+++ b/client/session_fetch_bulk_blocks_test.go
@@ -1693,7 +1693,7 @@ func TestBlocksResultAddBlockFromPeerReadUnmerged(t *testing.T) {
 		idx := asserted
 		dp, unit, annotation := iter.Current()
 		assert.Equal(t, all[idx].value, dp.Value)
-		assert.Equal(t, all[idx].t, dp.Timestamp)
+		assert.True(t, all[idx].t.Equal(dp.Timestamp))
 		assert.Equal(t, all[idx].unit, unit)
 		assert.Equal(t, all[idx].annotation, []byte(annotation))
 		asserted++

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 28af70e9a86e892bbdb06c12c9000295565b43967fbe5015d3d30cbce57612bf
-updated: 2017-11-08T13:06:52.812830135-05:00
+hash: 0c0adc2d1d5754541cd25d8602bcff5464bfa76d2d15d6f5840775fbb88d1611
+updated: 2017-11-08T15:19:37.101058172-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -133,7 +133,7 @@ imports:
   - gen
   - prop
 - name: github.com/m3db/m3cluster
-  version: 6edd2de9c678c51ef4d4d91eb66d191e9d7190f5
+  version: 8354845ef3ba8c1a4ddbad288fca248516fb0a50
   subpackages:
   - client
   - client/etcd
@@ -171,7 +171,7 @@ imports:
   - os/fs
   - x/grpc
 - name: github.com/m3db/m3x
-  version: 640bad305baa75986e8b4cbacd23b530374f9c76
+  version: f55f7ecf679d192f0f272ce2088e24b2b640c194
   vcs: git
   subpackages:
   - checked

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 14225747cbe4f4ccc8b7fbcf10b33ea7524ae10fda47b2450d3fbbeaf351c9fc
-updated: 2017-10-26T11:54:34.139208089-04:00
+hash: 28af70e9a86e892bbdb06c12c9000295565b43967fbe5015d3d30cbce57612bf
+updated: 2017-11-08T13:06:52.812830135-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -171,7 +171,7 @@ imports:
   - os/fs
   - x/grpc
 - name: github.com/m3db/m3x
-  version: 74f8fce525a9170e42bdf27983f74f022d356585
+  version: 640bad305baa75986e8b4cbacd23b530374f9c76
   vcs: git
   subpackages:
   - checked

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,14 +44,14 @@ import:
   version: <4.0.0
 
 - package: github.com/m3db/m3cluster
-  version: 6edd2de9c678c51ef4d4d91eb66d191e9d7190f5
+  version: 8354845ef3ba8c1a4ddbad288fca248516fb0a50
   subpackages:
   - client
   - services
   - integration/etcd
 
 - package: github.com/m3db/m3x
-  version: 640bad305baa75986e8b4cbacd23b530374f9c76
+  version: f55f7ecf679d192f0f272ce2088e24b2b640c194
   vcs: git
   subpackages:
   - checked

--- a/glide.yaml
+++ b/glide.yaml
@@ -51,7 +51,7 @@ import:
   - integration/etcd
 
 - package: github.com/m3db/m3x
-  version: 74f8fce525a9170e42bdf27983f74f022d356585
+  version: 640bad305baa75986e8b4cbacd23b530374f9c76
   vcs: git
   subpackages:
   - checked

--- a/storage/block/block_test.go
+++ b/storage/block/block_test.go
@@ -55,8 +55,8 @@ func testDatabaseSeriesBlocksWithTimes(times []time.Time) *databaseSeriesBlocks 
 }
 
 func validateBlocks(t *testing.T, blocks *databaseSeriesBlocks, minTime, maxTime time.Time, expectedTimes []time.Time) {
-	require.Equal(t, minTime, blocks.MinTime())
-	require.Equal(t, maxTime, blocks.MaxTime())
+	require.True(t, minTime.Equal(blocks.MinTime()))
+	require.True(t, maxTime.Equal(blocks.MaxTime()))
 	allBlocks := blocks.elems
 	require.Equal(t, len(expectedTimes), len(allBlocks))
 	for _, timestamp := range expectedTimes {

--- a/storage/bootstrap/bootstrapper/fs/source.go
+++ b/storage/bootstrap/bootstrapper/fs/source.go
@@ -139,7 +139,7 @@ func (s *fileSystemSource) enqueueReaders(
 		readers := make([]fs.FileSetReader, 0, len(files))
 		for i := 0; i < len(files); i++ {
 			r := readerPool.get()
-			t := xtime.FromNanoseconds(files[i].Start)
+			t := xtime.FromNanoseconds(files[i].Start).Round(0).UTC()
 			if err := r.Open(namespace, shard, t); err != nil {
 				s.log.WithFields(
 					xlog.NewField("shard", shard),

--- a/storage/bootstrap/bootstrapper/fs/source_test.go
+++ b/storage/bootstrap/bootstrapper/fs/source_test.go
@@ -146,7 +146,7 @@ func validateTimeRanges(t *testing.T, tr xtime.Ranges, expected []xtime.Range) {
 	it := tr.Iter()
 	idx := 0
 	for it.Next() {
-		require.Equal(t, expected[idx], it.Value())
+		require.True(t, expected[idx].Equal(it.Value()))
 		idx++
 	}
 }

--- a/storage/bootstrap/bootstrapper/fs/source_test.go
+++ b/storage/bootstrap/bootstrapper/fs/source_test.go
@@ -404,7 +404,7 @@ func TestReadValidateError(t *testing.T) {
 	writeTSDBFiles(t, dir, testNs1ID, shard, testStart,
 		"foo", []byte{0x1})
 	reader.EXPECT().
-		Open(idMatcher, shard, testStart).
+		Open(idMatcher, shard, xtime.NewMatcher(testStart)).
 		Return(nil)
 	reader.EXPECT().
 		Range().
@@ -456,7 +456,7 @@ func TestReadDeleteOnError(t *testing.T) {
 
 	idMatcher := ts.NewIDMatcher(testNs1ID.String())
 	gomock.InOrder(
-		reader.EXPECT().Open(idMatcher, shard, testStart).Return(nil),
+		reader.EXPECT().Open(idMatcher, shard, xtime.NewMatcher(testStart)).Return(nil),
 		reader.EXPECT().
 			Range().
 			Return(xtime.Range{

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -447,7 +447,7 @@ func TestSeriesFetchBlocksMetadata(t *testing.T) {
 	}
 	require.Equal(t, len(expected), len(metadata))
 	for i := 0; i < len(expected); i++ {
-		require.Equal(t, expected[i].start, metadata[i].Start)
+		require.True(t, expected[i].start.Equal(metadata[i].Start))
 		require.Equal(t, expected[i].size, metadata[i].Size)
 		if expected[i].checksum == nil {
 			require.Nil(t, metadata[i].Checksum)


### PR DESCRIPTION
1) Add a linter to automatically detect usage of map[time.Time]
2) Fix remaining instances of map[time.Time]
3) Fix tests that do the equivalent of time.Time == time.Time
4) Add Go 1.9.2 to travis.yml