### PR TITLE
client.Session methods use `ts.ID`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -86,6 +86,10 @@ func (c *client) defaultSession() (AdminSession, error) {
 	return session, nil
 }
 
+func (c *client) Options() Options {
+	return c.opts
+}
+
 func (c *client) NewSession() (Session, error) {
 	return c.newSession()
 }

--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -66,6 +66,16 @@ func (_m *MockClient) EXPECT() *_MockClientRecorder {
 	return _m.recorder
 }
 
+func (_m *MockClient) Options() Options {
+	ret := _m.ctrl.Call(_m, "Options")
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) Options() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
+}
+
 func (_m *MockClient) NewSession() (Session, error) {
 	ret := _m.ctrl.Call(_m, "NewSession")
 	ret0, _ := ret[0].(Session)
@@ -119,7 +129,7 @@ func (_m *MockSession) EXPECT() *_MockSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockSession) Write(namespace ident.ID, id ident.ID, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -139,7 +149,7 @@ func (_mr *_MockSessionRecorder) WriteTagged(arg0, arg1, arg2, arg3, arg4, arg5,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteTagged", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockSession) Fetch(namespace ident.ID, id ident.ID, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -150,15 +160,15 @@ func (_mr *_MockSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
-	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
+func (_m *MockSession) FetchIDs(namespace ident.ID, ids ident.Iterator, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+	ret := _m.ctrl.Call(_m, "FetchIDs", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
+func (_mr *_MockSessionRecorder) FetchIDs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchIDs", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
@@ -183,7 +193,7 @@ func (_mr *_MockSessionRecorder) FetchTaggedIDs(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchTaggedIDs", arg0, arg1)
 }
 
-func (_m *MockSession) ShardID(id string) (uint32, error) {
+func (_m *MockSession) ShardID(id ident.ID) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
 	ret1, _ := ret[1].(error)
@@ -223,6 +233,16 @@ func NewMockAdminClient(ctrl *gomock.Controller) *MockAdminClient {
 
 func (_m *MockAdminClient) EXPECT() *_MockAdminClientRecorder {
 	return _m.recorder
+}
+
+func (_m *MockAdminClient) Options() Options {
+	ret := _m.ctrl.Call(_m, "Options")
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+func (_mr *_MockAdminClientRecorder) Options() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Options")
 }
 
 func (_m *MockAdminClient) NewSession() (Session, error) {
@@ -405,7 +425,7 @@ func (_m *MockAdminSession) EXPECT() *_MockAdminSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAdminSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockAdminSession) Write(namespace ident.ID, id ident.ID, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -425,7 +445,7 @@ func (_mr *_MockAdminSessionRecorder) WriteTagged(arg0, arg1, arg2, arg3, arg4, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteTagged", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockAdminSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockAdminSession) Fetch(namespace ident.ID, id ident.ID, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -436,15 +456,15 @@ func (_mr *_MockAdminSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockAdminSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
-	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
+func (_m *MockAdminSession) FetchIDs(namespace ident.ID, ids ident.Iterator, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+	ret := _m.ctrl.Call(_m, "FetchIDs", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockAdminSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
+func (_mr *_MockAdminSessionRecorder) FetchIDs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchIDs", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockAdminSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
@@ -469,7 +489,7 @@ func (_mr *_MockAdminSessionRecorder) FetchTaggedIDs(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchTaggedIDs", arg0, arg1)
 }
 
-func (_m *MockAdminSession) ShardID(id string) (uint32, error) {
+func (_m *MockAdminSession) ShardID(id ident.ID) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
 	ret1, _ := ret[1].(error)
@@ -575,7 +595,7 @@ func (_m *MockclientSession) EXPECT() *_MockclientSessionRecorder {
 	return _m.recorder
 }
 
-func (_m *MockclientSession) Write(namespace string, id string, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
+func (_m *MockclientSession) Write(namespace ident.ID, id ident.ID, t time.Time, value float64, unit time0.Unit, annotation []byte) error {
 	ret := _m.ctrl.Call(_m, "Write", namespace, id, t, value, unit, annotation)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -595,7 +615,7 @@ func (_mr *_MockclientSessionRecorder) WriteTagged(arg0, arg1, arg2, arg3, arg4,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WriteTagged", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockclientSession) Fetch(namespace string, id string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
+func (_m *MockclientSession) Fetch(namespace ident.ID, id ident.ID, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterator, error) {
 	ret := _m.ctrl.Call(_m, "Fetch", namespace, id, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterator)
 	ret1, _ := ret[1].(error)
@@ -606,15 +626,15 @@ func (_mr *_MockclientSessionRecorder) Fetch(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Fetch", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockclientSession) FetchAll(namespace string, ids []string, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
-	ret := _m.ctrl.Call(_m, "FetchAll", namespace, ids, startInclusive, endExclusive)
+func (_m *MockclientSession) FetchIDs(namespace ident.ID, ids ident.Iterator, startInclusive time.Time, endExclusive time.Time) (encoding.SeriesIterators, error) {
+	ret := _m.ctrl.Call(_m, "FetchIDs", namespace, ids, startInclusive, endExclusive)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockclientSessionRecorder) FetchAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchAll", arg0, arg1, arg2, arg3)
+func (_mr *_MockclientSessionRecorder) FetchIDs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchIDs", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockclientSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
@@ -639,7 +659,7 @@ func (_mr *_MockclientSessionRecorder) FetchTaggedIDs(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchTaggedIDs", arg0, arg1)
 }
 
-func (_m *MockclientSession) ShardID(id string) (uint32, error) {
+func (_m *MockclientSession) ShardID(id ident.ID) (uint32, error) {
 	ret := _m.ctrl.Call(_m, "ShardID", id)
 	ret0, _ := ret[0].(uint32)
 	ret1, _ := ret[1].(error)

--- a/client/fetch_attempt.go
+++ b/client/fetch_attempt.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/m3db/m3db/encoding"
 	xerrors "github.com/m3db/m3x/errors"
+	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/pool"
 	xretry "github.com/m3db/m3x/retry"
 )
@@ -42,8 +43,8 @@ type fetchAttempt struct {
 }
 
 type fetchAttemptArgs struct {
-	namespace string
-	ids       []string
+	namespace ident.ID
+	ids       ident.Iterator
 	start     time.Time
 	end       time.Time
 }
@@ -54,7 +55,7 @@ func (f *fetchAttempt) reset() {
 }
 
 func (f *fetchAttempt) perform() error {
-	result, err := f.session.fetchAllAttempt(f.args.namespace,
+	result, err := f.session.fetchIDsAttempt(f.args.namespace,
 		f.args.ids, f.args.start, f.args.end)
 	f.result = result
 

--- a/client/session.go
+++ b/client/session.go
@@ -906,7 +906,11 @@ func (s *session) fetchIDsAttempt(
 	// NB(prateek): need to make a copy of inputNamespace and inputIDs to control
 	// their life-cycle within this function.
 	namespace := s.idPool.Clone(inputNamespace)
+	// First, we clone the iterator (only the struct referencing the underlying slice,
+	// not the slice itself). Need this to be able to iterate the original iterator
+	// multiple times in case of retries.
 	idsClone := inputIDs.Clone()
+	// Now we actually clones the ids in the slice.
 	ids := s.idPool.CloneIDs(idsClone)
 
 	// can release cloned iterator as we have a copy of underlying IDs.

--- a/client/session_fetch_high_concurrency_test.go
+++ b/client/session_fetch_high_concurrency_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3db/topology"
 	"github.com/m3db/m3db/ts"
 	xclose "github.com/m3db/m3x/close"
+	"github.com/m3db/m3x/ident"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"
@@ -46,7 +47,7 @@ type noopCloser struct{}
 
 func (noopCloser) Close() {}
 
-func TestSessionFetchAllHighConcurrency(t *testing.T) {
+func TestSessionFetchIDsHighConcurrency(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -186,7 +187,8 @@ func TestSessionFetchAllHighConcurrency(t *testing.T) {
 
 			for j := 0; j < fetchAllEach; j++ {
 				ids := fetchAllTypes[j%len(fetchAllTypes)].ids
-				iters, err := session.FetchAll(testNamespaceName, ids, start, end)
+				iters, err := session.FetchIDs(ident.StringID(testNamespaceName),
+					ident.NewStringIDsSliceIterator(ids), start, end)
 				if err != nil {
 					panic(err)
 				}

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -117,7 +117,7 @@ func TestSessionShardID(t *testing.T) {
 	s, err := newSession(opts)
 	assert.NoError(t, err)
 
-	_, err = s.ShardID("foo")
+	_, err = s.ShardID(ident.StringID("foo"))
 	assert.Error(t, err)
 	assert.Equal(t, errSessionStateNotOpen, err)
 
@@ -126,7 +126,7 @@ func TestSessionShardID(t *testing.T) {
 	require.NoError(t, s.Open())
 
 	// The shard set we create in newSessionTestOptions always hashes to uint32
-	shard, err := s.ShardID("foo")
+	shard, err := s.ShardID(ident.StringID("foo"))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), shard)
 

--- a/client/types.go
+++ b/client/types.go
@@ -183,6 +183,9 @@ func (l *ReadConsistencyLevel) UnmarshalYAML(unmarshal func(interface{}) error) 
 
 // Client can create sessions to write and read to a cluster
 type Client interface {
+	// Options returns the Client Options.
+	Options() Options
+
 	// NewSession creates a new session
 	NewSession() (Session, error)
 
@@ -196,16 +199,16 @@ type Client interface {
 // Session can write and read to a cluster
 type Session interface {
 	// Write value to the database for an ID
-	Write(namespace string, id string, t time.Time, value float64, unit xtime.Unit, annotation []byte) error
+	Write(namespace ident.ID, id ident.ID, t time.Time, value float64, unit xtime.Unit, annotation []byte) error
 
 	// WriteTagged value to the database for an ID and given tags.
 	WriteTagged(namespace string, id string, tags ident.TagIterator, t time.Time, value float64, unit xtime.Unit, annotation []byte) error
 
 	// Fetch values from the database for an ID
-	Fetch(namespace string, id string, startInclusive, endExclusive time.Time) (encoding.SeriesIterator, error)
+	Fetch(namespace ident.ID, id ident.ID, startInclusive, endExclusive time.Time) (encoding.SeriesIterator, error)
 
-	// FetchAll values from the database for a set of IDs
-	FetchAll(namespace string, ids []string, startInclusive, endExclusive time.Time) (encoding.SeriesIterators, error)
+	// FetchIDs values from the database for a set of IDs
+	FetchIDs(namespace ident.ID, ids ident.Iterator, startInclusive, endExclusive time.Time) (encoding.SeriesIterators, error)
 
 	// FetchTagged resolves the provided query to known IDs, and fetches the data for them.
 	FetchTagged(index.Query, index.QueryOptions) (index.QueryResults, error)
@@ -216,7 +219,7 @@ type Session interface {
 	// ShardID returns the given shard for an ID for callers
 	// to easily discern what shard is failing when operations
 	// for given IDs begin failing
-	ShardID(id string) (uint32, error)
+	ShardID(id ident.ID) (uint32, error)
 
 	// Close the session
 	Close() error

--- a/client/write_attempt.go
+++ b/client/write_attempt.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	xerrors "github.com/m3db/m3x/errors"
+	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/pool"
 	xretry "github.com/m3db/m3x/retry"
 	xtime "github.com/m3db/m3x/time"
@@ -40,8 +41,8 @@ type writeAttempt struct {
 }
 
 type writeAttemptArgs struct {
-	namespace  string
-	id         string
+	namespace  ident.ID
+	id         ident.ID
 	t          time.Time
 	value      float64
 	unit       xtime.Unit

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/m3db/m3cluster/shard"
 	tterrors "github.com/m3db/m3db/network/server/tchannelthrift/errors"
 	"github.com/m3db/m3db/topology"
-	"github.com/m3db/m3x/context"
 	xerrors "github.com/m3db/m3x/errors"
 
 	"github.com/golang/mock/gomock"
@@ -125,12 +124,13 @@ func TestShardNotAvailable(t *testing.T) {
 
 // utils
 
-func getWriteState(s *session) *writeState {
+func getWriteState(s *session, w writeStub) *writeState {
 	wState := s.writeStatePool.Get()
-	wState.ctx = context.NewContext()
 	wState.topoMap = s.topoMap
 	wState.op = s.writeOpPool.Get()
 	wState.op.shardID = 0 // Any valid shardID
+	wState.nsID = w.ns
+	wState.tsID = w.id
 	return wState
 }
 
@@ -168,7 +168,7 @@ func writeTestSetup(t *testing.T, writeWg *sync.WaitGroup) (*writeState, *sessio
 
 	host := s.topoMap.Hosts()[0] // any host
 
-	wState := getWriteState(s)
+	wState := getWriteState(s, w)
 	wState.incRef() // for the test
 	wState.incRef() // allow introspection
 

--- a/encoding/encoding_mock.go
+++ b/encoding/encoding_mock.go
@@ -553,24 +553,14 @@ func (_mr *_MockSeriesIteratorRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockSeriesIterator) ID() string {
+func (_m *MockSeriesIterator) ID() ident.ID {
 	ret := _m.ctrl.Call(_m, "ID")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(ident.ID)
 	return ret0
 }
 
 func (_mr *_MockSeriesIteratorRecorder) ID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ID")
-}
-
-func (_m *MockSeriesIterator) Tags() ident.TagIterator {
-	ret := _m.ctrl.Call(_m, "Tags")
-	ret0, _ := ret[0].(ident.TagIterator)
-	return ret0
-}
-
-func (_mr *_MockSeriesIteratorRecorder) Tags() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tags")
 }
 
 func (_m *MockSeriesIterator) Namespace() ident.ID {
@@ -581,6 +571,16 @@ func (_m *MockSeriesIterator) Namespace() ident.ID {
 
 func (_mr *_MockSeriesIteratorRecorder) Namespace() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Namespace")
+}
+
+func (_m *MockSeriesIterator) Tags() ident.TagIterator {
+	ret := _m.ctrl.Call(_m, "Tags")
+	ret0, _ := ret[0].(ident.TagIterator)
+	return ret0
+}
+
+func (_mr *_MockSeriesIteratorRecorder) Tags() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Tags")
 }
 
 func (_m *MockSeriesIterator) Start() time.Time {
@@ -603,12 +603,12 @@ func (_mr *_MockSeriesIteratorRecorder) End() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "End")
 }
 
-func (_m *MockSeriesIterator) Reset(id string, startInclusive time.Time, endExclusive time.Time, replicas []Iterator) {
-	_m.ctrl.Call(_m, "Reset", id, startInclusive, endExclusive, replicas)
+func (_m *MockSeriesIterator) Reset(id ident.ID, ns ident.ID, startInclusive time.Time, endExclusive time.Time, replicas []Iterator) {
+	_m.ctrl.Call(_m, "Reset", id, ns, startInclusive, endExclusive, replicas)
 }
 
-func (_mr *_MockSeriesIteratorRecorder) Reset(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0, arg1, arg2, arg3)
+func (_mr *_MockSeriesIteratorRecorder) Reset(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Reset", arg0, arg1, arg2, arg3, arg4)
 }
 
 // Mock of SeriesIterators interface

--- a/encoding/series_iterator_pool.go
+++ b/encoding/series_iterator_pool.go
@@ -41,7 +41,7 @@ func NewSeriesIteratorPool(opts pool.ObjectPoolOptions) SeriesIteratorPool {
 
 func (p *seriesIteratorPool) Init() {
 	p.pool.Init(func() interface{} {
-		return NewSeriesIterator("", timeZero, timeZero, nil, p)
+		return NewSeriesIterator(nil, nil, timeZero, timeZero, nil, p)
 	})
 }
 

--- a/encoding/series_iterator_test.go
+++ b/encoding/series_iterator_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3x/ident"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ import (
 
 type testSeries struct {
 	id          string
+	nsID        string
 	start       time.Time
 	end         time.Time
 	input       [][]testValue
@@ -67,6 +69,7 @@ func TestMultiReaderMergesReplicas(t *testing.T) {
 
 	test := testSeries{
 		id:       "foo",
+		nsID:     "bar",
 		start:    start,
 		end:      end,
 		input:    values,
@@ -91,6 +94,7 @@ func TestMultiReaderFiltersToRange(t *testing.T) {
 
 	test := testSeries{
 		id:       "foo",
+		nsID:     "bar",
 		start:    start,
 		end:      end,
 		input:    [][]testValue{values, values, values},
@@ -112,6 +116,7 @@ func TestSeriesIteratorIgnoresEmptyReplicas(t *testing.T) {
 
 	test := testSeries{
 		id:       "foo",
+		nsID:     "bar",
 		start:    start,
 		end:      end,
 		input:    [][]testValue{values, []testValue{}, values},
@@ -133,6 +138,7 @@ func TestSeriesIteratorErrorOnOutOfOrder(t *testing.T) {
 
 	test := testSeries{
 		id:       "foo",
+		nsID:     "bar",
 		start:    start,
 		end:      end,
 		input:    [][]testValue{values},
@@ -159,10 +165,11 @@ func assertTestSeriesIterator(
 		}
 	}
 
-	iter := NewSeriesIterator(series.id, series.start, series.end, iters, nil)
+	iter := NewSeriesIterator(ident.StringID(series.id), ident.StringID(series.nsID), series.start, series.end, iters, nil)
 	defer iter.Close()
 
-	assert.Equal(t, series.id, iter.ID())
+	assert.Equal(t, series.id, iter.ID().String())
+	assert.Equal(t, series.nsID, iter.Namespace().String())
 	assert.Equal(t, series.start, iter.Start())
 	assert.Equal(t, series.end, iter.End())
 	for i := 0; i < len(series.expected); i++ {

--- a/encoding/types.go
+++ b/encoding/types.go
@@ -148,13 +148,13 @@ type SeriesIterator interface {
 	Iterator
 
 	// ID gets the ID of the series
-	ID() string
+	ID() ident.ID
+
+	// Namespace gets the namespace of the series
+	Namespace() ident.ID
 
 	// Tags returns an iterator over the tags associated with the ID.
 	Tags() ident.TagIterator
-
-	// Namespace returns the namespace associated with the ID.
-	Namespace() ident.ID
 
 	// Start returns the start time filter specified for the iterator
 	Start() time.Time
@@ -163,8 +163,10 @@ type SeriesIterator interface {
 	End() time.Time
 
 	// Reset resets the iterator to read from a set of iterators from different replicas, one
-	// must note that this can be an array with nil entries if some replicas did not return successfully
-	Reset(id string, startInclusive, endExclusive time.Time, replicas []Iterator)
+	// must note that this can be an array with nil entries if some replicas did not return successfully.
+	// NB: the SeriesIterator assumes ownership of the provided ids, this includes calling `id.Finalize()` upon
+	// iter.Close().
+	Reset(id ident.ID, ns ident.ID, startInclusive, endExclusive time.Time, replicas []Iterator)
 }
 
 // SeriesIterators is a collection of SeriesIterator that can close all iterators

--- a/generated/thrift/rpc/GoUnusedProtection__.go
+++ b/generated/thrift/rpc/GoUnusedProtection__.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,5 +23,4 @@
 
 package rpc
 
-var GoUnusedProtection__ int;
-
+var GoUnusedProtection__ int

--- a/generated/thrift/rpc/rpc-consts.go
+++ b/generated/thrift/rpc/rpc-consts.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ package rpc
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/apache/thrift/lib/go/thrift"
 )
 

--- a/generated/thrift/rpc/rpc.go
+++ b/generated/thrift/rpc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+
 	"github.com/apache/thrift/lib/go/thrift"
 )
 

--- a/generated/thrift/rpc/tchan-rpc.go
+++ b/generated/thrift/rpc/tchan-rpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/glide.lock
+++ b/glide.lock
@@ -185,7 +185,7 @@ imports:
   - doc
   - index/segment
 - name: github.com/m3db/m3x
-  version: 7ea8c2f35f9fa0f52bd189e44b11113d708acada
+  version: 870290a8e708beb5e2ea2165d0c4517ddc8ca534
   vcs: git
   subpackages:
   - checked

--- a/glide.yaml
+++ b/glide.yaml
@@ -62,7 +62,7 @@ import:
   - integration/etcd
 
 - package: github.com/m3db/m3x
-  version: 7ea8c2f35f9fa0f52bd189e44b11113d708acada
+  version: 870290a8e708beb5e2ea2165d0c4517ddc8ca534
   vcs: git
   subpackages:
   - checked

--- a/integration/client.go
+++ b/integration/client.go
@@ -122,7 +122,7 @@ func m3dbClientWriteBatch(client client.Client, workerPool xsync.WorkerPool, nam
 				defer wg.Done()
 
 				if err := session.Write(
-					namespace.String(), id.String(), d.Timestamp, d.Value, xtime.Second, nil); err != nil {
+					namespace, id, d.Timestamp, d.Value, xtime.Second, nil); err != nil {
 					select {
 					case errCh <- err:
 					default:
@@ -146,8 +146,8 @@ func m3dbClientFetch(client client.Client, req *rpc.FetchRequest) ([]ts.Datapoin
 	}
 
 	iter, err := session.Fetch(
-		req.NameSpace,
-		req.ID,
+		ident.StringID(req.NameSpace),
+		ident.StringID(req.ID),
 		xtime.FromNormalizedTime(req.RangeStart, time.Second),
 		xtime.FromNormalizedTime(req.RangeEnd, time.Second),
 	)

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -215,7 +215,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, v := range values {
-		err := session.Write(namespaceID, "foo", v.at, v.value, v.unit, nil)
+		err := session.Write(ident.StringID(namespaceID), ident.StringID("foo"), v.at, v.value, v.unit, nil)
 		require.NoError(t, err)
 	}
 
@@ -226,7 +226,7 @@ func TestConfig(t *testing.T) {
 	// the "end" param to fetch being exclusive
 	fetchEnd := values[len(values)-1].at.Truncate(time.Second).Add(time.Nanosecond)
 
-	iter, err := session.Fetch(namespaceID, "foo", fetchStart, fetchEnd)
+	iter, err := session.Fetch(ident.StringID(namespaceID), ident.StringID("foo"), fetchStart, fetchEnd)
 	require.NoError(t, err)
 
 	for _, v := range values {

--- a/integration/write_quorum_test.go
+++ b/integration/write_quorum_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3db/client"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3x/ident"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/assert"
@@ -227,7 +228,7 @@ func makeTestWrite(
 		s, err := c.NewSession()
 		require.NoError(t, err)
 
-		return s.Write(nspaces[0].ID().String(), "quorumTest", now, 42, xtime.Second, nil)
+		return s.Write(nspaces[0].ID(), ident.StringID("quorumTest"), now, 42, xtime.Second, nil)
 	}
 
 	return nodes, closeFn, testWrite

--- a/integration/write_read_timezone_test.go
+++ b/integration/write_read_timezone_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3x/ident"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
@@ -137,13 +138,15 @@ func TestWriteReadTimezone(t *testing.T) {
 	// Write datapoints
 	for _, series := range writeSeries {
 		for _, write := range series.datapoints {
-			err = session.Write(series.namespace, series.id, write.timestamp, write.value, xtime.Second, nil)
+			err = session.Write(ident.StringID(series.namespace), ident.StringID(series.id), write.timestamp, write.value, xtime.Second, nil)
 			require.NoError(t, err)
 		}
 	}
 
 	// Read datapoints back
-	iters, err := session.FetchAll(namespace, []string{"some-id-1", "some-id-2"}, startNy, startNy.Add(1*time.Hour))
+	iters, err := session.FetchIDs(ident.StringID(namespace),
+		ident.NewIDsIterator(ident.StringID("some-id-1"), ident.StringID("some-id-2")),
+		startNy, startNy.Add(1*time.Hour))
 	require.NoError(t, err)
 
 	// Assert datapoints match what we wrote

--- a/storage/series/series_test.go
+++ b/storage/series/series_test.go
@@ -480,6 +480,7 @@ func TestSeriesOutOfOrderWritesAndRotate(t *testing.T) {
 	var (
 		ctx        = context.NewContext()
 		id         = ident.StringID("foo")
+		nsID       = ident.StringID("bar")
 		startValue = 1.0
 		blockSize  = opts.RetentionOptions().BlockSize()
 		numPoints  = 10
@@ -520,7 +521,7 @@ func TestSeriesOutOfOrderWritesAndRotate(t *testing.T) {
 
 	multiIt := opts.MultiReaderIteratorPool().Get()
 	multiIt.ResetSliceOfSlices(xio.NewReaderSliceOfSlicesFromSegmentReadersIterator(encoded))
-	it := encoding.NewSeriesIterator(id.String(), qStart, qEnd, []encoding.Iterator{multiIt}, nil)
+	it := encoding.NewSeriesIterator(id, nsID, qStart, qEnd, []encoding.Iterator{multiIt}, nil)
 	defer it.Close()
 
 	var actual []ts.Datapoint


### PR DESCRIPTION
Changes:
- Changes all API methods in `client/Session` to use `ts.ID` (instead of string) for both namespace and metric ID
- Adds a ts.ID iterator type

/cc @robskillington @richardartoul @jeromefroe 