### PR TITLE
Shorten sleep to make test less flaky

### DIFF
--- a/persist/fs/seek_manager_test.go
+++ b/persist/fs/seek_manager_test.go
@@ -89,6 +89,9 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 		}
 		return mock, nil
 	}
+	m.sleepFn = func(_ time.Duration) {
+		time.Sleep(time.Millisecond)
+	}
 
 	metadata := testNs1Metadata(t)
 	require.NoError(t, m.Open(metadata))


### PR DESCRIPTION
I think this test fails in C.I sometimes due to high concurrency causing the background loop combined with the 1-second sleep in-between loops to not execute frequently enough.

Cannot reproduce the flaky test locally.