### PR TITLE
Enable expensive integration tests in CI

### DIFF
--- a/integration/peers_bootstrap_high_concurrency_test.go
+++ b/integration/peers_bootstrap_high_concurrency_test.go
@@ -1,4 +1,4 @@
-// +build integration_disabled
+// +build integration
 
 // Copyright (c) 2016 Uber Technologies, Inc.
 //

--- a/integration/peers_bootstrap_v2_high_concurrency_test.go
+++ b/integration/peers_bootstrap_v2_high_concurrency_test.go
@@ -1,4 +1,4 @@
-// +build integration_disabled
+// +build integration
 
 // Copyright (c) 2017 Uber Technologies, Inc.
 //


### PR DESCRIPTION
re-enabling expensive integration tests in the CI. This does make builds run about 2-3 minutes longer, and flakier. 