### PR TITLE
Add topologyResolutionTimeout to config

### DIFF
--- a/environment/config.go
+++ b/environment/config.go
@@ -62,7 +62,7 @@ type Configuration struct {
 	// NamespaceResolutionTimeout is the maximum time to wait to discover namespaces from KV
 	NamespaceResolutionTimeout time.Duration `yaml:"namespaceResolutionTimeout"`
 
-	// TopologyResolutionTimeout is the maximum time to wait to discover namespaces from KV
+	// TopologyResolutionTimeout is the maximum time to wait for a topology from KV
 	TopologyResolutionTimeout time.Duration `yaml:"topologyResolutionTimeout"`
 }
 

--- a/environment/config.go
+++ b/environment/config.go
@@ -61,6 +61,9 @@ type Configuration struct {
 
 	// NamespaceResolutionTimeout is the maximum time to wait to discover namespaces from KV
 	NamespaceResolutionTimeout time.Duration `yaml:"namespaceResolutionTimeout"`
+
+	// TopologyResolutionTimeout is the maximum time to wait to discover namespaces from KV
+	TopologyResolutionTimeout time.Duration `yaml:"topologyResolutionTimeout"`
 }
 
 // SeedNodesConfig defines fields for seed node
@@ -138,6 +141,7 @@ type ConfigurationParameters struct {
 	HashingSeed                uint32
 	HostID                     string
 	NamespaceResolutionTimeout time.Duration
+	TopologyResolutionTimeout  time.Duration
 }
 
 // Configure creates a new ConfigureResults
@@ -191,7 +195,8 @@ func (c Configuration) configureDynamic(configSvcClient client.Client, cfgParams
 		SetServiceID(serviceID).
 		SetQueryOptions(services.NewQueryOptions().SetIncludeUnhealthy(true)).
 		SetInstrumentOptions(cfgParams.InstrumentOpts).
-		SetHashGen(sharding.NewHashGenWithSeed(cfgParams.HashingSeed))
+		SetHashGen(sharding.NewHashGenWithSeed(cfgParams.HashingSeed)).
+		SetInitTimeout(cfgParams.TopologyResolutionTimeout)
 	topoInit := topology.NewDynamicInitializer(topoOpts)
 
 	kv, err := configSvcClient.KV()

--- a/services/m3dbnode/config/config_test.go
+++ b/services/m3dbnode/config/config_test.go
@@ -311,6 +311,7 @@ client:
     static: null
     seedNodes: null
     namespaceResolutionTimeout: 0s
+    topologyResolutionTimeout: 0s
   writeConsistencyLevel: 2
   readConsistencyLevel: 2
   connectConsistencyLevel: 0
@@ -532,6 +533,7 @@ config:
       clientCertAuth: false
       autoTls: false
   namespaceResolutionTimeout: 0s
+  topologyResolutionTimeout: 0s
 hashing:
   seed: 42
 index:

--- a/services/m3dbnode/server/server.go
+++ b/services/m3dbnode/server/server.go
@@ -77,7 +77,8 @@ import (
 const (
 	bootstrapConfigInitTimeout        = 10 * time.Second
 	serverGracefulCloseTimeout        = 10 * time.Second
-	defaultNamespaceResolutionTimeout = 30 * time.Second
+	defaultNamespaceResolutionTimeout = time.Minute
+	defaultTopologyResolutionTimeout  = time.Minute
 )
 
 // RunOptions provides options for running the server
@@ -319,10 +320,16 @@ func Run(runOpts RunOptions) {
 			namespaceResolutionTimeout = defaultNamespaceResolutionTimeout
 		}
 
+		topologyResolutionTimeout := cfg.EnvironmentConfig.TopologyResolutionTimeout
+		if topologyResolutionTimeout <= 0 {
+			topologyResolutionTimeout = defaultTopologyResolutionTimeout
+		}
+
 		envCfg, err = cfg.EnvironmentConfig.Configure(environment.ConfigurationParameters{
 			InstrumentOpts:             iopts,
 			HashingSeed:                cfg.Hashing.Seed,
 			NamespaceResolutionTimeout: namespaceResolutionTimeout,
+			TopologyResolutionTimeout:  topologyResolutionTimeout,
 		})
 		if err != nil {
 			logger.Fatalf("could not initialize dynamic config: %v", err)


### PR DESCRIPTION
This, along with `namespaceResolutionTimeout`, will enable users to specify a long enough duration for them to set up an M3DB cluster properties so they don't feel rushed to complete the process before the timeout is reached.