### PR TITLE
Codecov enhancements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default: off
+      unittests:
+        flags: unittests
+      integration:
+        flags: integration
+    patch:
+      default: on
+    changes:
+      default: off
+
+comment:
+  layout: "header, reach, diff, flags, footer"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes

--- a/.excludecoverage
+++ b/.excludecoverage
@@ -1,0 +1,6 @@
+_mock.go
+_matcher.go
+generated/
+tools/
+vendor/
+integration/

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,17 @@ test-single-integration:
 	TEST_NATIVE_POOLING=false make test-base-single-integration name=$(name)
 
 .PHONY: test-ci-unit
-test-ci-unit: test-base-ci-unit
+test-ci-unit: test-base
+	$(codecov_push) -f $(coverfile) -F unittests
+
+.PHONY: test-ci-big-unit
+test-ci-big-unit: test-big-base
+	$(codecov_push) -f $(coverfile) -F unittests
 
 .PHONY: test-ci-integration
 test-ci-integration:
 	INTEGRATION_TIMEOUT=4m TEST_NATIVE_POOLING=false TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration
+	$(codecov_push) -f $(coverfile) -F integration
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## WARNING: This is pre-release software, and is not intended for use until a stable release.
 
-# M3DB [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# M3DB [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status](https://codecov.io/gh/m3db/m3db/branch/master/graph/badge.svg)](https://codecov.io/gh/m3db/m3db)
 
 A time series database.
 
@@ -14,5 +14,3 @@ This project is released under the [MIT License](LICENSE.md).
 [doc]: https://godoc.org/github.com/m3db/m3db
 [ci-img]: https://semaphoreci.com/api/v1/m3db/m3db/branches/master/shields_badge.svg
 [ci]: https://semaphoreci.com/m3db/m3db
-[cov-img]: https://coveralls.io/repos/m3db/m3db/badge.svg?branch=master&service=github
-[cov]: https://coveralls.io/github/m3db/m3db?branch=master

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -56,6 +56,10 @@ import (
 // - ns1 block at t0 and t1
 // - commit log blocks from [t1, t3]
 func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// Test setup
 	var (
 		rOpts              = retention.NewOptions().SetRetentionPeriod(12 * time.Hour)

--- a/tools/read_ids/main/main.go
+++ b/tools/read_ids/main/main.go
@@ -38,14 +38,13 @@ import (
 	"github.com/uber/tchannel-go/thrift"
 )
 
-var (
-	tchannelNodeAddrArg = flag.String("nodetchanneladdr", "127.0.0.1:9003", "Node TChannel server address")
-	namespaceArg        = flag.String("namespace", "default", "Namespace to read from")
-	shardsArg           = flag.String("shards", "0", "Shards to pull IDs from, comma separated")
-	pageLimitArg        = flag.Int64("pagelimit", 4096, "Page limit to pull for a single request")
-)
-
 func main() {
+	var (
+		tchannelNodeAddrArg = flag.String("nodetchanneladdr", "127.0.0.1:9003", "Node TChannel server address")
+		namespaceArg        = flag.String("namespace", "default", "Namespace to read from")
+		shardsArg           = flag.String("shards", "0", "Shards to pull IDs from, comma separated")
+		pageLimitArg        = flag.Int64("pagelimit", 4096, "Page limit to pull for a single request")
+	)
 	flag.Parse()
 
 	if *tchannelNodeAddrArg == "" ||


### PR DESCRIPTION
- Use `codecov.io` for coverage reports
- Separate big unit tests into their own make target 
- Add coverage reporting for integration tests under separate codecov flags
- Exclude `integration/`, `generated/`, `tools` and a couple of other files from coverage reports

/cc @richardartoul @robskillington 