### PR TITLE
[WIP] Re-work ci-scripts to have big unit tests as a separate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,9 @@ test-single-integration:
 .PHONY: test-ci-unit
 test-ci-unit: test-base-ci-unit
 
+.PHONY: test-ci-unit
+test-ci-big-unit: test-base-ci-big-unit
+
 .PHONY: test-ci-integration
 test-ci-integration:
 	INTEGRATION_TIMEOUT=4m TEST_NATIVE_POOLING=false TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration

--- a/persist/fs/commitlog/read_write_prop_test.go
+++ b/persist/fs/commitlog/read_write_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/serialize/decoder_lifecycle_prop_test.go
+++ b/serialize/decoder_lifecycle_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/serialize/encode_decode_prop_test.go
+++ b/serialize/encode_decode_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/storage/cleanup_prop_test.go
+++ b/storage/cleanup_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/storage/namespace/convert_prop_test.go
+++ b/storage/namespace/convert_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
- extract big unit tests as a separate target,
- don't re-run non-big tests when executing big tests