### PR TITLE
Replace scanning through dataFD (using seek) with an mmap

### DIFF
--- a/persist/fs/fs.go
+++ b/persist/fs/fs.go
@@ -48,8 +48,9 @@ const (
 
 var (
 	// Use an easy marker for out of band analyzing the raw data files
-	marker    = []byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}
-	markerLen = len(marker)
+	marker      = []byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}
+	markerLen   = len(marker)
+	prologueLen = markerLen + idxLen
 
 	// Endianness is little endian
 	endianness = binary.LittleEndian

--- a/persist/fs/options.go
+++ b/persist/fs/options.go
@@ -261,6 +261,6 @@ func (o *options) SetMmapHugeTLBThreshold(value int64) Options {
 	return &opts
 }
 
-func (o *options) MmapHugePagesThreshold() int64 {
+func (o *options) MmapHugeTLBThreshold() int64 {
 	return o.mmapHugePagesThreshold
 }

--- a/persist/fs/read.go
+++ b/persist/fs/read.go
@@ -112,7 +112,7 @@ func NewReader(
 		filePathPrefix: opts.FilePathPrefix(),
 		hugePagesOpts: mmapHugeTLBOptions{
 			enabled:   opts.MmapEnableHugeTLB(),
-			threshold: opts.MmapHugePagesThreshold(),
+			threshold: opts.MmapHugeTLBThreshold(),
 		},
 		infoFdWithDigest:           digest.NewFdWithDigestReader(opts.InfoReaderBufferSize()),
 		digestFdWithDigestContents: digest.NewFdWithDigestContentsReader(opts.InfoReaderBufferSize()),

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -182,7 +182,6 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	}
 
 	// Mmap necessary files
-	// TODO: Handle hugeTLB
 	mmapResult, err := mmapFiles(os.Open, map[string]mmapFileDesc{
 		filesetPathFromTime(shardDir, blockStart, indexFileSuffix): mmapFileDesc{
 			file:  &indexFd,

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -182,23 +182,24 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	}
 
 	// Mmap necessary files
+	mmapOptions := mmapOptions{
+		read: true,
+		hugeTLB: mmapHugeTLBOptions{
+			enabled:   s.opts.MmapEnableHugeTLB(),
+			threshold: s.opts.MmapHugeTLBThreshold(),
+		},
+	}
 	mmapResult, err := mmapFiles(os.Open, map[string]mmapFileDesc{
 		filesetPathFromTime(shardDir, blockStart, indexFileSuffix): mmapFileDesc{
 			file:  &indexFd,
 			bytes: &s.indexMmap,
 			// Index files are small enough that they don't warrant hugeTLB
-			options: mmapOptions{read: true, hugeTLB: mmapHugeTLBOptions{enabled: false}},
+			options: mmapOptions,
 		},
 		filesetPathFromTime(shardDir, blockStart, dataFileSuffix): mmapFileDesc{
-			file:  &dataFd,
-			bytes: &s.dataMmap,
-			options: mmapOptions{
-				read: true,
-				hugeTLB: mmapHugeTLBOptions{
-					enabled:   s.opts.MmapEnableHugeTLB(),
-					threshold: s.opts.MmapHugeTLBThreshold(),
-				},
-			},
+			file:    &dataFd,
+			bytes:   &s.dataMmap,
+			options: mmapOptions,
 		},
 	})
 	if err != nil {

--- a/persist/fs/seek.go
+++ b/persist/fs/seek.go
@@ -207,7 +207,7 @@ func (s *seeker) Open(namespace ts.ID, shard uint32, blockStart time.Time) error
 	}
 	if warning := mmapResult.warning; warning != nil {
 		s.opts.InstrumentOptions().Logger().Warnf(
-			"warning while mmapping index file in seeker: %s", warning.Error())
+			"warning while mmaping files in seeker: %s", warning.Error())
 	}
 
 	// Setup digest readers

--- a/persist/fs/seek_test.go
+++ b/persist/fs/seek_test.go
@@ -98,7 +98,7 @@ func TestSeekDataUnexpectedSize(t *testing.T) {
 
 	_, err = s.SeekByID(ts.StringID("foo"))
 	assert.Error(t, err)
-	assert.Equal(t, errReadNotExpectedSize, err)
+	assert.Equal(t, errNotEnoughBytes, err)
 
 	assert.NoError(t, s.Close())
 }

--- a/persist/fs/types.go
+++ b/persist/fs/types.go
@@ -242,8 +242,8 @@ type Options interface {
 	// SetMmapHugeTLBThreshold sets the threshold when to use mmap huge pages for mmap'd files on linux
 	SetMmapHugeTLBThreshold(value int64) Options
 
-	// MmapHugePagesThreshold returns the threshold when to use mmap huge pages for mmap'd files on linux
-	MmapHugePagesThreshold() int64
+	// MmapHugeTLBThreshold returns the threshold when to use mmap huge pages for mmap'd files on linux
+	MmapHugeTLBThreshold() int64
 }
 
 // BlockRetrieverOptions represents the options for block retrieval


### PR DESCRIPTION
Instead of scanning through data files in the seeker using a file descriptor and the Seek() syscall, we can use mmap instead.