### PR TITLE
Embedded KV cluster

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -154,7 +154,7 @@ func (c Configuration) NewAdminClient(
 	var err error
 	if envCfg.TopologyInitializer == nil {
 		switch {
-		case c.EnvironmentConfig.Service != nil:
+		case c.EnvironmentConfig.Static == nil && c.EnvironmentConfig.KV != nil:
 
 			envCfg, err = c.EnvironmentConfig.Configure(environment.ConfigurationParameters{
 				InstrumentOpts: iopts,
@@ -165,7 +165,7 @@ func (c Configuration) NewAdminClient(
 				return nil, err
 			}
 
-		case c.EnvironmentConfig.Static != nil:
+		case c.EnvironmentConfig.Static != nil && c.EnvironmentConfig.KV != nil:
 
 			envCfg, err = c.EnvironmentConfig.Configure(environment.ConfigurationParameters{})
 			if err != nil {

--- a/client/config.go
+++ b/client/config.go
@@ -153,27 +153,24 @@ func (c Configuration) NewAdminClient(
 
 	var err error
 	if envCfg.TopologyInitializer == nil {
-		switch {
-		case c.EnvironmentConfig.Static == nil && c.EnvironmentConfig.KV != nil:
-
+		if c.EnvironmentConfig.Service != nil {
 			envCfg, err = c.EnvironmentConfig.Configure(environment.ConfigurationParameters{
 				InstrumentOpts: iopts,
 				HashingSeed:    c.HashingConfiguration.Seed,
 			})
+
 			if err != nil {
 				err = fmt.Errorf("unable to create dynamic topology initializer, err: %v", err)
 				return nil, err
 			}
-
-		case c.EnvironmentConfig.Static != nil && c.EnvironmentConfig.KV != nil:
-
+		} else if c.EnvironmentConfig.Static != nil {
 			envCfg, err = c.EnvironmentConfig.Configure(environment.ConfigurationParameters{})
+
 			if err != nil {
 				err = fmt.Errorf("unable to create static topology initializer, err: %v", err)
 				return nil, err
 			}
-
-		default:
+		} else {
 			return nil, errConfigurationMustSupplyConfig
 		}
 	}

--- a/environment/config.go
+++ b/environment/config.go
@@ -65,13 +65,24 @@ type Configuration struct {
 
 // EmbeddedKV defines specific fields for the embedded kv server
 type EmbeddedKV struct {
-	Dir            string   `yaml:"dir"`
-	APUrls         []string `yaml:"initialAdvertisePeerUrls"`
-	ACUrls         []string `yaml:"advertiseClientUrls"`
-	LPUrls         []string `yaml:"listenPeerUrls"`
-	LCUrls         []string `yaml:"listenClientUrls"`
-	InitialCluster string   `yaml:"initialCluster"`
-	Name           string   `yaml:"name"`
+	Dir                string     `yaml:"dir"`
+	APUrls             []string   `yaml:"initialAdvertisePeerUrls"`
+	ACUrls             []string   `yaml:"advertiseClientUrls"`
+	LPUrls             []string   `yaml:"listenPeerUrls"`
+	LCUrls             []string   `yaml:"listenClientUrls"`
+	InitialCluster     string     `yaml:"initialCluster"`
+	Name               string     `yaml:"name"`
+	ClientSecurityJSON KVSecurity `json:"client-transport-security"`
+	PeerSecurityJSON   KVSecurity `json:"peer-transport-security"`
+}
+
+type KVSecurity struct {
+	CAFile        string `json:"ca-file"`
+	CertFile      string `json:"cert-file"`
+	KeyFile       string `json:"key-file"`
+	CertAuth      bool   `json:"client-cert-auth"`
+	TrustedCAFile string `json:"trusted-ca-file"`
+	AutoTLS       bool   `json:"auto-tls"`
 }
 
 // StaticConfiguration is used for running M3DB with a static config

--- a/environment/config.go
+++ b/environment/config.go
@@ -143,13 +143,14 @@ type ConfigurationParameters struct {
 func (c Configuration) Configure(cfgParams ConfigurationParameters) (ConfigureResults, error) {
 	var emptyConfig ConfigureResults
 
-	if c.Service.SDConfig.InitTimeout == 0 {
-		c.Service.SDConfig.InitTimeout = defaultSDTimeout
+	sdTimeout := defaultSDTimeout
+	if initTimeout := c.Service.SDConfig.InitTimeout; initTimeout != nil && *initTimeout != 0 {
+		sdTimeout = *initTimeout
 	}
 
 	configSvcClientOpts := c.Service.NewOptions().
 		SetInstrumentOptions(cfgParams.InstrumentOpts).
-		SetServiceDiscoveryConfig(c.Service.SDConfig)
+		SetServicesOptions(c.Service.SDConfig.NewOptions().SetInitTimeout(sdTimeout))
 	configSvcClient, err := etcdclient.NewConfigServiceClient(configSvcClientOpts)
 	if err != nil {
 		err = fmt.Errorf("could not create m3cluster client: %v", err)

--- a/environment/config.go
+++ b/environment/config.go
@@ -62,6 +62,9 @@ type KVConfig struct {
 
 	// Presence of a (etcd) server in this config denotes an embedded cluster
 	Server *EmbeddedKV `yaml:"server"`
+
+	// NamespaceTimeout is the timeout duration for setting a namespace
+	NamespaceTimeout time.Duration `yaml:"namespaceTimeout"`
 }
 
 // EmbeddedKV defines specific fields for the embedded kv server
@@ -73,9 +76,6 @@ type EmbeddedKV struct {
 	LCUrls         []string `yaml:"listenClientUrls"`
 	InitialCluster string   `yaml:"initialCluster"`
 	Name           string   `yaml:"name"`
-
-	// NamespaceTimeout is the timeout duration for setting a namespace
-	NamespaceTimeout time.Duration `yaml:"namespaceTimeout"`
 }
 
 // StaticConfiguration is used for running M3DB with a static config

--- a/environment/config.go
+++ b/environment/config.go
@@ -71,14 +71,13 @@ type SeedNodeConfig struct {
 	ListenPeerUrls           []string               `yaml:"listenPeerUrls"`
 	ListenClientUrls         []string               `yaml:"listenClientUrls"`
 	InitialCluster           []SeedNode             `yaml:"initialCluster"`
-	Name                     string                 `yaml:"name"`
-	ClientTransportSecurity  SeedNodeSecurityConfig `json:"clientTransportSecurity"`
-	PeerTransportSecurity    SeedNodeSecurityConfig `json:"peerTransportSecurity"`
+	ClientTransportSecurity  SeedNodeSecurityConfig `yaml:"clientTransportSecurity"`
+	PeerTransportSecurity    SeedNodeSecurityConfig `yaml:"peerTransportSecurity"`
 }
 
 // SeedNode represents a seed node for the cluster
 type SeedNode struct {
-	HostID   string `yaml:"hostId"`
+	HostID   string `yaml:"hostID"`
 	Endpoint string `yaml:"endpoint"`
 }
 

--- a/environment/config.go
+++ b/environment/config.go
@@ -57,14 +57,14 @@ type Configuration struct {
 	Static *StaticConfiguration `yaml:"static"`
 
 	// Presence of a (etcd) server in this config denotes an embedded cluster
-	SeedNode *SeedNodeConfig `yaml:"seedNode"`
+	SeedNodes *SeedNodesConfig `yaml:"seedNodes"`
 
 	// NamespaceResolutionTimeout is the maximum time to wait to discover namespaces from KV
 	NamespaceResolutionTimeout time.Duration `yaml:"namespaceResolutionTimeout"`
 }
 
-// SeedNodeConfig defines fields for seed node
-type SeedNodeConfig struct {
+// SeedNodesConfig defines fields for seed node
+type SeedNodesConfig struct {
 	RootDir                  string                 `yaml:"rootDir"`
 	InitialAdvertisePeerUrls []string               `yaml:"initialAdvertisePeerUrls"`
 	AdvertiseClientUrls      []string               `yaml:"advertiseClientUrls"`
@@ -83,12 +83,12 @@ type SeedNode struct {
 
 // SeedNodeSecurityConfig contains the data used for security in seed nodes
 type SeedNodeSecurityConfig struct {
-	CAFile        string `json:"caFile"`
-	CertFile      string `json:"certFile"`
-	KeyFile       string `json:"keyFile"`
-	TrustedCAFile string `json:"trustedCaFile"`
-	CertAuth      bool   `json:"clientCertAuth"`
-	AutoTLS       bool   `json:"autoTls"`
+	CAFile        string `yaml:"caFile"`
+	CertFile      string `yaml:"certFile"`
+	KeyFile       string `yaml:"keyFile"`
+	TrustedCAFile string `yaml:"trustedCaFile"`
+	CertAuth      bool   `yaml:"clientCertAuth"`
+	AutoTLS       bool   `yaml:"autoTls"`
 }
 
 // StaticConfiguration is used for running M3DB with a static config

--- a/services/m3dbnode/config/config.go
+++ b/services/m3dbnode/config/config.go
@@ -212,6 +212,12 @@ func NewEtcdEmbedConfig(cfg Configuration) (*embed.Config, error) {
 	newKVCfg := embed.NewConfig()
 	kvCfg := cfg.EnvironmentConfig.SeedNode
 
+	hostID, err := cfg.HostID.Resolve()
+	if err != nil {
+		return nil, err
+	}
+	newKVCfg.Name = hostID
+
 	dir := kvCfg.RootDir
 	if dir == "" {
 		dir = path.Join(cfg.Filesystem.FilePathPrefix, defaultEtcdDirSuffix)
@@ -230,7 +236,7 @@ func NewEtcdEmbedConfig(cfg Configuration) (*embed.Config, error) {
 	}
 	newKVCfg.LCUrls = LCUrls
 
-	host, err := getHostFromHostID(kvCfg.InitialCluster, kvCfg.Name)
+	host, err := getHostFromHostID(kvCfg.InitialCluster, hostID)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +253,6 @@ func NewEtcdEmbedConfig(cfg Configuration) (*embed.Config, error) {
 	}
 	newKVCfg.ACUrls = ACUrls
 
-	newKVCfg.Name = kvCfg.Name
 	newKVCfg.InitialCluster = initialClusterString(kvCfg.InitialCluster)
 
 	copySecurityDetails := func(tls *transport.TLSInfo, ysc *environment.SeedNodeSecurityConfig) {

--- a/services/m3dbnode/config/config.go
+++ b/services/m3dbnode/config/config.go
@@ -210,7 +210,7 @@ type HashingConfiguration struct {
 // NewEtcdEmbedConfig creates a new embedded etcd config from kv config.
 func NewEtcdEmbedConfig(cfg Configuration) (*embed.Config, error) {
 	newKVCfg := embed.NewConfig()
-	kvCfg := cfg.EnvironmentConfig.SeedNode
+	kvCfg := cfg.EnvironmentConfig.SeedNodes
 
 	hostID, err := cfg.HostID.Resolve()
 	if err != nil {

--- a/services/m3dbnode/config/config.go
+++ b/services/m3dbnode/config/config.go
@@ -255,7 +255,7 @@ func GetETCDConfig(cfg Configuration) (*embed.Config, error) {
 }
 
 func convertToURLsWithDefault(rawURLs []string, def ...string) ([]url.URL, error) {
-	if rawURLs == nil || len(rawURLs) == 0 {
+	if len(rawURLs) == 0 {
 		rawURLs = def
 	}
 

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -485,6 +485,11 @@ config:
         - 1.1.1.1:2379
         - 1.1.1.2:2379
         - 1.1.1.3:2379
+        keepAlive:
+          enabled: false
+          period: 0s
+          jitter: 0s
+          timeout: 0s
         tls: null
       m3sd:
         initTimeout: 0s

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -56,7 +56,8 @@ httpClusterListenAddress: 0.0.0.0:9003
 debugListenAddress: 0.0.0.0:9004
 
 hostID:
-    resolver: hostname
+    resolver: config
+    value: host1
 
 client:
     writeConsistencyLevel: majority
@@ -247,13 +248,12 @@ config:
         advertiseClientUrls:
             - http://1.1.1.1:2379
         initialCluster:
-            - hostId: host1
+            - hostID: host1
               endpoint: http://1.1.1.1:2380
-            - hostId: host2
+            - hostID: host2
               endpoint: http://1.1.1.2:2380
-            - hostId: host3
+            - hostID: host3
               endpoint: http://1.1.1.3:2380
-        name: host1
 hashing:
   seed: 42
 writeNewSeriesAsync: true
@@ -302,8 +302,8 @@ httpNodeListenAddress: 0.0.0.0:9002
 httpClusterListenAddress: 0.0.0.0:9003
 debugListenAddress: 0.0.0.0:9004
 hostID:
-  resolver: hostname
-  value: null
+  resolver: config
+  value: host1
   envVarName: null
 client:
   config:
@@ -511,21 +511,20 @@ config:
     listenClientUrls:
     - http://0.0.0.0:2379
     initialCluster:
-    - hostId: host1
+    - hostID: host1
       endpoint: http://1.1.1.1:2380
-    - hostId: host2
+    - hostID: host2
       endpoint: http://1.1.1.2:2380
-    - hostId: host3
+    - hostID: host3
       endpoint: http://1.1.1.3:2380
-    name: host1
-    clienttransportsecurity:
+    clientTransportSecurity:
       cafile: ""
       certfile: ""
       keyfile: ""
       trustedcafile: ""
       certauth: false
       autotls: false
-    peertransportsecurity:
+    peerTransportSecurity:
       cafile: ""
       certfile: ""
       keyfile: ""

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -505,7 +505,7 @@ config:
       - http://0.0.0.0:2379
       initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
       name: host1
-      namespaceTimeout: 0s
+    namespaceTimeout: 0s
 hashing:
   seed: 42
 writeNewSeriesAsync: true
@@ -533,13 +533,13 @@ func TestInitialClusterToETCDEndpoints(t *testing.T) {
 	assert.Equal(t, "http://1.1.1.2:2379", endpoints[1])
 	assert.Equal(t, "http://1.1.1.3:2379", endpoints[2])
 
-	endpoints, err = InitialClusterToETCDEndpoints("")
+	_, err = InitialClusterToETCDEndpoints("")
 	require.Error(t, err)
 
-	endpoints, err = InitialClusterToETCDEndpoints("host1")
+	_, err = InitialClusterToETCDEndpoints("host1")
 	require.Error(t, err)
 
-	endpoints, err = InitialClusterToETCDEndpoints("http://1.1.1.1:2380")
+	_, err = InitialClusterToETCDEndpoints("http://1.1.1.1:2380")
 	require.Error(t, err)
 }
 

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -505,6 +505,20 @@ config:
     - http://0.0.0.0:2379
     initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
     name: host1
+    clientsecurityjson:
+      cafile: ""
+      certfile: ""
+      keyfile: ""
+      certauth: false
+      trustedcafile: ""
+      autotls: false
+    peersecurityjson:
+      cafile: ""
+      certfile: ""
+      keyfile: ""
+      certauth: false
+      trustedcafile: ""
+      autotls: false
   namespaceTimeout: 0s
 hashing:
   seed: 42

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -498,7 +498,7 @@ config:
         timeout: 0s
       tls: null
     m3sd:
-      initTimeout: 0s
+      initTimeout: null
   static: null
   seedNodes:
     rootDir: /var/lib/etcd

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -224,30 +224,29 @@ pooling:
               highWatermark: 0.02
 
 config:
-    kv:
-        client:
-            env: production
-            zone: embedded
-            service: m3db
-            cacheDir: /var/lib/m3kv
-            etcdClusters:
-                - zone: embedded
-                  endpoints:
-                    - 1.1.1.1:2379
-                    - 1.1.1.2:2379
-                    - 1.1.1.3:2379
-        server:
-            listenPeerUrls:
-                - http://0.0.0.0:2380
-            listenClientUrls:
-                - http://0.0.0.0:2379
-            dir: '/var/lib/etcd'
-            initialAdvertisePeerUrls:
-                - http://1.1.1.1:2380
-            advertiseClientUrls:
-                - http://1.1.1.1:2379
-            initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
-            name: host1
+    service:
+        env: production
+        zone: embedded
+        service: m3db
+        cacheDir: /var/lib/m3kv
+        etcdClusters:
+            - zone: embedded
+              endpoints:
+                  - 1.1.1.1:2379
+                  - 1.1.1.2:2379
+                  - 1.1.1.3:2379
+    embeddedServer:
+        listenPeerUrls:
+            - http://0.0.0.0:2380
+        listenClientUrls:
+            - http://0.0.0.0:2379
+        dir: /var/lib/etcd
+        initialAdvertisePeerUrls:
+            - http://1.1.1.1:2380
+        advertiseClientUrls:
+            - http://1.1.1.1:2379
+        initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
+        name: host1
 hashing:
   seed: 42
 writeNewSeriesAsync: true
@@ -301,8 +300,10 @@ hostID:
   envVarName: null
 client:
   config:
+    service: null
     static: null
-    kv: null
+    embeddedServer: null
+    namespaceTimeout: 0s
   writeConsistencyLevel: 2
   readConsistencyLevel: 2
   connectConsistencyLevel: 0
@@ -472,40 +473,39 @@ pooling:
     lowWatermark: 0.01
     highWatermark: 0.02
 config:
+  service:
+    zone: embedded
+    env: production
+    service: m3db
+    cacheDir: /var/lib/m3kv
+    etcdClusters:
+    - zone: embedded
+      endpoints:
+      - 1.1.1.1:2379
+      - 1.1.1.2:2379
+      - 1.1.1.3:2379
+      keepAlive:
+        enabled: false
+        period: 0s
+        jitter: 0s
+        timeout: 0s
+      tls: null
+    m3sd:
+      initTimeout: 0s
   static: null
-  kv:
-    client:
-      zone: embedded
-      env: production
-      service: m3db
-      cacheDir: /var/lib/m3kv
-      etcdClusters:
-      - zone: embedded
-        endpoints:
-        - 1.1.1.1:2379
-        - 1.1.1.2:2379
-        - 1.1.1.3:2379
-        keepAlive:
-          enabled: false
-          period: 0s
-          jitter: 0s
-          timeout: 0s
-        tls: null
-      m3sd:
-        initTimeout: 0s
-    server:
-      dir: /var/lib/etcd
-      initialAdvertisePeerUrls:
-      - http://1.1.1.1:2380
-      advertiseClientUrls:
-      - http://1.1.1.1:2379
-      listenPeerUrls:
-      - http://0.0.0.0:2380
-      listenClientUrls:
-      - http://0.0.0.0:2379
-      initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
-      name: host1
-    namespaceTimeout: 0s
+  embeddedServer:
+    dir: /var/lib/etcd
+    initialAdvertisePeerUrls:
+    - http://1.1.1.1:2380
+    advertiseClientUrls:
+    - http://1.1.1.1:2379
+    listenPeerUrls:
+    - http://0.0.0.0:2380
+    listenClientUrls:
+    - http://0.0.0.0:2379
+    initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
+    name: host1
+  namespaceTimeout: 0s
 hashing:
   seed: 42
 writeNewSeriesAsync: true

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -237,7 +237,7 @@ config:
                   - 1.1.1.1:2379
                   - 1.1.1.2:2379
                   - 1.1.1.3:2379
-    seedNode:
+    seedNodes:
         listenPeerUrls:
             - http://0.0.0.0:2380
         listenClientUrls:
@@ -309,7 +309,7 @@ client:
   config:
     service: null
     static: null
-    seedNode: null
+    seedNodes: null
     namespaceResolutionTimeout: 0s
   writeConsistencyLevel: 2
   readConsistencyLevel: 2
@@ -500,7 +500,7 @@ config:
     m3sd:
       initTimeout: 0s
   static: null
-  seedNode:
+  seedNodes:
     rootDir: /var/lib/etcd
     initialAdvertisePeerUrls:
     - http://1.1.1.1:2380
@@ -518,19 +518,19 @@ config:
     - hostID: host3
       endpoint: http://1.1.1.3:2380
     clientTransportSecurity:
-      cafile: ""
-      certfile: ""
-      keyfile: ""
-      trustedcafile: ""
-      certauth: false
-      autotls: false
+      caFile: ""
+      certFile: ""
+      keyFile: ""
+      trustedCaFile: ""
+      clientCertAuth: false
+      autoTls: false
     peerTransportSecurity:
-      cafile: ""
-      certfile: ""
-      keyfile: ""
-      trustedcafile: ""
-      certauth: false
-      autotls: false
+      caFile: ""
+      certFile: ""
+      keyFile: ""
+      trustedCaFile: ""
+      clientCertAuth: false
+      autoTls: false
   namespaceResolutionTimeout: 0s
 hashing:
   seed: 42

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -633,7 +633,7 @@ config:
         advertiseClientUrls:
             - {{.ACURL}}
         initialCluster:
-            - hostId: {{.InitialClusterHostID}}
+            - hostID: {{.InitialClusterHostID}}
               endpoint: {{.InitialClusterEndpoint}}
 `
 )

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3db/client"
-	"github.com/m3db/m3db/environment"
 	"github.com/m3db/m3db/kvconfig"
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/services/m3dbnode/config"
@@ -119,7 +118,7 @@ func TestConfig(t *testing.T) {
 	err = xconfig.LoadFile(&cfg, configFd.Name())
 	require.NoError(t, err)
 
-	configSvcClient, err := cfg.EnvironmentConfig.KV.Client.NewClient(instrument.NewOptions().
+	configSvcClient, err := cfg.EnvironmentConfig.Service.NewClient(instrument.NewOptions().
 		SetLogger(xlog.NullLogger))
 	require.NoError(t, err)
 
@@ -190,8 +189,7 @@ func TestConfig(t *testing.T) {
 	// NB(r): Make sure client config points to the root config
 	// service since we're going to instantiate the client configuration
 	// just by itself.
-	cfg.Client.EnvironmentConfig.KV = &environment.KVConfig{}
-	cfg.Client.EnvironmentConfig.KV.Client = cfg.EnvironmentConfig.KV.Client
+	cfg.Client.EnvironmentConfig.Service = cfg.EnvironmentConfig.Service
 
 	cli, err := cfg.Client.NewClient(client.ConfigurationParameters{})
 	require.NoError(t, err)
@@ -403,15 +401,14 @@ pooling:
               size: 128
 
 config:
-    kv:
-        client:
-            env: {{.ServiceEnv}}
-            zone: {{.ServiceZone}}
-            service: {{.ServiceName}}
-            cacheDir: {{.ConfigServiceCacheDir}}
-            etcdClusters:
-                - zone: {{.ServiceZone}}
-                  endpoints: {{.EtcdEndpoints}}
+    service:
+        env: {{.ServiceEnv}}
+        zone: {{.ServiceZone}}
+        service: {{.ServiceName}}
+        cacheDir: {{.ConfigServiceCacheDir}}
+        etcdClusters:
+            - zone: {{.ServiceZone}}
+              endpoints: {{.EtcdEndpoints}}
 `
 
 type cleanup func()

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -56,21 +56,19 @@ import (
 )
 
 const (
-	hostID       = "m3dbtest01"
-	serviceName  = "m3dbnode_test"
-	serviceEnv   = "test"
-	serviceZone  = "local"
-	servicePort  = 9000
-	namespaceID  = "metrics"
-	lpURL        = "http://0.0.0.0:2380"
-	lcURL        = "http://0.0.0.0:2379"
-	apURL        = "http://localhost:2380"
-	acURL        = "http://localhost:2379"
-	etcdEndpoint = acURL
-)
-
-var (
-	initialCluster = fmt.Sprintf("%s=%s", hostID, apURL)
+	hostID                 = "m3dbtest01"
+	serviceName            = "m3dbnode_test"
+	serviceEnv             = "test"
+	serviceZone            = "local"
+	servicePort            = 9000
+	namespaceID            = "metrics"
+	lpURL                  = "http://0.0.0.0:2380"
+	lcURL                  = "http://0.0.0.0:2379"
+	apURL                  = "http://localhost:2380"
+	acURL                  = "http://localhost:2379"
+	etcdEndpoint           = acURL
+	initialClusterHostID   = hostID
+	initialClusterEndpoint = apURL
 )
 
 // TestConfig tests booting a server using file based configuration.
@@ -271,37 +269,39 @@ func TestEmbeddedConfig(t *testing.T) {
 	defer cleanupDataDir()
 
 	err = tmpl.Execute(configFd, struct {
-		HostID                string
-		LogFile               string
-		DataDir               string
-		ServicePort           string
-		ServiceName           string
-		ServiceEnv            string
-		ServiceZone           string
-		ConfigServiceCacheDir string
-		EmbeddedKVDir         string
-		LPURL                 string
-		LCURL                 string
-		APURL                 string
-		ACURL                 string
-		InitialCluster        string
-		EtcdEndpoint          string
+		HostID                 string
+		LogFile                string
+		DataDir                string
+		ServicePort            string
+		ServiceName            string
+		ServiceEnv             string
+		ServiceZone            string
+		ConfigServiceCacheDir  string
+		EmbeddedKVDir          string
+		LPURL                  string
+		LCURL                  string
+		APURL                  string
+		ACURL                  string
+		EtcdEndpoint           string
+		InitialClusterHostID   string
+		InitialClusterEndpoint string
 	}{
-		HostID:                hostID,
-		LogFile:               logFile,
-		DataDir:               dataDir,
-		ServicePort:           strconv.Itoa(int(servicePort)),
-		ServiceName:           serviceName,
-		ServiceEnv:            serviceEnv,
-		ServiceZone:           serviceZone,
-		ConfigServiceCacheDir: configServiceCacheDir,
-		EmbeddedKVDir:         embeddedKVDir,
-		LPURL:                 lpURL,
-		LCURL:                 lcURL,
-		APURL:                 apURL,
-		ACURL:                 acURL,
-		EtcdEndpoint:          etcdEndpoint,
-		InitialCluster:        initialCluster,
+		HostID:                 hostID,
+		LogFile:                logFile,
+		DataDir:                dataDir,
+		ServicePort:            strconv.Itoa(int(servicePort)),
+		ServiceName:            serviceName,
+		ServiceEnv:             serviceEnv,
+		ServiceZone:            serviceZone,
+		ConfigServiceCacheDir:  configServiceCacheDir,
+		EmbeddedKVDir:          embeddedKVDir,
+		LPURL:                  lpURL,
+		LCURL:                  lcURL,
+		APURL:                  apURL,
+		ACURL:                  acURL,
+		EtcdEndpoint:           etcdEndpoint,
+		InitialClusterHostID:   initialClusterHostID,
+		InitialClusterEndpoint: initialClusterEndpoint,
 	})
 	require.NoError(t, err)
 
@@ -622,7 +622,7 @@ config:
             - zone: {{.ServiceZone}}
               endpoints:
                   - {{.EtcdEndpoint}}
-    embeddedServer:
+    seedNode:
         listenPeerUrls:
             - {{.LPURL}}
         listenClientUrls:
@@ -632,7 +632,9 @@ config:
             - {{.APURL}}
         advertiseClientUrls:
             - {{.ACURL}}
-        initialCluster: {{.InitialCluster}}
+        initialCluster:
+            - hostId: {{.InitialClusterHostID}}
+              endpoint: {{.InitialClusterEndpoint}}
 `
 )
 

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3db/client"
+	"github.com/m3db/m3db/environment"
 	"github.com/m3db/m3db/kvconfig"
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/services/m3dbnode/config"
@@ -118,7 +119,7 @@ func TestConfig(t *testing.T) {
 	err = xconfig.LoadFile(&cfg, configFd.Name())
 	require.NoError(t, err)
 
-	configSvcClient, err := cfg.EnvironmentConfig.Service.NewClient(instrument.NewOptions().
+	configSvcClient, err := cfg.EnvironmentConfig.KV.Client.NewClient(instrument.NewOptions().
 		SetLogger(xlog.NullLogger))
 	require.NoError(t, err)
 
@@ -189,7 +190,8 @@ func TestConfig(t *testing.T) {
 	// NB(r): Make sure client config points to the root config
 	// service since we're going to instantiate the client configuration
 	// just by itself.
-	cfg.Client.EnvironmentConfig.Service = cfg.EnvironmentConfig.Service
+	cfg.Client.EnvironmentConfig.KV = &environment.KVConfig{}
+	cfg.Client.EnvironmentConfig.KV.Client = cfg.EnvironmentConfig.KV.Client
 
 	cli, err := cfg.Client.NewClient(client.ConfigurationParameters{})
 	require.NoError(t, err)
@@ -401,14 +403,15 @@ pooling:
               size: 128
 
 config:
-    service:
-        env: {{.ServiceEnv}}
-        zone: {{.ServiceZone}}
-        service: {{.ServiceName}}
-        cacheDir: {{.ConfigServiceCacheDir}}
-        etcdClusters:
-            - zone: {{.ServiceZone}}
-              endpoints: {{.EtcdEndpoints}}
+    kv:
+        client:
+            env: {{.ServiceEnv}}
+            zone: {{.ServiceZone}}
+            service: {{.ServiceName}}
+            cacheDir: {{.ConfigServiceCacheDir}}
+            etcdClusters:
+                - zone: {{.ServiceZone}}
+                  endpoints: {{.EtcdEndpoints}}
 `
 
 type cleanup func()

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -56,12 +56,21 @@ import (
 )
 
 const (
-	hostID      = "m3dbtest01"
-	serviceName = "m3dbnode_test"
-	serviceEnv  = "test"
-	serviceZone = "local"
-	servicePort = 9000
-	namespaceID = "metrics"
+	hostID       = "m3dbtest01"
+	serviceName  = "m3dbnode_test"
+	serviceEnv   = "test"
+	serviceZone  = "local"
+	servicePort  = 9000
+	namespaceID  = "metrics"
+	lpURL        = "http://0.0.0.0:2380"
+	lcURL        = "http://0.0.0.0:2379"
+	apURL        = "http://localhost:2380"
+	acURL        = "http://localhost:2379"
+	etcdEndpoint = acURL
+)
+
+var (
+	initialCluster = fmt.Sprintf("%s=%s", hostID, apURL)
 )
 
 // TestConfig tests booting a server using file based configuration.
@@ -75,7 +84,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, embeddedKV.Start())
 
 	// Create config file
-	tmpl, err := template.New("config").Parse(testConfig)
+	tmpl, err := template.New("config").Parse(testConfig + kvConfigPortion)
 	require.NoError(t, err)
 
 	configFd, cleanup := tempFile(t, "config.yaml")
@@ -240,7 +249,196 @@ func TestConfig(t *testing.T) {
 	serverWg.Wait()
 }
 
-var testConfig = `
+// TestEmbeddedConfig tests booting a server using an embedded KV.
+func TestEmbeddedConfig(t *testing.T) {
+	// Create config file
+	tmpl, err := template.New("config").Parse(testConfig + embeddedKVConfigPortion)
+	require.NoError(t, err)
+
+	configFd, cleanup := tempFile(t, "config.yaml")
+	defer cleanup()
+
+	logFile, cleanupLogFile := tempFileTouch(t, "m3dbnode.log")
+	defer cleanupLogFile()
+
+	configServiceCacheDir, cleanupConfigServiceCacheDir := tempDir(t, "kv")
+	defer cleanupConfigServiceCacheDir()
+
+	embeddedKVDir, cleanupEmbeddedKVDir := tempDir(t, "embedded")
+	defer cleanupEmbeddedKVDir()
+
+	dataDir, cleanupDataDir := tempDir(t, "data")
+	defer cleanupDataDir()
+
+	err = tmpl.Execute(configFd, struct {
+		HostID                string
+		LogFile               string
+		DataDir               string
+		ServicePort           string
+		ServiceName           string
+		ServiceEnv            string
+		ServiceZone           string
+		ConfigServiceCacheDir string
+		EmbeddedKVDir         string
+		LPURL                 string
+		LCURL                 string
+		APURL                 string
+		ACURL                 string
+		InitialCluster        string
+		EtcdEndpoint          string
+	}{
+		HostID:                hostID,
+		LogFile:               logFile,
+		DataDir:               dataDir,
+		ServicePort:           strconv.Itoa(int(servicePort)),
+		ServiceName:           serviceName,
+		ServiceEnv:            serviceEnv,
+		ServiceZone:           serviceZone,
+		ConfigServiceCacheDir: configServiceCacheDir,
+		EmbeddedKVDir:         embeddedKVDir,
+		LPURL:                 lpURL,
+		LCURL:                 lcURL,
+		APURL:                 apURL,
+		ACURL:                 acURL,
+		EtcdEndpoint:          etcdEndpoint,
+		InitialCluster:        initialCluster,
+	})
+	require.NoError(t, err)
+
+	// Run server
+	var (
+		interruptCh           = make(chan error, 1)
+		bootstrapCh           = make(chan struct{}, 1)
+		embeddedKVBootstrapCh = make(chan struct{}, 1)
+		serverWg              sync.WaitGroup
+	)
+	serverWg.Add(1)
+	go func() {
+		server.Run(server.RunOptions{
+			ConfigFile:            configFd.Name(),
+			BootstrapCh:           bootstrapCh,
+			EmbeddedKVBootstrapCh: embeddedKVBootstrapCh,
+			InterruptCh:           interruptCh,
+		})
+		serverWg.Done()
+	}()
+
+	// Wait for embedded KV to be up
+	<-embeddedKVBootstrapCh
+
+	// Setup the placement
+	var cfg config.Configuration
+	err = xconfig.LoadFile(&cfg, configFd.Name())
+	require.NoError(t, err)
+
+	configSvcClient, err := cfg.EnvironmentConfig.Service.NewClient(instrument.NewOptions().
+		SetLogger(xlog.NullLogger))
+	require.NoError(t, err)
+
+	svcs, err := configSvcClient.Services(services.NewOptions())
+	require.NoError(t, err)
+
+	serviceID := services.NewServiceID().
+		SetName(serviceName).
+		SetEnvironment(serviceEnv).
+		SetZone(serviceZone)
+
+	metadata := services.NewMetadata().
+		SetPort(servicePort).
+		SetLivenessInterval(time.Minute).
+		SetHeartbeatInterval(10 * time.Second)
+
+	err = svcs.SetMetadata(serviceID, metadata)
+	require.NoError(t, err)
+
+	placementOpts := placement.NewOptions().
+		SetValidZone(serviceZone)
+	placementSvc, err := svcs.PlacementService(serviceID, placementOpts)
+	require.NoError(t, err)
+
+	instance := placement.NewInstance().
+		SetID(hostID).
+		SetEndpoint(endpoint("127.0.0.1", servicePort)).
+		SetPort(servicePort).
+		SetRack("local").
+		SetWeight(1).
+		SetZone(serviceZone)
+	instances := []placement.Instance{instance}
+	shards := 256
+	replicas := 1
+	_, err = placementSvc.BuildInitialPlacement(instances, shards, replicas)
+	require.NoError(t, err)
+
+	// Setup the namespace
+	ns, err := newNamespaceProtoValue(namespaceID)
+	require.NoError(t, err)
+
+	kvStore, err := configSvcClient.KV()
+	require.NoError(t, err)
+
+	_, err = kvStore.Set(kvconfig.NamespacesKey, ns)
+	require.NoError(t, err)
+
+	// Wait for bootstrap
+	<-bootstrapCh
+
+	// Create client, read and write some data
+	// NB(r): Make sure client config points to the root config
+	// service since we're going to instantiate the client configuration
+	// just by itself.
+	cfg.Client.EnvironmentConfig.Service = cfg.EnvironmentConfig.Service
+
+	cli, err := cfg.Client.NewClient(client.ConfigurationParameters{})
+	require.NoError(t, err)
+
+	session, err := cli.DefaultSession()
+	require.NoError(t, err)
+
+	defer session.Close()
+
+	start := time.Now().Add(-time.Minute)
+	values := []struct {
+		value float64
+		at    time.Time
+		unit  xtime.Unit
+	}{
+		{value: 1.0, at: start, unit: xtime.Second},
+		{value: 2.0, at: start.Add(1 * time.Second), unit: xtime.Second},
+		{value: 3.0, at: start.Add(2 * time.Second), unit: xtime.Second},
+	}
+
+	for _, v := range values {
+		err := session.Write(ident.StringID(namespaceID), ident.StringID("foo"), v.at, v.value, v.unit, nil)
+		require.NoError(t, err)
+	}
+
+	// Account for first value inserted at xtime.Second precision
+	fetchStart := start.Truncate(time.Second)
+
+	// Account for last value being inserted at xtime.Second and
+	// the "end" param to fetch being exclusive
+	fetchEnd := values[len(values)-1].at.Truncate(time.Second).Add(time.Nanosecond)
+
+	iter, err := session.Fetch(ident.StringID(namespaceID), ident.StringID("foo"), fetchStart, fetchEnd)
+	require.NoError(t, err)
+
+	for _, v := range values {
+		require.True(t, iter.Next())
+		dp, unit, _ := iter.Current()
+		assert.Equal(t, v.value, dp.Value)
+		// Account for xtime.Second precision on values going in
+		expectAt := v.at.Truncate(time.Second)
+		assert.Equal(t, expectAt, dp.Timestamp)
+		assert.Equal(t, v.unit, unit)
+	}
+
+	// Wait for server to stop
+	interruptCh <- fmt.Errorf("test complete")
+	serverWg.Wait()
+}
+
+var (
+	testConfig = `
 logging:
     level: info
     file: {{.LogFile}}
@@ -399,7 +597,9 @@ pooling:
               size: 128
             - capacity: 4096
               size: 128
+`
 
+	kvConfigPortion = `
 config:
     service:
         env: {{.ServiceEnv}}
@@ -410,6 +610,31 @@ config:
             - zone: {{.ServiceZone}}
               endpoints: {{.EtcdEndpoints}}
 `
+
+	embeddedKVConfigPortion = `
+config:
+    service:
+        env: {{.ServiceEnv}}
+        zone: {{.ServiceZone}}
+        service: {{.ServiceName}}
+        cacheDir: {{.ConfigServiceCacheDir}}
+        etcdClusters:
+            - zone: {{.ServiceZone}}
+              endpoints:
+                  - {{.EtcdEndpoint}}
+    embeddedServer:
+        listenPeerUrls:
+            - {{.LPURL}}
+        listenClientUrls:
+            - {{.LCURL}}
+        dir: {{.EmbeddedKVDir}}
+        initialAdvertisePeerUrls:
+            - {{.APURL}}
+        advertiseClientUrls:
+            - {{.ACURL}}
+        initialCluster: {{.InitialCluster}}
+`
+)
 
 type cleanup func()
 

--- a/services/m3dbnode/main/main_test.go
+++ b/services/m3dbnode/main/main_test.go
@@ -622,7 +622,7 @@ config:
             - zone: {{.ServiceZone}}
               endpoints:
                   - {{.EtcdEndpoint}}
-    seedNode:
+    seedNodes:
         listenPeerUrls:
             - {{.LPURL}}
         listenClientUrls:

--- a/services/m3dbnode/server/server.go
+++ b/services/m3dbnode/server/server.go
@@ -89,6 +89,9 @@ type RunOptions struct {
 	// BootstrapCh is a channel to listen on to be notified of bootstrap.
 	BootstrapCh chan<- struct{}
 
+	// EmbeddedKVBootstrapCh is a channel to listen on to be notified of the embedded KV being bootstrapped.
+	EmbeddedKVBootstrapCh chan<- struct{}
+
 	// InterruptCh is a programmatic interrupt channel to supply to
 	// interrupt and shutdown the server.
 	InterruptCh <-chan error
@@ -158,6 +161,12 @@ func Run(runOpts RunOptions) {
 			if err != nil {
 				logger.Fatalf("could not start embedded etcd: %v", err)
 			}
+
+			if runOpts.EmbeddedKVBootstrapCh != nil {
+				// Notify on embedded KV bootstrap chan if specified
+				runOpts.EmbeddedKVBootstrapCh <- struct{}{}
+			}
+
 			defer e.Close()
 		}
 	}

--- a/services/m3dbnode/server/server.go
+++ b/services/m3dbnode/server/server.go
@@ -134,7 +134,7 @@ func Run(runOpts RunOptions) {
 
 		// Default etcd client clusters if not set already
 		clusters := cfg.EnvironmentConfig.KV.Client.ETCDClusters
-		if clusters == nil || len(clusters) == 0 {
+		if len(clusters) == 0 {
 			endpoints, err := config.InitialClusterToETCDEndpoints(cfg.EnvironmentConfig.KV.Server.InitialCluster)
 			if err != nil {
 				logger.Fatalf("unable to create etcd clusters: %v", err)
@@ -319,7 +319,7 @@ func Run(runOpts RunOptions) {
 	if cfg.EnvironmentConfig.Static == nil {
 		logger.Info("creating dynamic config service client with m3cluster")
 
-		namespaceTimeout := cfg.EnvironmentConfig.KV.Server.NamespaceTimeout
+		namespaceTimeout := cfg.EnvironmentConfig.KV.NamespaceTimeout
 		if namespaceTimeout <= 0 {
 			namespaceTimeout = namespaceInitTimeout
 		}

--- a/services/m3dbnode/server/server.go
+++ b/services/m3dbnode/server/server.go
@@ -123,11 +123,11 @@ func Run(runOpts RunOptions) {
 	}
 
 	// Presence of KV server config indicates embedded etcd cluster
-	if cfg.EnvironmentConfig.SeedNode != nil {
+	if cfg.EnvironmentConfig.SeedNodes != nil {
 		// Default etcd client clusters if not set already
 		clusters := cfg.EnvironmentConfig.Service.ETCDClusters
 		if len(clusters) == 0 {
-			endpoints, err := config.InitialClusterEndpoints(cfg.EnvironmentConfig.SeedNode.InitialCluster)
+			endpoints, err := config.InitialClusterEndpoints(cfg.EnvironmentConfig.SeedNodes.InitialCluster)
 
 			if err != nil {
 				logger.Fatalf("unable to create etcd clusters: %v", err)
@@ -135,7 +135,7 @@ func Run(runOpts RunOptions) {
 
 			zone := cfg.EnvironmentConfig.Service.Zone
 
-			logger.Infof("setting client etcd cluster to zone [%s], endpoints %v", zone, endpoints)
+			logger.Infof("using seed nodes etcd cluster: zone=%s, endpoints=%v", zone, endpoints)
 
 			cfg.EnvironmentConfig.Service.ETCDClusters = []etcd.ClusterConfig{etcd.ClusterConfig{
 				Zone:      zone,
@@ -143,7 +143,7 @@ func Run(runOpts RunOptions) {
 			}}
 		}
 
-		if config.IsSeedNode(cfg.EnvironmentConfig.SeedNode.InitialCluster, hostID) {
+		if config.IsSeedNode(cfg.EnvironmentConfig.SeedNodes.InitialCluster, hostID) {
 			logger.Info("is a seed node; starting etcd server")
 
 			etcdCfg, err := config.NewEtcdEmbedConfig(cfg)


### PR DESCRIPTION
Enable an embedded etcd cluster to be run in M3DB via configuration.

The KV config can be minimally specified with the service defaulting required arguments, e.g.:
```
config:
    service:
        env: production
        zone: embedded
        service: m3db
        cacheDir: /var/lib/m3kv
    embeddedServer:
        initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
```
Or more fully as something like:
```
config:
    service:
        env: production
        zone: embedded
        service: m3db
        cacheDir: /var/lib/m3kv
        etcdClusters: # defaults to endpoints parsed from initialCluster
            - zone: embedded
              endpoints:
                  - 1.1.1.1:2379
                  - 1.1.1.2:2379
                  - 1.1.1.3:2379
    embeddedServer:
        listenPeerUrls: # defaults to below
            - http://0.0.0.0:2380
        listenClientUrls: # defaults to below
            - http://0.0.0.0:2379
        dir: '/var/lib/etcd' # defaults to `fs.filePathPrefix` + '/etcd'
        initialAdvertisePeerUrls: # defaults to finding corresponding endpoint in initialCluster
            - http://1.1.1.1:2380
        advertiseClientUrls: # defaults to finding corresponding endpoint in initialCluster
            - http://1.1.1.1:2379
        initialCluster: host1=http://1.1.1.1:2380,host2=http://1.1.1.2:2380,host3=http://1.1.1.3:2380
        name: host1 # defaults to hostID
```