### PR TITLE
Make Mmap files handle mmap warning appropriately

### DIFF
--- a/persist/fs/mmap.go
+++ b/persist/fs/mmap.go
@@ -27,8 +27,6 @@ import (
 	xerrors "github.com/m3db/m3x/errors"
 )
 
-type mmapFdFuncType func(fd, offset, length int64, opts mmapOptions) (mmapResult, error)
-
 // Package-level global for easy mocking
 var mmapFdFunc = mmapFd
 

--- a/persist/fs/mmap.go
+++ b/persist/fs/mmap.go
@@ -29,6 +29,7 @@ import (
 
 type mmapFdFuncType func(fd, offset, length int64, opts mmapOptions) (mmapResult, error)
 
+// Package-level global for easy mocking
 var mmapFdFunc = mmapFd
 
 type mmapFileDesc struct {

--- a/persist/fs/mmap.go
+++ b/persist/fs/mmap.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Package-level global for easy mocking
-var mmapFdFunc = mmapFd
+var mmapFdFn = mmapFd
 
 type mmapFileDesc struct {
 	// file is the *os.File ref to store
@@ -117,7 +117,7 @@ func mmapFile(file *os.File, opts mmapOptions) (mmapResult, error) {
 	if stat.IsDir() {
 		return mmapResult{}, fmt.Errorf("mmap target is directory: %s", name)
 	}
-	return mmapFdFunc(int64(file.Fd()), 0, stat.Size(), opts)
+	return mmapFdFn(int64(file.Fd()), 0, stat.Size(), opts)
 }
 
 func errorWithFilename(name string, err error) error {

--- a/persist/fs/mmap.go
+++ b/persist/fs/mmap.go
@@ -81,7 +81,6 @@ func mmapFiles(opener fileOpener, files map[string]mmapFileDesc) (mmapFilesResul
 		}
 		if result.warning != nil {
 			multiWarn = multiWarn.Add(errorWithFilename(filePath, result.warning))
-			break
 		}
 
 		*desc.file = fd

--- a/persist/fs/mmap_test.go
+++ b/persist/fs/mmap_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fs
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestMmapFile(t *testing.T) {
+	fd, err := ioutil.TempFile("", "testfile")
+	assert.NoError(t, err)
+
+	result, err := mmapFile(fd, mmapOptions{})
+	assert.NoError(t, err)
+	assert.NoError(t, result.warning)
+	assert.Equal(t, []byte{}, result.result)
+
+	munmap(result.result)
+}
+
+func TestMmapFiles(t *testing.T) {
+	fd1, err := ioutil.TempFile("", "1")
+	assert.NoError(t, err)
+	fd1Path := fd1.Name()
+	fd2, err := ioutil.TempFile("", "2")
+	assert.NoError(t, err)
+	fd2Path := fd2.Name()
+
+	var (
+		bytes1 = []byte{}
+		bytes2 = []byte{}
+	)
+	result, err := mmapFiles(os.Open, map[string]mmapFileDesc{
+		fd1Path: mmapFileDesc{
+			file:    &fd1,
+			bytes:   &bytes1,
+			options: mmapOptions{},
+		},
+		fd2Path: mmapFileDesc{
+			file:    &fd2,
+			bytes:   &bytes2,
+			options: mmapOptions{},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.NoError(t, result.warning)
+}
+
+func TestMmapFilesHandlesError(t *testing.T) {
+	fd1, err := ioutil.TempFile("", "1")
+	assert.NoError(t, err)
+	fd1Path := fd1.Name()
+
+	fd2, err := ioutil.TempFile("", "doesnt-matter")
+	assert.NoError(t, err)
+	var (
+		bytes1 = []byte{}
+		bytes2 = []byte{}
+	)
+	_, err = mmapFiles(os.Open, map[string]mmapFileDesc{
+		fd1Path: mmapFileDesc{
+			file:    &fd1,
+			bytes:   &bytes1,
+			options: mmapOptions{},
+		},
+		"does_not_exist": mmapFileDesc{
+			file:    &fd2,
+			bytes:   &bytes2,
+			options: mmapOptions{},
+		},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestMmapFilesHandlesWarnings(t *testing.T) {
+	fd1, err := ioutil.TempFile("", "1")
+	assert.NoError(t, err)
+	fd1Path := fd1.Name()
+
+	bytes1 := []byte{}
+
+	warningFunc := func(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
+		return mmapResult{warning: errors.New("some-error"), result: []byte("a")}, nil
+	}
+	result, err := mmapFilesWithFunc(os.Open, map[string]mmapFileDesc{
+		fd1Path: mmapFileDesc{
+			file:    &fd1,
+			bytes:   &bytes1,
+			options: mmapOptions{},
+		},
+	}, warningFunc)
+
+	assert.NoError(t, err)
+	// Warning should be present AND byte slice pointer should have been
+	// modified as well
+	assert.Error(t, result.warning)
+	assert.Equal(t, []byte("a"), bytes1)
+}

--- a/persist/fs/mmap_test.go
+++ b/persist/fs/mmap_test.go
@@ -20,6 +20,8 @@
 
 package fs
 
+type mmapFDFuncType func(fd, offset, length int64, opts mmapOptions) (mmapResult, error)
+
 import (
 	"errors"
 	"github.com/stretchr/testify/assert"

--- a/persist/fs/mmap_test.go
+++ b/persist/fs/mmap_test.go
@@ -97,15 +97,17 @@ func TestMmapFilesHandlesError(t *testing.T) {
 }
 
 func TestMmapFilesHandlesWarnings(t *testing.T) {
+	mmapFdReturnWarn := func(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
+		return mmapResult{warning: errors.New("some-error"), result: []byte("a")}, nil
+	}
+	defer mockMmapFdFunc(mmapFdReturnWarn)()
+
 	fd1, err := ioutil.TempFile("", "1")
 	assert.NoError(t, err)
 	fd1Path := fd1.Name()
 
 	bytes1 := []byte{}
 
-	defer mockMmapFdFunc(func(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
-		return mmapResult{warning: errors.New("some-error"), result: []byte("a")}, nil
-	})()
 	result, err := mmapFiles(os.Open, map[string]mmapFileDesc{
 		fd1Path: mmapFileDesc{
 			file:    &fd1,

--- a/persist/fs/mmap_test.go
+++ b/persist/fs/mmap_test.go
@@ -20,8 +20,6 @@
 
 package fs
 
-type mmapFDFuncType func(fd, offset, length int64, opts mmapOptions) (mmapResult, error)
-
 import (
 	"errors"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +27,8 @@ import (
 	"os"
 	"testing"
 )
+
+type mmapFdFuncType func(fd, offset, length int64, opts mmapOptions) (mmapResult, error)
 
 func TestMmapFile(t *testing.T) {
 	fd, err := ioutil.TempFile("", "testfile")

--- a/persist/fs/mmap_test.go
+++ b/persist/fs/mmap_test.go
@@ -126,9 +126,9 @@ func TestMmapFilesHandlesWarnings(t *testing.T) {
 }
 
 func mockMmapFdFunc(f mmapFdFuncType) func() {
-	old := mmapFdFunc
-	mmapFdFunc = f
+	old := mmapFdFn
+	mmapFdFn = f
 	return func() {
-		mmapFdFunc = old
+		mmapFdFn = old
 	}
 }


### PR DESCRIPTION
  Should not break in warning case, otherwise file descriptor pointer doesn't get updated