### PR TITLE
Use truncate instead of divide to decide bucket index

### DIFF
--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -194,7 +194,7 @@ func (b *dbBuffer) Write(
 }
 
 func (b *dbBuffer) writableBucketIdx(t time.Time) int {
-	return int(t.Truncate(b.blockSize).UnixNano() % bucketsLen)
+	return int(t.Truncate(b.blockSize).UnixNano() / int64(b.blockSize) % bucketsLen)
 }
 
 func (b *dbBuffer) IsEmpty() bool {

--- a/storage/series/buffer.go
+++ b/storage/series/buffer.go
@@ -194,7 +194,7 @@ func (b *dbBuffer) Write(
 }
 
 func (b *dbBuffer) writableBucketIdx(t time.Time) int {
-	return int((t.UnixNano() / int64(b.blockSize)) % bucketsLen)
+	return int(t.Truncate(b.blockSize).UnixNano() % bucketsLen)
 }
 
 func (b *dbBuffer) IsEmpty() bool {

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -536,6 +536,12 @@ func TestSeriesWriteReadFromTheSameBucket(t *testing.T) {
 	opts := newSeriesTestOptions()
 	opts = opts.SetRetentionOptions(opts.RetentionOptions().
 		SetRetentionPeriod(40 * 24 * time.Hour).
+		// A block size of 5 days is not equally as divisible as seconds from time zero and seconds from time epoch.
+		// now := time.Now()
+		// blockSize := 5 * 24 * time.Hour
+		// fmt.Println(now) -> 2018-01-24 14:29:31.624265 -0500 EST m=+0.003810489
+		// fmt.Println(now.Truncate(blockSize)) -> 2018-01-21 19:00:00 -0500 EST
+		// fmt.Println(time.Unix(0, now.UnixNano()/int64(blockSize)*int64(blockSize))) -> 2018-01-23 19:00:00 -0500 EST
 		SetBlockSize(5 * 24 * time.Hour).
 		SetBufferFuture(10 * time.Minute).
 		SetBufferPast(20 * time.Minute))


### PR DESCRIPTION
time.Truncate does not equal to a simple math division.
 
For example:
```
now := time.Now()
blockSize := 5 * 24 * time.Hour
fmt.Println(now)
fmt.Println(now.Truncate(blockSize))
fmt.Println(time.Unix(0, now.UnixNano()/int64(blockSize)*int64(blockSize)))
```
returns:
```
2018-01-24 14:29:31.624265 -0500 EST m=+0.003810489
2018-01-21 19:00:00 -0500 EST
2018-01-23 19:00:00 -0500 EST
```

That is because `Truncate returns the result of rounding t down to a multiple of d (since the zero time).`, where as `UnixNano returns t as a Unix time, the number of nanoseconds elapsed since January 1, 1970 UTC.`.

Since the start of each bucket are aligned using Truncate, we need to use Truncate when looking up which bucket to write to.

@xichen2020 @robskillington 