### PR TITLE
Speeding up CI

### DIFF
--- a/.excludecoverage
+++ b/.excludecoverage
@@ -4,3 +4,4 @@ generated/
 tools/
 vendor/
 integration/
+testgen/

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,24 @@
+M3DB Testing Patterns
+=====================
+
+`m3db` uses a combination of testing strategies, they're listed below for completeness.
+
+(1) Unit tests
+These are package local tests where we use mocks/stubs to ensure components interact with each other
+as we expect.
+
+These come in two flavors:
+- white-box: i.e. the tests know about the internals of the components they are testing, and may modify them
+  (by injecting functions, changing consts) for testing.
+- black-box: i.e. when the tests do not know about the internals of the components they are testing, and rely
+  on only the exported methods for testing.
+
+(2) Property tests
+We use a property testing library, [gopter] for generative tests. These allow us to specify input generators,
+and ensure the invariants expected on the system hold.
+
+These come in two flavors:
+- Vanilla property tests: used when we're testing `pure` functions (i.e. side-effect free).
+- System under test: used when we're testing stateful systems.
+
+(3)

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,5 +47,3 @@ m3db packages.
 (5) DTests
 TODO
 
-(6) Production shadow
-TODO

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,18 +7,45 @@ M3DB Testing Patterns
 These are package local tests where we use mocks/stubs to ensure components interact with each other
 as we expect.
 
-These come in two flavors:
+These come in two flavours:
 - white-box: i.e. the tests know about the internals of the components they are testing, and may modify them
   (by injecting functions, changing consts) for testing.
 - black-box: i.e. when the tests do not know about the internals of the components they are testing, and rely
   on only the exported methods for testing.
 
+These are all run by the CI for every push, with race detection enabled, and code coverage within the package
+being tested.
+
 (2) Property tests
 We use a property testing library, [gopter] for generative tests. These allow us to specify input generators,
 and ensure the invariants expected on the system hold.
 
-These come in two flavors:
-- Vanilla property tests: used when we're testing `pure` functions (i.e. side-effect free).
-- System under test: used when we're testing stateful systems.
+[gopter]: https://godoc.org/github.com/leanovate/gopter
 
-(3)
+These come in two flavours:
+- Vanilla property tests: used when we're testing `pure` functions (i.e. side-effect free).
+- System under test: used when we're testing stateful systems. The allow generation of input state,
+  and the methods use to transition the state of the system.
+
+These are all run by the CI for every push, with race detection enabled, and code coverage within the package
+being tested.
+
+(3) Big Unit Tests
+These are a specialized version of the unit tests that are marked with the build tag `big`. They are heavier weight
+unit tests for which we disable race detection.
+
+These are all run by the CI for every push, with race detection disabled, and code coverage measured across all
+m3db packages.
+
+(4) Integration tests
+These tests are heavier weight tests that spin up one or more m3db DB's within a single process and test
+interactions with each other, and other components (e.g. etcd, read/write quorum).
+
+These are all run by the CI for every push, with race detection disabled, and code coverage measured across all
+m3db packages.
+
+(5) DTests
+TODO
+
+(6) Production shadow
+TODO

--- a/persist/fs/retriever_concurrent_test.go
+++ b/persist/fs/retriever_concurrent_test.go
@@ -1,4 +1,3 @@
-// +build big
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/storage/shard_foreachentry_prop_test.go
+++ b/storage/shard_foreachentry_prop_test.go
@@ -1,5 +1,3 @@
-// +build big
-//
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/storage/shard_race_prop_test.go
+++ b/storage/shard_race_prop_test.go
@@ -1,5 +1,3 @@
-// +build big
-//
 // Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Includes following changes:
 - Run `+build big` tests without the race detector (https://github.com/m3db/ci-scripts/pull/46)
 - Move any `+build big` tests which need race detection to be non-big unit tests

Results:
- Big unit tests finish in 3m instead of 7m+ 

Pending:
- [x] short doc describing testing strategies 