### PR TITLE
Extract checked bytes wrapper pool into `x/xpool`

### DIFF
--- a/x/xpool/pool.go
+++ b/x/xpool/pool.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xpool
+
+import (
+	"github.com/m3db/m3x/checked"
+	"github.com/m3db/m3x/pool"
+)
+
+type checkedPool struct {
+	pool pool.ObjectPool
+	opts checked.BytesOptions
+}
+
+// NewCheckedBytesWrapperPool returns a new CheckedBytesWrapperPool with the
+// defined size.
+func NewCheckedBytesWrapperPool(size int) CheckedBytesWrapperPool {
+	p := pool.NewObjectPool(
+		pool.NewObjectPoolOptions().SetSize(size))
+
+	opts := checked.NewBytesOptions().SetFinalizer(
+		checked.BytesFinalizerFn(func(b checked.Bytes) {
+			b.IncRef()
+			b.Reset(nil)
+			b.DecRef()
+			p.Put(b)
+		}))
+
+	return &checkedPool{
+		pool: p,
+		opts: opts,
+	}
+}
+
+func (p *checkedPool) Init() {
+	p.pool.Init(func() interface{} {
+		return checked.NewBytes(nil, p.opts)
+	})
+}
+
+func (p *checkedPool) Get(b []byte) checked.Bytes {
+	checkedBytes := p.pool.Get().(checked.Bytes)
+	checkedBytes.IncRef()
+	checkedBytes.Reset(b)
+	checkedBytes.DecRef()
+	return checkedBytes
+}

--- a/x/xpool/pool_test.go
+++ b/x/xpool/pool_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xpool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testPool() CheckedBytesWrapperPool {
+	p := NewCheckedBytesWrapperPool(1)
+	p.Init()
+	return p
+}
+
+func TestCheckedBytesWrapperPool(t *testing.T) {
+	initBytes := []byte("some-string")
+
+	pool := testPool()
+	cb := pool.Get(initBytes)
+
+	cb.IncRef()
+	require.Equal(t, initBytes, cb.Get())
+	cb.DecRef()
+
+	cb.Finalize()
+	cb.IncRef()
+	require.Nil(t, cb.Get())
+	cb.DecRef()
+	require.Equal(t, []byte("some-string"), initBytes)
+}

--- a/x/xpool/types.go
+++ b/x/xpool/types.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xpool
+
+import (
+	"github.com/m3db/m3x/checked"
+)
+
+// CheckedBytesWrapperPool allows users to wrap []byte which have been
+// allocated by other libraries (e.g. thrift/t-channel) with a checked.Bytes
+// abstraction. This is to ensure we reference count usage, and more importantly,
+// can interop with the rest of the M3DB codebase (which requires checked.Bytes).
+// NB: This pool doesn't require a Put method, as Finalizing the bytes returned from
+// Get does the Put internally.
+type CheckedBytesWrapperPool interface {
+	Init()
+
+	Get([]byte) checked.Bytes
+}


### PR DESCRIPTION
This pool is currently only used by `network/server/tchannelthrift/node/service`, a subsequent PR requires it in a new package (`serialize` which does tag encoding/decoding) too. Doing the extraction in this PR to keep the review small.

/cc @robskillington 