### PR TITLE
Refactor mmap into separate xpackage, and check if host supports HugeTLB on startup

### DIFF
--- a/persist/fs/read_test.go
+++ b/persist/fs/read_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3db/persist/fs/msgpack"
 	"github.com/m3db/m3db/persist/schema"
 	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3db/x/mmap"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/pool"
 
@@ -151,7 +152,7 @@ func TestReadDataError(t *testing.T) {
 
 	// Close out the dataFd and use a mock to expect an error on next read
 	reader := r.(*reader)
-	require.NoError(t, munmap(reader.dataMmap))
+	require.NoError(t, mmap.Munmap(reader.dataMmap))
 	require.NoError(t, reader.dataFd.Close())
 
 	mockReader := digest.NewMockReaderWithDigest(ctrl)
@@ -162,7 +163,7 @@ func TestReadDataError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Cleanly close
-	require.NoError(t, munmap(reader.indexMmap))
+	require.NoError(t, mmap.Munmap(reader.indexMmap))
 	require.NoError(t, reader.indexFd.Close())
 }
 

--- a/services/m3dbnode/server/server.go
+++ b/services/m3dbnode/server/server.go
@@ -167,7 +167,7 @@ func Run(runOpts RunOptions) {
 			logger.Fatalf("could not determine if host supports HugeTLB: %v", err)
 		}
 		if !shouldUseHugeTLB {
-			logger.Infof("Host doesn't support HugeTLB, proceeding without it")
+			logger.Warnf("host doesn't support HugeTLB, proceeding without it")
 		}
 	}
 

--- a/topology/dynamic_test.go
+++ b/topology/dynamic_test.go
@@ -37,7 +37,7 @@ import (
 func testSetup(ctrl *gomock.Controller) (DynamicOptions, *testWatch) {
 	opts := NewDynamicOptions()
 
-	watch := newTestWatch(ctrl, time.Millisecond, time.Millisecond, 10, 10)
+	watch := newTestWatch(ctrl, time.Millisecond, time.Millisecond, 100, 100)
 	mockCSServices := services.NewMockServices(ctrl)
 	mockCSServices.EXPECT().Watch(opts.ServiceID(), opts.QueryOptions()).Return(watch, nil)
 

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Fd mmaps a file
-func Fd(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
+func Fd(fd, offset, length int64, opts MmapOptions) (MmapResult, error) {
 	// MAP_PRIVATE because we only want to ever mmap immutable things and we don't
 	// ever want to propagate writes back to the underlying file
 	// Set HugeTLB to disabled because its not supported for files
@@ -35,19 +35,19 @@ func Fd(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
 }
 
 // Bytes requests a private (non-shared) region of anonymous (not backed by a file) memory from the O.S
-func Bytes(length int64, opts mmapOptions) (mmapResult, error) {
+func Bytes(length int64, opts MmapOptions) (MmapResult, error) {
 	// offset is 0 because we're not indexing into a file
 	// fd is -1 and MAP_ANON because we're asking for an anonymous region of memory not tied to a file
 	// MAP_PRIVATE because we don't plan on sharing this region of memory with other processes
 	return mmap(-1, 0, length, syscall.MAP_ANON|syscall.MAP_PRIVATE, opts)
 }
 
-func mmap(fd, offset, length int64, flags int, opts mmapOptions) (mmapResult, error) {
+func mmap(fd, offset, length int64, flags int, opts MmapOptions) (MmapResult, error) {
 	if length == 0 {
 		// Return an empty slice (but not nil so callers who
 		// use nil to mean something special like not initialized
 		// get back an actual ref)
-		return mmapResult{result: make([]byte, 0)}, nil
+		return MmapResult{result: make([]byte, 0)}, nil
 	}
 
 	var prot int
@@ -90,10 +90,10 @@ func mmap(fd, offset, length int64, flags int, opts mmapOptions) (mmapResult, er
 	}
 
 	if err != nil {
-		return mmapResult{}, fmt.Errorf("mmap error: %v", err)
+		return MmapResult{}, fmt.Errorf("mmap error: %v", err)
 	}
 
-	return mmapResult{result: b, warning: warning}, nil
+	return MmapResult{result: b, warning: warning}, nil
 }
 
 // Munmap munmaps a byte slice that is backed by an mmap

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -59,7 +59,7 @@ func mmap(fd, offset, length int64, flags int, opts Options) (Result, error) {
 	}
 
 	flagsWithoutHugeTLB := flags
-	shouldUseHugeTLB := opts.HugeTLB.enabled && length >= opts.HugeTLB.threshold
+	shouldUseHugeTLB := opts.HugeTLB.Enabled && length >= opts.HugeTLB.Threshold
 	if shouldUseHugeTLB {
 		// We use the MAP_HUGETLB flag instead of MADV_HUGEPAGE because transparent
 		// hugepages only work with anonymous, private pages. Please see the MADV_HUGEPAGE

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Fd mmaps a file
-func Fd(fd, offset, length int64, opts MmapOptions) (MmapResult, error) {
+func Fd(fd, offset, length int64, opts Options) (Result, error) {
 	// MAP_PRIVATE because we only want to ever mmap immutable things and we don't
 	// ever want to propagate writes back to the underlying file
 	// Set HugeTLB to disabled because its not supported for files
@@ -35,19 +35,19 @@ func Fd(fd, offset, length int64, opts MmapOptions) (MmapResult, error) {
 }
 
 // Bytes requests a private (non-shared) region of anonymous (not backed by a file) memory from the O.S
-func Bytes(length int64, opts MmapOptions) (MmapResult, error) {
+func Bytes(length int64, opts Options) (Result, error) {
 	// offset is 0 because we're not indexing into a file
 	// fd is -1 and MAP_ANON because we're asking for an anonymous region of memory not tied to a file
 	// MAP_PRIVATE because we don't plan on sharing this region of memory with other processes
 	return mmap(-1, 0, length, syscall.MAP_ANON|syscall.MAP_PRIVATE, opts)
 }
 
-func mmap(fd, offset, length int64, flags int, opts MmapOptions) (MmapResult, error) {
+func mmap(fd, offset, length int64, flags int, opts Options) (Result, error) {
 	if length == 0 {
 		// Return an empty slice (but not nil so callers who
 		// use nil to mean something special like not initialized
 		// get back an actual ref)
-		return MmapResult{result: make([]byte, 0)}, nil
+		return Result{result: make([]byte, 0)}, nil
 	}
 
 	var prot int
@@ -90,10 +90,10 @@ func mmap(fd, offset, length int64, flags int, opts MmapOptions) (MmapResult, er
 	}
 
 	if err != nil {
-		return MmapResult{}, fmt.Errorf("mmap error: %v", err)
+		return Result{}, fmt.Errorf("mmap error: %v", err)
 	}
 
-	return MmapResult{result: b, warning: warning}, nil
+	return Result{result: b, warning: warning}, nil
 }
 
 // Munmap munmaps a byte slice that is backed by an mmap

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -47,19 +47,19 @@ func mmap(fd, offset, length int64, flags int, opts Options) (Result, error) {
 		// Return an empty slice (but not nil so callers who
 		// use nil to mean something special like not initialized
 		// get back an actual ref)
-		return Result{result: make([]byte, 0)}, nil
+		return Result{Result: make([]byte, 0)}, nil
 	}
 
 	var prot int
-	if opts.read {
+	if opts.Read {
 		prot = prot | syscall.PROT_READ
 	}
-	if opts.write {
+	if opts.Write {
 		prot = prot | syscall.PROT_WRITE
 	}
 
 	flagsWithoutHugeTLB := flags
-	shouldUseHugeTLB := opts.hugeTLB.enabled && length >= opts.hugeTLB.threshold
+	shouldUseHugeTLB := opts.HugeTLB.enabled && length >= opts.HugeTLB.threshold
 	if shouldUseHugeTLB {
 		// We use the MAP_HUGETLB flag instead of MADV_HUGEPAGE because transparent
 		// hugepages only work with anonymous, private pages. Please see the MADV_HUGEPAGE
@@ -93,7 +93,7 @@ func mmap(fd, offset, length int64, flags int, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("mmap error: %v", err)
 	}
 
-	return Result{result: b, warning: warning}, nil
+	return Result{Result: b, Warning: warning}, nil
 }
 
 // Munmap munmaps a byte slice that is backed by an mmap

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -29,6 +29,8 @@ import (
 func Fd(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
 	// MAP_PRIVATE because we only want to ever mmap immutable things and we don't
 	// ever want to propagate writes back to the underlying file
+	// Set HugeTLB to disabled because its not supported for files
+	opts.HugeTLB.Enabled = false
 	return mmap(fd, offset, length, syscall.MAP_PRIVATE, opts)
 }
 

--- a/x/mmap/mmap_linux.go
+++ b/x/mmap/mmap_linux.go
@@ -18,22 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package fs
+package mmap
 
 import (
 	"fmt"
 	"syscall"
 )
 
-// mmapFd mmaps a file
-func mmapFd(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
+// Fd mmaps a file
+func Fd(fd, offset, length int64, opts mmapOptions) (mmapResult, error) {
 	// MAP_PRIVATE because we only want to ever mmap immutable things and we don't
 	// ever want to propagate writes back to the underlying file
 	return mmap(fd, offset, length, syscall.MAP_PRIVATE, opts)
 }
 
-// mmapBytes requests a private (non-shared) region of anonymous (not backed by a file) memory from the O.S
-func mmapBytes(length int64, opts mmapOptions) (mmapResult, error) {
+// Bytes requests a private (non-shared) region of anonymous (not backed by a file) memory from the O.S
+func Bytes(length int64, opts mmapOptions) (mmapResult, error) {
 	// offset is 0 because we're not indexing into a file
 	// fd is -1 and MAP_ANON because we're asking for an anonymous region of memory not tied to a file
 	// MAP_PRIVATE because we don't plan on sharing this region of memory with other processes
@@ -94,7 +94,8 @@ func mmap(fd, offset, length int64, flags int, opts mmapOptions) (mmapResult, er
 	return mmapResult{result: b, warning: warning}, nil
 }
 
-func munmap(b []byte) error {
+// Munmap munmaps a byte slice that is backed by an mmap
+func Munmap(b []byte) error {
 	if len(b) == 0 {
 		// Never actually mmapd this, just returned empty slice
 		return nil

--- a/x/mmap/mmap_other.go
+++ b/x/mmap/mmap_other.go
@@ -31,6 +31,8 @@ import (
 func Fd(fd, offset, length int64, opts Options) (Result, error) {
 	// MAP_PRIVATE because we only want to ever mmap immutable things and we don't
 	// ever want to propagate writes back to the underlying file
+	// Set HugeTLB to disabled because its not supported for files
+	opts.HugeTLB.Enabled = false
 	return mmap(fd, offset, length, syscall.MAP_PRIVATE, opts)
 }
 


### PR DESCRIPTION
Currently if the host doesn't support HugeTLB then there is a huge amount of log spam warning that HugeTLB is not supported and that we're falling back to not using it. This P.R changes it so that will only happen once at startup.