### PR TITLE
Fix Race Conditions in Shard

### DIFF
--- a/storage/shard.go
+++ b/storage/shard.go
@@ -658,8 +658,8 @@ func (s *dbShard) tickAndExpire(
 // NB(prateek): purgeExpiredSeries requires that all entries passed to it have at least one reader/writer,
 // i.e. have a readWriteCount of at least 1.
 // Currently, this function is only called by the lambda inside `tickAndExpire`'s `forEachShardEntryBatch`
-// call. This satifies the contract of all entries it operates upon being guaranteed to have a readerWriterEntryCount
-// of at least 1, by virtue of the implementation of `forEachShardEntryBatch`.
+// call. This satisfies the contract of all entries it operating upon being guaranteed to have a
+// readerWriterEntryCount of at least 1, by virtue of the implementation of `forEachShardEntryBatch`.
 func (s *dbShard) purgeExpiredSeries(expiredEntries []*dbShardEntry) {
 	// Remove all expired series from lookup and list.
 	s.Lock()

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -57,13 +57,9 @@ import (
 
 const (
 	shardIterateBatchPercent = 0.01
+	shardIterateBatchMinSize = 16
 )
 
-var (
-	// NB(prateek): the following is set to a var instead of a const because we
-	// override it in tests
-	expireBatchLength = 1024
-)
 var (
 	errShardEntryNotFound         = errors.New("shard entry not found")
 	errShardNotOpen               = errors.New("shard is not open")
@@ -395,13 +391,21 @@ func (s *dbShard) forEachShardEntry(entryFn dbShardEntryWorkFn) error {
 	})
 }
 
+func iterateBatchSize(elemsLen int) int {
+	if elemsLen < shardIterateBatchMinSize {
+		return elemsLen
+	}
+	t := math.Ceil(float64(shardIterateBatchPercent) * float64(elemsLen))
+	return int(math.Max(shardIterateBatchMinSize, t))
+}
+
 func (s *dbShard) forEachShardEntryBatch(entriesBatchFn dbShardEntryBatchWorkFn) error {
 	// NB(r): consider using a lockless list for ticking.
 	s.RLock()
 	elemsLen := s.list.Len()
-	batchSize := int(math.Ceil(shardIterateBatchPercent * float64(elemsLen)))
 	s.RUnlock()
 
+	batchSize := iterateBatchSize(elemsLen)
 	decRefElem := func(e *list.Element) {
 		if e == nil {
 			return
@@ -568,13 +572,19 @@ func (s *dbShard) tickAndExpire(
 		terminatedTickingDueToClosing bool
 		i                             int
 		slept                         time.Duration
+		expired                       []*dbShardEntry
 	)
 	s.RLock()
 	tickSleepBatch := s.currRuntimeOptions.tickSleepSeriesBatchSize
 	tickSleepPerSeries := s.currRuntimeOptions.tickSleepPerSeries
 	s.RUnlock()
 	s.forEachShardEntryBatch(func(currEntries []*dbShardEntry) bool {
-		var expired []*dbShardEntry
+		// re-using `expired` to amortize allocs, still need to reset it
+		// to be safe for re-use.
+		for i := range expired {
+			expired[i] = nil
+		}
+		expired = expired[:0]
 		for _, entry := range currEntries {
 			if i > 0 && i%tickSleepBatch == 0 {
 				// NB(xichen): if the tick is cancelled, we bail out immediately.
@@ -609,17 +619,6 @@ func (s *dbShard) tickAndExpire(
 			if err == series.ErrSeriesAllDatapointsExpired {
 				expired = append(expired, entry)
 				r.expiredSeries++
-				if len(expired) >= expireBatchLength {
-					// Purge when reaching max batch size to avoid large array growth
-					// and ensure smooth rate of elements being returned to pools.
-					// This method does not run using a lock so this is safe to
-					// perform inline.
-					s.purgeExpiredSeries(expired)
-					for i := range expired {
-						expired[i] = nil
-					}
-					expired = expired[:0]
-				}
 			} else {
 				r.activeSeries++
 				if err != nil {
@@ -636,8 +635,8 @@ func (s *dbShard) tickAndExpire(
 			i++
 		}
 
+		// Purge any series requiring purging.
 		if len(expired) > 0 {
-			// Purge any series that still haven't been purged yet
 			s.purgeExpiredSeries(expired)
 			for i := range expired {
 				expired[i] = nil
@@ -656,8 +655,11 @@ func (s *dbShard) tickAndExpire(
 	return r, nil
 }
 
-// NB(prateek): the calling function must ensure it has incremented the reference
-// count on the provided `expiredEntries`.
+// NB(prateek): purgeExpiredSeries requires that all entries passed to it have at least one reader/writer,
+// i.e. have a readWriteCount of at least 1.
+// Currently, this function is only called by the lambda inside `tickAndExpire`'s `forEachShardEntryBatch`
+// call. This satifies the contract of all entries it operates upon being guaranteed to have a readerWriterEntryCount
+// of at least 1, by virtue of the implementation of `forEachShardEntryBatch`.
 func (s *dbShard) purgeExpiredSeries(expiredEntries []*dbShardEntry) {
 	// Remove all expired series from lookup and list.
 	s.Lock()
@@ -668,12 +670,17 @@ func (s *dbShard) purgeExpiredSeries(expiredEntries []*dbShardEntry) {
 		if !exists {
 			continue
 		}
+
+		count := entry.readerWriterCount()
+		// The contract requires all entries to have count >= 1.
+		if count < 1 {
+			s.logger.Errorf(`observed series [%s] with readerWriterCount [%d]. This violates
+				expected guarantees in the code.`, series.ID().String(), count)
+			continue
+		}
 		// If this series is currently being written to or read from, we don't
-		// remove it even though it's empty in that it might become non-empty
-		// soon.
-		// We avoid closing the series during a read to ensure a consistent view
-		// of the series if they manage to take a reference to it.
-		if entry.readerWriterCount() > 1 {
+		// remove to ensure a consistent view of the series to other users.
+		if count > 1 {
 			continue
 		}
 		// If there have been datapoints written to the series since its

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -674,8 +674,8 @@ func (s *dbShard) purgeExpiredSeries(expiredEntries []*dbShardEntry) {
 		count := entry.readerWriterCount()
 		// The contract requires all entries to have count >= 1.
 		if count < 1 {
-			s.logger.Errorf(`observed series [%s] with readerWriterCount [%d]. This violates
-				expected guarantees in the code.`, series.ID().String(), count)
+			s.logger.Errorf("observed series [%s] with readerWriterCount [%d]. %s",
+				series.ID().String(), count, "This violates expected guarantees in the code.")
 			continue
 		}
 		// If this series is currently being written to or read from, we don't

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -674,8 +674,10 @@ func (s *dbShard) purgeExpiredSeries(expiredEntries []*dbShardEntry) {
 		count := entry.readerWriterCount()
 		// The contract requires all entries to have count >= 1.
 		if count < 1 {
-			s.logger.Errorf("observed series [%s] with readerWriterCount [%d]. %s",
-				series.ID().String(), count, "This violates expected guarantees in the code.")
+			s.logger.WithFields(
+				xlog.NewField("series", series.ID().String()),
+				xlog.NewField("readerWriterCount", count),
+			).Errorf("observed series with invalid readerWriterCount in `purgeExpiredSeries`")
 			continue
 		}
 		// If this series is currently being written to or read from, we don't

--- a/storage/shard_foreachentry_prop_test.go
+++ b/storage/shard_foreachentry_prop_test.go
@@ -1,0 +1,257 @@
+// +build big
+//
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3x/context"
+	"github.com/m3db/m3x/ident"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardConcurrentForEaches(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	seed := time.Now().UnixNano()
+	parameters.MinSuccessfulTests = 200
+	parameters.MaxSize = 40
+	parameters.MaxDiscardRatio = 20
+	parameters.Rng = rand.New(rand.NewSource(seed))
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property(`ForEachShardEntry does not change the shard entries ref count`, prop.ForAll(
+		func(entries []shardEntryState, workFns []dbShardEntryBatchWorkFn) (bool, error) {
+			result := testShardConcurrentForEach(t, entries, workFns)
+			if result.Status == gopter.PropTrue {
+				return true, nil
+			}
+			return false, result.Error
+		},
+		genShardEntryStates(),
+		genBatchWorkFns(),
+	))
+	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)
+	if !properties.Run(reporter) {
+		t.Errorf("failed with initial seed: %d", seed)
+	}
+}
+
+func TestShardConcurrentForEachesAndTick(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	seed := time.Now().UnixNano()
+	parameters.MinSuccessfulTests = 200
+	parameters.MaxSize = 40
+	parameters.MaxDiscardRatio = 20
+	parameters.Rng = rand.New(rand.NewSource(seed))
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property(`Concurrent ForEachShardEntry and Tick does not panic`, prop.ForAll(
+		func(entries []shardEntryState, workFns []dbShardEntryBatchWorkFn) bool {
+			testShardConcurrentForEachTick(t, entries, workFns)
+			return true
+		},
+		genShardEntryStates(),
+		genBatchWorkFns(),
+	))
+	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)
+	if !properties.Run(reporter) {
+		t.Errorf("failed with initial seed: %d", seed)
+	}
+}
+
+func testShardConcurrentForEachTick(
+	t *testing.T,
+	entries []shardEntryState,
+	workFns []dbShardEntryBatchWorkFn,
+) {
+	shard, opts := propTestDatabaseShard(t, 10)
+	defer func() {
+		shard.Close()
+		opts.RuntimeOptionsManager().Close()
+	}()
+
+	for _, entry := range entries {
+		addTestSeriesWithCount(shard, entry.id, entry.refCount)
+	}
+
+	require.NoError(t, shardEntriesAreEqual(shard, entries))
+
+	var (
+		numRoutines = len(workFns) + 1
+		barrier     = make(chan struct{}, numRoutines)
+		wg          sync.WaitGroup
+	)
+
+	wg.Add(numRoutines)
+
+	for _, fn := range workFns {
+		fn := fn
+		go func() {
+			<-barrier
+			shard.forEachShardEntryBatch(fn)
+			wg.Done()
+		}()
+	}
+
+	go func() {
+		<-barrier
+		shard.Tick(context.NewNoOpCanncellable())
+		wg.Done()
+	}()
+
+	for i := 0; i < numRoutines; i++ {
+		barrier <- struct{}{}
+	}
+
+	wg.Wait()
+}
+
+func testShardConcurrentForEach(
+	t *testing.T,
+	entries []shardEntryState,
+	workFns []dbShardEntryBatchWorkFn,
+) gopter.PropResult {
+	shard, opts := propTestDatabaseShard(t, 10)
+	defer func() {
+		shard.Close()
+		opts.RuntimeOptionsManager().Close()
+	}()
+
+	for _, entry := range entries {
+		addTestSeriesWithCount(shard, entry.id, entry.refCount)
+	}
+
+	require.NoError(t, shardEntriesAreEqual(shard, entries))
+
+	var (
+		numRoutines = len(workFns)
+		barrier     = make(chan struct{}, numRoutines)
+		wg          sync.WaitGroup
+	)
+
+	wg.Add(numRoutines)
+
+	for _, fn := range workFns {
+		fn := fn
+		go func() {
+			<-barrier
+			shard.forEachShardEntryBatch(fn)
+			wg.Done()
+		}()
+	}
+
+	for i := 0; i < numRoutines; i++ {
+		barrier <- struct{}{}
+	}
+
+	wg.Wait()
+
+	if err := shardEntriesAreEqual(shard, entries); err != nil {
+		return gopter.PropResult{
+			Status: gopter.PropError,
+			Error:  err,
+		}
+	}
+
+	return gopter.PropResult{
+		Status: gopter.PropTrue,
+	}
+}
+
+func shardEntriesAreEqual(shard *dbShard, expectedEntries []shardEntryState) error {
+	shard.Lock()
+	defer shard.Unlock()
+
+	if len(expectedEntries) == 0 && shard.list.Front() == nil {
+		return nil
+	}
+
+	elem := shard.list.Front()
+	for idx, expectedEntry := range expectedEntries {
+		if elem == nil {
+			return fmt.Errorf("expected to have %d idx, but did not see anything", idx)
+		}
+		nextElem := elem.Next()
+		entry := elem.Value.(*dbShardEntry)
+		if !entry.series.ID().Equal(expectedEntry.id) {
+			return fmt.Errorf("expected id: %s at %d, observed: %s",
+				expectedEntry.id.String(), idx, entry.series.ID().String())
+		}
+		if entry.readerWriterCount() != expectedEntry.refCount {
+			return fmt.Errorf("expected id: %s at %d to have ref count %d, observed: %d",
+				entry.series.ID().String(), idx, expectedEntry.refCount, entry.readerWriterCount())
+		}
+		elem = nextElem
+	}
+
+	if elem != nil {
+		return fmt.Errorf("expected to have see %d entries, but observed more", len(expectedEntries))
+	}
+
+	return nil
+}
+
+type shardEntryState struct {
+	id       ident.ID
+	refCount int32
+}
+
+func genShardEntryStates() gopter.Gen {
+	return gen.SliceOf(genShardEntryState())
+}
+
+func genShardEntryState() gopter.Gen {
+	return gopter.CombineGens(gen.UInt(), gen.UInt16()).
+		Map(
+			func(values []interface{}) shardEntryState {
+				return shardEntryState{
+					id:       ident.StringID(fmt.Sprintf("foo%d", values[0].(uint))),
+					refCount: int32(values[1].(uint16)),
+				}
+			},
+		)
+}
+
+func genBatchWorkFns() gopter.Gen {
+	return gen.SliceOf(genBatchWorkFn())
+}
+
+func genBatchWorkFn() gopter.Gen {
+	return gen.UInt8().
+		Map(func(n uint8) dbShardEntryBatchWorkFn {
+			i := uint8(0)
+			return func([]*dbShardEntry) bool {
+				i++
+				return i < n
+			}
+		})
+}

--- a/storage/shard_race_prop_test.go
+++ b/storage/shard_race_prop_test.go
@@ -1,0 +1,144 @@
+// +build big
+//
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/runtime"
+	"github.com/m3db/m3db/storage/block"
+	"github.com/m3db/m3x/context"
+	"github.com/m3db/m3x/ident"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+)
+
+func TestShardTickReadFnRace(t *testing.T) {
+	oldExpired := expireBatchLength
+	defer func() {
+		expireBatchLength = oldExpired
+	}()
+
+	parameters := gopter.DefaultTestParameters()
+	seed := time.Now().UnixNano()
+	parameters.MinSuccessfulTests = 200
+	parameters.MaxSize = 40
+	parameters.MaxDiscardRatio = 20
+	parameters.Rng = rand.New(rand.NewSource(seed))
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property("Concurrent Tick and Shard Fn doesn't panic", prop.ForAll(
+		func(ids []ident.ID, tickBatchSize uint8, expireBatchLength uint8, fn testShardReadFn) bool {
+			testShardTickReadFnRace(t, ids, int(expireBatchLength), int(tickBatchSize), fn)
+			return true
+		},
+		anyIDs().WithLabel("ids"),
+		gen.UInt8().WithLabel("expireBatchLength").SuchThat(func(x uint8) bool { return x > 0 }),
+		gen.UInt8().WithLabel("tickBatchSize").SuchThat(func(x uint8) bool { return x > 0 }),
+		gen.OneConstOf(fetchBlocksMetadataShardFn, fetchBlocksMetadataV2ShardFn),
+	))
+
+	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)
+	if !properties.Run(reporter) {
+		t.Errorf("failed with initial seed: %d", seed)
+	}
+}
+
+func testShardTickReadFnRace(t *testing.T, ids []ident.ID, expireLen int, tickBatchSize int, fn testShardReadFn) {
+	shard, opts := propTestDatabaseShard(t, tickBatchSize)
+	defer func() {
+		shard.Close()
+		opts.RuntimeOptionsManager().Close()
+	}()
+
+	expireBatchLength = expireLen
+	for _, id := range ids {
+		addTestSeries(shard, id)
+	}
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		shard.Tick(context.NewNoOpCanncellable())
+		wg.Done()
+	}()
+
+	go func() {
+		fn(shard)
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+type testShardReadFn func(shard *dbShard)
+
+var fetchBlocksMetadataShardFn testShardReadFn = func(shard *dbShard) {
+	ctx := context.NewContext()
+	start := time.Time{}
+	end := time.Now()
+	shard.FetchBlocksMetadata(ctx, start, end, 100, 0, block.FetchBlocksMetadataOptions{
+		IncludeChecksums: true,
+		IncludeLastRead:  true,
+		IncludeSizes:     true,
+	})
+	ctx.BlockingClose()
+}
+
+var fetchBlocksMetadataV2ShardFn testShardReadFn = func(shard *dbShard) {
+	ctx := context.NewContext()
+	start := time.Time{}
+	end := time.Now()
+	shard.FetchBlocksMetadataV2(ctx, start, end, 100, nil, block.FetchBlocksMetadataOptions{
+		IncludeChecksums: true,
+		IncludeLastRead:  true,
+		IncludeSizes:     true,
+	})
+	ctx.BlockingClose()
+}
+
+func propTestDatabaseShard(t *testing.T, tickBatchSize int) (*dbShard, Options) {
+	opts := testDatabaseOptions().SetRuntimeOptionsManager(runtime.NewOptionsManager())
+	shard := testDatabaseShard(t, opts)
+	shard.currRuntimeOptions.tickSleepPerSeries = time.Microsecond
+	shard.currRuntimeOptions.tickSleepSeriesBatchSize = tickBatchSize
+	return shard, opts
+}
+
+func anyIDs() gopter.Gen {
+	return gen.IntRange(0, 20).
+		Map(func(n int) interface{} {
+			ids := make([]ident.ID, 0, n)
+			for i := 0; i < n; i++ {
+				ids = append(ids, ident.StringID(fmt.Sprintf("foo.%d", i)))
+			}
+			return ids
+		})
+}

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -530,13 +530,6 @@ func TestShardTickRace(t *testing.T) {
 func TestShardTickCleanupSmallBatchSize(t *testing.T) {
 	opts := testDatabaseOptions()
 	shard := testDatabaseShard(t, opts)
-	oldExpired := expireBatchLength
-	defer func() {
-		shard.Close()
-		expireBatchLength = oldExpired
-	}()
-
-	expireBatchLength = 1
 	addTestSeries(shard, ident.StringID("foo"))
 	shard.Tick(context.NewNoOpCanncellable())
 	require.Equal(t, 0, len(shard.lookup))
@@ -952,4 +945,13 @@ func TestShardReadEncodedCachesSeriesWithRecentlyReadPolicy(t *testing.T) {
 
 	assert.False(t, entry.series.IsEmpty())
 	assert.Equal(t, 2, entry.series.NumActiveBlocks())
+}
+
+func TestShardIterateBatchSize(t *testing.T) {
+	smaller := shardIterateBatchMinSize - 1
+	require.Equal(t, smaller, iterateBatchSize(smaller))
+
+	require.Equal(t, shardIterateBatchMinSize, iterateBatchSize(shardIterateBatchMinSize+1))
+
+	require.True(t, shardIterateBatchMinSize < iterateBatchSize(2000))
 }

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -60,10 +60,11 @@ func (i *testIncreasingIndex) nextIndex() uint64 {
 }
 
 func testDatabaseShard(t *testing.T, opts Options) *dbShard {
-	ns := newTestNamespace(t)
-	nsReaderMgr := newNamespaceReaderManager(ns.metadata, tally.NoopScope, opts)
-	seriesOpts := NewSeriesOptionsFromOptions(opts, ns.Options().RetentionOptions())
-	return newDatabaseShard(ns.metadata, 0, nil, nsReaderMgr,
+	metadata, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
+	require.NoError(t, err)
+	nsReaderMgr := newNamespaceReaderManager(metadata, tally.NoopScope, opts)
+	seriesOpts := NewSeriesOptionsFromOptions(opts, defaultTestNs1Opts.RetentionOptions())
+	return newDatabaseShard(metadata, 0, nil, nsReaderMgr,
 		&testIncreasingIndex{}, commitLogWriteNoOp, databaseIndexNoOp, true, opts, seriesOpts).(*dbShard)
 }
 
@@ -336,10 +337,15 @@ func addMockTestSeries(ctrl *gomock.Controller, shard *dbShard, id ident.ID) *se
 }
 
 func addTestSeries(shard *dbShard, id ident.ID) series.DatabaseSeries {
+	return addTestSeriesWithCount(shard, id, 0)
+}
+
+func addTestSeriesWithCount(shard *dbShard, id ident.ID, count int32) series.DatabaseSeries {
 	series := series.NewDatabaseSeries(id, shard.seriesOpts)
 	series.Bootstrap(nil)
 	shard.Lock()
-	shard.lookup[id.Hash()] = shard.list.PushBack(&dbShardEntry{series: series})
+	shard.lookup[id.Hash()] = shard.list.PushBack(&dbShardEntry{
+		series: series, curReadWriters: count})
 	shard.Unlock()
 	return series
 }
@@ -406,6 +412,7 @@ func TestShardTick(t *testing.T) {
 	_, ok := shard.flushState.statesByTime[xtime.ToUnixNano(earliestFlush)]
 	require.True(t, ok)
 }
+
 func TestShardWriteAsync(t *testing.T) {
 	testReporter := xmetrics.NewTestStatsReporter(xmetrics.NewTestStatsReporterOptions())
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{
@@ -513,8 +520,26 @@ func TestShardTickRace(t *testing.T) {
 	wg.Wait()
 
 	shard.RLock()
-	require.Equal(t, 0, len(shard.lookup))
+	shardlen := len(shard.lookup)
 	shard.RUnlock()
+	require.Equal(t, 0, shardlen)
+}
+
+// Catches a logic bug we had trying to purgeSeries and counted the reference
+// we had while trying to purge as a concurrent read.
+func TestShardTickCleanupSmallBatchSize(t *testing.T) {
+	opts := testDatabaseOptions()
+	shard := testDatabaseShard(t, opts)
+	oldExpired := expireBatchLength
+	defer func() {
+		shard.Close()
+		expireBatchLength = oldExpired
+	}()
+
+	expireBatchLength = 1
+	addTestSeries(shard, ident.StringID("foo"))
+	shard.Tick(context.NewNoOpCanncellable())
+	require.Equal(t, 0, len(shard.lookup))
 }
 
 // This tests ensures the shard returns an error if two ticks are triggered concurrently.


### PR DESCRIPTION
- `tickAndExpire`s usual path of calling `purgeExpired` within the `forEachShardEntry` always skipped cleanup for entries present in the underlying batch; it cleaned up stuff in the lagging if check at the end. 
- A race in `forEachShardEntry`: took a reference to the front of the list but didn't increment the entry's reference count immediately, and released a lock. This was the bug allowing ticks to cleanup data while something else held a reference to it.
- Another race in `forEachShardEntry`: similar to the point above, we held onto an entry pointer with zero reference counts while transitioning from one batch to another, this pointer could get invalidated during a tick and cause panics. 
- Tests to ensure we are guarding against these issues

/cc @robskillington @richardartoul 