### PR TITLE
Refactoring client/

### DIFF
--- a/client/client_mock.go
+++ b/client/client_mock.go
@@ -195,8 +195,8 @@ func (_mr *MockSessionMockRecorder) FetchIDs(arg0, arg1, arg2, arg3 interface{})
 }
 
 // FetchTagged mocks base method
-func (_m *MockSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (encoding.SeriesIterators, bool, error) {
-	ret := _m.ctrl.Call(_m, "FetchTagged", _param0, _param1)
+func (_m *MockSession) FetchTagged(q index.Query, opts index.QueryOptions) (encoding.SeriesIterators, bool, error) {
+	ret := _m.ctrl.Call(_m, "FetchTagged", q, opts)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -209,8 +209,8 @@ func (_mr *MockSessionMockRecorder) FetchTagged(arg0, arg1 interface{}) *gomock.
 }
 
 // FetchTaggedIDs mocks base method
-func (_m *MockSession) FetchTaggedIDs(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
-	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", _param0, _param1)
+func (_m *MockSession) FetchTaggedIDs(q index.Query, opts index.QueryOptions) (index.QueryResults, error) {
+	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", q, opts)
 	ret0, _ := ret[0].(index.QueryResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -540,8 +540,8 @@ func (_mr *MockAdminSessionMockRecorder) FetchIDs(arg0, arg1, arg2, arg3 interfa
 }
 
 // FetchTagged mocks base method
-func (_m *MockAdminSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (encoding.SeriesIterators, bool, error) {
-	ret := _m.ctrl.Call(_m, "FetchTagged", _param0, _param1)
+func (_m *MockAdminSession) FetchTagged(q index.Query, opts index.QueryOptions) (encoding.SeriesIterators, bool, error) {
+	ret := _m.ctrl.Call(_m, "FetchTagged", q, opts)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -554,8 +554,8 @@ func (_mr *MockAdminSessionMockRecorder) FetchTagged(arg0, arg1 interface{}) *go
 }
 
 // FetchTaggedIDs mocks base method
-func (_m *MockAdminSession) FetchTaggedIDs(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
-	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", _param0, _param1)
+func (_m *MockAdminSession) FetchTaggedIDs(q index.Query, opts index.QueryOptions) (index.QueryResults, error) {
+	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", q, opts)
 	ret0, _ := ret[0].(index.QueryResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2851,8 +2851,8 @@ func (_mr *MockclientSessionMockRecorder) FetchIDs(arg0, arg1, arg2, arg3 interf
 }
 
 // FetchTagged mocks base method
-func (_m *MockclientSession) FetchTagged(_param0 index.Query, _param1 index.QueryOptions) (encoding.SeriesIterators, bool, error) {
-	ret := _m.ctrl.Call(_m, "FetchTagged", _param0, _param1)
+func (_m *MockclientSession) FetchTagged(q index.Query, opts index.QueryOptions) (encoding.SeriesIterators, bool, error) {
+	ret := _m.ctrl.Call(_m, "FetchTagged", q, opts)
 	ret0, _ := ret[0].(encoding.SeriesIterators)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -2865,8 +2865,8 @@ func (_mr *MockclientSessionMockRecorder) FetchTagged(arg0, arg1 interface{}) *g
 }
 
 // FetchTaggedIDs mocks base method
-func (_m *MockclientSession) FetchTaggedIDs(_param0 index.Query, _param1 index.QueryOptions) (index.QueryResults, error) {
-	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", _param0, _param1)
+func (_m *MockclientSession) FetchTaggedIDs(q index.Query, opts index.QueryOptions) (index.QueryResults, error) {
+	ret := _m.ctrl.Call(_m, "FetchTaggedIDs", q, opts)
 	ret0, _ := ret[0].(index.QueryResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/client/host_queue_fetch_batch_test.go
+++ b/client/host_queue_fetch_batch_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/uber/tchannel-go/thrift"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostQueueFetchBatches(t *testing.T) {
+	namespace := "testNs"
+	ids := []string{"foo", "bar", "baz", "qux"}
+	result := &rpc.FetchBatchRawResult_{}
+	for range ids {
+		result.Elements = append(result.Elements, &rpc.FetchRawResult_{Segments: []*rpc.Segments{}})
+	}
+	var expected []hostQueueResult
+	for i := range ids {
+		expected = append(expected, hostQueueResult{result.Elements[i].Segments, nil})
+	}
+	testHostQueueFetchBatches(t, namespace, ids, result, expected, nil, func(results []hostQueueResult) {
+		assert.Equal(t, expected, results)
+	})
+}
+
+func TestHostQueueFetchBatchesErrorOnNextClientUnavailable(t *testing.T) {
+	namespace := "testNs"
+	ids := []string{"foo", "bar", "baz", "qux"}
+	expectedErr := fmt.Errorf("an error")
+	var expected []hostQueueResult
+	for range ids {
+		expected = append(expected, hostQueueResult{nil, expectedErr})
+	}
+	opts := &testHostQueueFetchBatchesOptions{
+		nextClientErr: expectedErr,
+	}
+	testHostQueueFetchBatches(t, namespace, ids, nil, expected, opts, func(results []hostQueueResult) {
+		assert.Equal(t, expected, results)
+	})
+}
+
+func TestHostQueueFetchBatchesErrorOnFetchRawBatchError(t *testing.T) {
+	namespace := "testNs"
+	ids := []string{"foo", "bar", "baz", "qux"}
+	expectedErr := fmt.Errorf("an error")
+	var expected []hostQueueResult
+	for range ids {
+		expected = append(expected, hostQueueResult{nil, expectedErr})
+	}
+	opts := &testHostQueueFetchBatchesOptions{
+		fetchRawBatchErr: expectedErr,
+	}
+	testHostQueueFetchBatches(t, namespace, ids, nil, expected, opts, func(results []hostQueueResult) {
+		assert.Equal(t, expected, results)
+	})
+}
+
+func TestHostQueueFetchBatchesErrorOnFetchNoResponse(t *testing.T) {
+	namespace := "testNs"
+	ids := []string{"foo", "bar", "baz", "qux"}
+	result := &rpc.FetchBatchRawResult_{}
+	for range ids[:len(ids)-1] {
+		result.Elements = append(result.Elements, &rpc.FetchRawResult_{Segments: []*rpc.Segments{}})
+	}
+	var expected []hostQueueResult
+	for i := range ids[:len(ids)-1] {
+		expected = append(expected, hostQueueResult{result.Elements[i].Segments, nil})
+	}
+
+	testHostQueueFetchBatches(t, namespace, ids, result, expected, nil, func(results []hostQueueResult) {
+		assert.Equal(t, expected, results[:len(results)-1])
+		lastResult := results[len(results)-1]
+		assert.Nil(t, lastResult.result)
+		assert.IsType(t, errQueueFetchNoResponse(""), lastResult.err)
+	})
+}
+
+func TestHostQueueFetchBatchesErrorOnResultError(t *testing.T) {
+	namespace := "testNs"
+	ids := []string{"foo", "bar", "baz", "qux"}
+	anError := &rpc.Error{Type: rpc.ErrorType_INTERNAL_ERROR, Message: "an error"}
+	result := &rpc.FetchBatchRawResult_{}
+	for range ids[:len(ids)-1] {
+		result.Elements = append(result.Elements, &rpc.FetchRawResult_{Segments: []*rpc.Segments{}})
+	}
+	result.Elements = append(result.Elements, &rpc.FetchRawResult_{Err: anError})
+	var expected []hostQueueResult
+	for i := range ids[:len(ids)-1] {
+		expected = append(expected, hostQueueResult{result.Elements[i].Segments, nil})
+	}
+	testHostQueueFetchBatches(t, namespace, ids, result, expected, nil, func(results []hostQueueResult) {
+		assert.Equal(t, expected, results[:len(results)-1])
+		rpcErr, ok := results[len(results)-1].err.(*rpc.Error)
+		assert.True(t, ok)
+		assert.Equal(t, anError.Type, rpcErr.Type)
+		assert.Equal(t, anError.Message, rpcErr.Message)
+	})
+}
+
+type testHostQueueFetchBatchesOptions struct {
+	nextClientErr    error
+	fetchRawBatchErr error
+}
+
+func testHostQueueFetchBatches(
+	t *testing.T,
+	namespace string,
+	ids []string,
+	result *rpc.FetchBatchRawResult_,
+	expected []hostQueueResult,
+	testOpts *testHostQueueFetchBatchesOptions,
+	assertion func(results []hostQueueResult),
+) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for fetches
+	var (
+		results []hostQueueResult
+		wg      sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		results = append(results, hostQueueResult{r, err})
+		wg.Done()
+	}
+
+	rawIDs := make([][]byte, len(ids))
+
+	for i, id := range ids {
+		rawIDs[i] = []byte(id)
+	}
+
+	// Prepare fetch batch op
+	fetchBatch := &fetchBatchOp{
+		request: rpc.FetchBatchRawRequest{
+			RangeStart: 0,
+			RangeEnd:   1,
+			NameSpace:  []byte(namespace),
+			Ids:        rawIDs,
+		},
+	}
+	for range fetchBatch.request.Ids {
+		fetchBatch.completionFns = append(fetchBatch.completionFns, callback)
+	}
+	wg.Add(len(fetchBatch.request.Ids))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	if testOpts != nil && testOpts.nextClientErr != nil {
+		mockConnPool.EXPECT().NextClient().Return(nil, testOpts.nextClientErr)
+	} else if testOpts != nil && testOpts.fetchRawBatchErr != nil {
+		fetchBatchRaw := func(ctx thrift.Context, req *rpc.FetchBatchRawRequest) {
+			assert.Equal(t, &fetchBatch.request, req)
+		}
+		mockClient.EXPECT().
+			FetchBatchRaw(gomock.Any(), gomock.Any()).
+			Do(fetchBatchRaw).
+			Return(nil, testOpts.fetchRawBatchErr)
+
+		mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+	} else {
+		fetchBatchRaw := func(ctx thrift.Context, req *rpc.FetchBatchRawRequest) {
+			assert.Equal(t, &fetchBatch.request, req)
+		}
+		mockClient.EXPECT().
+			FetchBatchRaw(gomock.Any(), gomock.Any()).
+			Do(fetchBatchRaw).
+			Return(result, nil)
+
+		mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+	}
+
+	// Fetch
+	assert.NoError(t, queue.Enqueue(fetchBatch))
+
+	// Wait for fetch to complete
+	wg.Wait()
+
+	// Assert results match expected
+	assertion(results)
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}

--- a/client/host_queue_write_batch_test.go
+++ b/client/host_queue_write_batch_test.go
@@ -1,0 +1,497 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3x/ident"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/thrift"
+)
+
+func TestHostQueueWriteErrorBeforeOpen(t *testing.T) {
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts)
+
+	assert.Error(t, queue.Enqueue(&writeOperation{}))
+}
+
+func TestHostQueueWriteErrorAfterClose(t *testing.T) {
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts)
+
+	queue.Open()
+	queue.Close()
+
+	assert.Error(t, queue.Enqueue(&writeOperation{}))
+}
+
+func TestHostQueueWriteBatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results []hostQueueResult
+		wg      sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		results = append(results, hostQueueResult{r, err})
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeOperation{
+		testWriteOp("testNs", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "bar", 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "baz", 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "qux", 4.0, 4000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	for i, write := range writes[:3] {
+		assert.NoError(t, queue.Enqueue(write))
+		assert.Equal(t, i+1, queue.Len())
+
+		// Sleep some so that we can ensure flushing is not happening until queue is full
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+		}
+	}
+	mockClient.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil)
+
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Final write will flush
+	assert.NoError(t, queue.Enqueue(writes[3]))
+	assert.Equal(t, 0, queue.Len())
+
+	// Wait for all writes
+	wg.Wait()
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteBatchesDifferentNamespaces(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results     []hostQueueResult
+		resultsLock sync.Mutex
+		wg          sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		resultsLock.Lock()
+		results = append(results, hostQueueResult{r, err})
+		resultsLock.Unlock()
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeOperation{
+		testWriteOp("testNs1", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs1", "bar", 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs1", "baz", 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs2", "qux", 4.0, 4000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteBatchRawRequest) {
+		var writesForNamespace []*writeOperation
+		if string(req.NameSpace) == "testNs1" {
+			writesForNamespace = writes[:3]
+		} else {
+			writesForNamespace = writes[3:]
+		}
+		assert.Equal(t, len(writesForNamespace), len(req.Elements))
+		for i, write := range writesForNamespace {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+		}
+	}
+
+	// Assert the writes will be handled in two batches
+	mockClient.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil).MinTimes(2).MaxTimes(2)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil).MinTimes(2).MaxTimes(2)
+
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for all writes
+	wg.Wait()
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteBatchesNoClientAvailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushInterval(time.Millisecond)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare mocks for flush
+	nextClientErr := fmt.Errorf("an error")
+	mockConnPool.EXPECT().NextClient().Return(nil, nextClientErr)
+
+	// Write
+	var wg sync.WaitGroup
+	wg.Add(1)
+	callback := func(r interface{}, err error) {
+		assert.Error(t, err)
+		assert.Equal(t, nextClientErr, err)
+		wg.Done()
+	}
+	assert.NoError(t, queue.Enqueue(testWriteOp("testNs", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback)))
+
+	// Wait for background flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteBatchesPartialBatchErrs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushSize(2)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare writes
+	var wg sync.WaitGroup
+	writeErr := "a write error"
+	writes := []*writeOperation{
+		testWriteOp("testNs", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, func(r interface{}, err error) {
+			assert.Error(t, err)
+			rpcErr, ok := err.(*rpc.Error)
+			assert.True(t, ok)
+			assert.Equal(t, rpc.ErrorType_INTERNAL_ERROR, rpcErr.Type)
+			assert.Equal(t, writeErr, rpcErr.Message)
+			wg.Done()
+		}),
+		testWriteOp("testNs", "bar", 2.0, 2000, rpc.TimeType_UNIX_SECONDS, func(r interface{}, err error) {
+			assert.NoError(t, err)
+			wg.Done()
+		}),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+		}
+	}
+	batchErrs := &rpc.WriteBatchRawErrors{Errors: []*rpc.WriteBatchRawError{
+		&rpc.WriteBatchRawError{Index: 0, Err: &rpc.Error{
+			Type:    rpc.ErrorType_INTERNAL_ERROR,
+			Message: writeErr,
+		}},
+	}}
+	mockClient.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(batchErrs)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Perform writes
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteBatchesEntireBatchErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushSize(2)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare writes
+	var wg sync.WaitGroup
+	writeErr := fmt.Errorf("an error")
+	callback := func(r interface{}, err error) {
+		assert.Error(t, err)
+		assert.Equal(t, writeErr, err)
+		wg.Done()
+	}
+	writes := []*writeOperation{
+		testWriteOp("testNs", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "bar", 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+		}
+	}
+	mockClient.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(writeErr)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Perform writes
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueDrainOnClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results []hostQueueResult
+		wg      sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		results = append(results, hostQueueResult{r, err})
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeOperation{
+		testWriteOp("testNs", "foo", 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "bar", 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteOp("testNs", "baz", 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+
+	for i, write := range writes {
+		wg.Add(1)
+		assert.NoError(t, queue.Enqueue(write))
+		assert.Equal(t, i+1, queue.Len())
+
+		// Sleep some so that we can ensure flushing is not happening until queue is full
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+		}
+	}
+	mockClient.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil)
+
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	mockConnPool.EXPECT().Close().AnyTimes()
+
+	// Close the queue should cause all writes to be flushed
+	queue.Close()
+
+	closeCh := make(chan struct{})
+
+	go func() {
+		// Wait for all writes
+		wg.Wait()
+
+		close(closeCh)
+	}()
+
+	select {
+	case <-closeCh:
+	case <-time.After(time.Minute):
+		assert.Fail(t, "Not flushing writes")
+	}
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+}
+
+func testWriteOp(
+	namespace string,
+	id string,
+	value float64,
+	timestamp int64,
+	timeType rpc.TimeType,
+	completionFn completionFn,
+) *writeOperation {
+	w := &writeOperation{}
+	w.reset()
+	w.namespace = ident.StringID(namespace)
+	w.request.ID = []byte(id)
+	w.request.Datapoint = &rpc.Datapoint{
+		Value:             value,
+		Timestamp:         timestamp,
+		TimestampTimeType: timeType,
+	}
+	w.completionFn = completionFn
+	return w
+}

--- a/client/host_queue_write_tagged_test.go
+++ b/client/host_queue_write_tagged_test.go
@@ -1,0 +1,548 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3x/ident"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/thrift"
+)
+
+func TestHostQueueWriteTaggedErrorBeforeOpen(t *testing.T) {
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts)
+
+	assert.Error(t, queue.Enqueue(&writeTaggedOperation{}))
+}
+
+func TestHostQueueWriteTaggedErrorAfterClose(t *testing.T) {
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts)
+
+	queue.Open()
+	queue.Close()
+
+	assert.Error(t, queue.Enqueue(&writeTaggedOperation{}))
+}
+
+func TestHostQueueWriteTaggedBatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results []hostQueueResult
+		wg      sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		results = append(results, hostQueueResult{r, err})
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeTaggedOperation{
+		testWriteTaggedOp("testNs", "foo", map[string]string{
+			"tag": "value",
+			"sup": "holmes",
+		}, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "bar", map[string]string{
+			"and": "one",
+		}, 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "baz", map[string]string{
+			"cmon": "dawg",
+			"mmm":  "kay",
+		}, 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "qux", map[string]string{
+			"mas": "ter",
+			"sal": "vo",
+		}, 4.0, 4000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	for i, write := range writes[:3] {
+		assert.NoError(t, queue.Enqueue(write))
+		assert.Equal(t, i+1, queue.Len())
+
+		// Sleep some so that we can ensure flushing is not happening until queue is full
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteTaggedBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+			assert.Equal(t, req.Elements[i].EncodedTags, write.request.EncodedTags)
+		}
+	}
+	mockClient.EXPECT().WriteTaggedBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil)
+
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Final write will flush
+	assert.NoError(t, queue.Enqueue(writes[3]))
+	assert.Equal(t, 0, queue.Len())
+
+	// Wait for all writes
+	wg.Wait()
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteTaggedBatchesDifferentNamespaces(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results     []hostQueueResult
+		resultsLock sync.Mutex
+		wg          sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		resultsLock.Lock()
+		results = append(results, hostQueueResult{r, err})
+		resultsLock.Unlock()
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeTaggedOperation{
+		testWriteTaggedOp("testNs1", "foo", map[string]string{
+			"tag": "value",
+			"sup": "holmes",
+		}, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs1", "bar", map[string]string{
+			"and": "one",
+		}, 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs1", "baz", map[string]string{
+			"cmon": "dawg",
+			"mmm":  "kay",
+		}, 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs2", "qux", map[string]string{
+			"mas": "ter",
+			"sal": "vo",
+		}, 4.0, 4000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteTaggedBatchRawRequest) {
+		var writesForNamespace []*writeTaggedOperation
+		if string(req.NameSpace) == "testNs1" {
+			writesForNamespace = writes[:3]
+		} else {
+			writesForNamespace = writes[3:]
+		}
+		assert.Equal(t, len(writesForNamespace), len(req.Elements))
+		for i, write := range writesForNamespace {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+			assert.Equal(t, req.Elements[i].EncodedTags, write.request.EncodedTags)
+		}
+	}
+
+	// Assert the writes will be handled in two batches
+	mockClient.EXPECT().WriteTaggedBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil).MinTimes(2).MaxTimes(2)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil).MinTimes(2).MaxTimes(2)
+
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for all writes
+	wg.Wait()
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteTaggedBatchesNoClientAvailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushInterval(time.Millisecond)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare mocks for flush
+	nextClientErr := fmt.Errorf("an error")
+	mockConnPool.EXPECT().NextClient().Return(nil, nextClientErr)
+
+	// Write
+	var wg sync.WaitGroup
+	wg.Add(1)
+	callback := func(r interface{}, err error) {
+		assert.Error(t, err)
+		assert.Equal(t, nextClientErr, err)
+		wg.Done()
+	}
+	assert.NoError(t, queue.Enqueue(testWriteTaggedOp("testNs", "foo", nil, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback)))
+
+	// Wait for background flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteTaggedBatchesPartialBatchErrs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushSize(2)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare writes
+	var wg sync.WaitGroup
+	writeErr := "a write error"
+	writes := []*writeTaggedOperation{
+		testWriteTaggedOp("testNs", "foo", map[string]string{
+			"mmm": "kay",
+		}, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, func(r interface{}, err error) {
+			assert.Error(t, err)
+			rpcErr, ok := err.(*rpc.Error)
+			assert.True(t, ok)
+			assert.Equal(t, rpc.ErrorType_INTERNAL_ERROR, rpcErr.Type)
+			assert.Equal(t, writeErr, rpcErr.Message)
+			wg.Done()
+		}),
+		testWriteTaggedOp("testNs", "bar", map[string]string{
+			"who": "dat",
+		}, 2.0, 2000, rpc.TimeType_UNIX_SECONDS, func(r interface{}, err error) {
+			assert.NoError(t, err)
+			wg.Done()
+		}),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteTaggedBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+			assert.Equal(t, req.Elements[i].EncodedTags, write.request.EncodedTags)
+		}
+	}
+	batchErrs := &rpc.WriteBatchRawErrors{Errors: []*rpc.WriteBatchRawError{
+		&rpc.WriteBatchRawError{Index: 0, Err: &rpc.Error{
+			Type:    rpc.ErrorType_INTERNAL_ERROR,
+			Message: writeErr,
+		}},
+	}}
+	mockClient.EXPECT().WriteTaggedBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(batchErrs)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Perform writes
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueWriteTaggedBatchesEntireBatchErr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	opts = opts.SetHostQueueOpsFlushSize(2)
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare writes
+	var wg sync.WaitGroup
+	writeErr := fmt.Errorf("an error")
+	callback := func(r interface{}, err error) {
+		assert.Error(t, err)
+		assert.Equal(t, writeErr, err)
+		wg.Done()
+	}
+	writes := []*writeTaggedOperation{
+		testWriteTaggedOp("testNs", "foo", map[string]string{"abc": "def"}, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "bar", map[string]string{"ghi": "klm"}, 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+	wg.Add(len(writes))
+
+	// Prepare mocks for flush
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteTaggedBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+			assert.Equal(t, req.Elements[i].EncodedTags, write.request.EncodedTags)
+		}
+	}
+	mockClient.EXPECT().WriteTaggedBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(writeErr)
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	// Perform writes
+	for _, write := range writes {
+		assert.NoError(t, queue.Enqueue(write))
+	}
+
+	// Wait for flush
+	wg.Wait()
+
+	// Close
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	mockConnPool.EXPECT().Close().Do(func() {
+		closeWg.Done()
+	})
+	queue.Close()
+	closeWg.Wait()
+}
+
+func TestHostQueueDrainOnCloseTaggedWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockConnPool := NewMockconnectionPool(ctrl)
+
+	opts := newHostQueueTestOptions()
+	queue := newHostQueue(h, testWriteBatchRawPool,
+		testWriteArrayPool, testWriteTaggedBatchRawPool,
+		testWriteTaggedArrayPool, opts).(*queue)
+	queue.connPool = mockConnPool
+
+	// Open
+	mockConnPool.EXPECT().Open()
+	queue.Open()
+	assert.Equal(t, statusOpen, queue.status)
+
+	// Prepare callback for writes
+	var (
+		results []hostQueueResult
+		wg      sync.WaitGroup
+	)
+	callback := func(r interface{}, err error) {
+		results = append(results, hostQueueResult{r, err})
+		wg.Done()
+	}
+
+	// Prepare writes
+	writes := []*writeTaggedOperation{
+		testWriteTaggedOp("testNs", "foo", map[string]string{"a": "b"}, 1.0, 1000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "bar", map[string]string{"k": "l"}, 2.0, 2000, rpc.TimeType_UNIX_SECONDS, callback),
+		testWriteTaggedOp("testNs", "baz", map[string]string{"e": "f"}, 3.0, 3000, rpc.TimeType_UNIX_SECONDS, callback),
+	}
+
+	for i, write := range writes {
+		wg.Add(1)
+		assert.NoError(t, queue.Enqueue(write))
+		assert.Equal(t, i+1, queue.Len())
+
+		// Sleep some so that we can ensure flushing is not happening until queue is full
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mockClient := rpc.NewMockTChanNode(ctrl)
+	writeBatch := func(ctx thrift.Context, req *rpc.WriteTaggedBatchRawRequest) {
+		for i, write := range writes {
+			assert.Equal(t, req.Elements[i].ID, write.request.ID)
+			assert.Equal(t, req.Elements[i].Datapoint, write.request.Datapoint)
+			assert.Equal(t, req.Elements[i].EncodedTags, write.request.EncodedTags)
+		}
+	}
+	mockClient.EXPECT().WriteTaggedBatchRaw(gomock.Any(), gomock.Any()).Do(writeBatch).Return(nil)
+
+	mockConnPool.EXPECT().NextClient().Return(mockClient, nil)
+
+	mockConnPool.EXPECT().Close().AnyTimes()
+
+	// Close the queue should cause all writes to be flushed
+	queue.Close()
+
+	closeCh := make(chan struct{})
+
+	go func() {
+		// Wait for all writes
+		wg.Wait()
+
+		close(closeCh)
+	}()
+
+	select {
+	case <-closeCh:
+	case <-time.After(time.Minute):
+		assert.Fail(t, "Not flushing writes")
+	}
+
+	// Assert writes successful
+	assert.Equal(t, len(writes), len(results))
+	for _, result := range results {
+		assert.Nil(t, result.err)
+	}
+}
+
+func testWriteTaggedOp(
+	namespace string,
+	id string,
+	tags map[string]string,
+	value float64,
+	timestamp int64,
+	timeType rpc.TimeType,
+	completionFn completionFn,
+) *writeTaggedOperation {
+	w := &writeTaggedOperation{}
+	w.reset()
+	w.namespace = ident.StringID(namespace)
+	w.request.ID = []byte(id)
+	w.request.Datapoint = &rpc.Datapoint{
+		Value:             value,
+		Timestamp:         timestamp,
+		TimestampTimeType: timeType,
+	}
+	w.request.EncodedTags = testEncode(tags)
+	w.completionFn = completionFn
+	return w
+}
+
+func testEncode(tags map[string]string) []byte {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b []byte
+	for _, k := range keys {
+		b = append(b, []byte(k)...)
+		b = append(b, []byte("=")...)
+		b = append(b, []byte(tags[k])...)
+		b = append(b, []byte("|")...)
+	}
+	return b
+}

--- a/client/session_pools.go
+++ b/client/session_pools.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,34 +20,27 @@
 
 package client
 
-var (
-	testWriteBatchRawPool       writeBatchRawRequestPool
-	testWriteArrayPool          writeBatchRawRequestElementArrayPool
-	testWriteTaggedBatchRawPool writeTaggedBatchRawRequestPool
-	testWriteTaggedArrayPool    writeTaggedBatchRawRequestElementArrayPool
+import (
+	"github.com/m3db/m3db/encoding"
+	"github.com/m3db/m3db/serialize"
+	"github.com/m3db/m3x/context"
+	"github.com/m3db/m3x/ident"
 )
 
-func init() {
-	testWriteBatchRawPool = newWriteBatchRawRequestPool(nil)
-	testWriteBatchRawPool.Init()
-	testWriteArrayPool = newWriteBatchRawRequestElementArrayPool(nil, 0)
-	testWriteArrayPool.Init()
-	testWriteTaggedBatchRawPool = newWriteTaggedBatchRawRequestPool(nil)
-	testWriteTaggedBatchRawPool.Init()
-	testWriteTaggedArrayPool = newWriteTaggedBatchRawRequestElementArrayPool(nil, 0)
-	testWriteTaggedArrayPool.Init()
-}
-
-type hostQueueResult struct {
-	result interface{}
-	err    error
-}
-
-func newHostQueueTestOptions() Options {
-	return NewOptions().
-		SetHostQueueOpsFlushSize(4).
-		SetHostQueueOpsArrayPoolSize(4).
-		SetWriteBatchSize(4).
-		SetFetchBatchSize(4).
-		SetHostQueueOpsFlushInterval(0)
+type sessionPools struct {
+	context                     context.Pool
+	id                          ident.Pool
+	writeOperation              *writeOperationPool
+	writeTaggedOperation        *writeTaggedOperationPool
+	fetchBatchOp                *fetchBatchOpPool
+	fetchBatchOpArrayArray      *fetchBatchOpArrayArrayPool
+	iteratorArray               encoding.IteratorArrayPool
+	tagEncoder                  serialize.TagEncoderPool
+	readerSliceOfSlicesIterator *readerSliceOfSlicesIteratorPool
+	multiReaderIterator         encoding.MultiReaderIteratorPool
+	seriesIterator              encoding.SeriesIteratorPool
+	seriesIterators             encoding.MutableSeriesIteratorsPool
+	writeAttempt                *writeAttemptPool
+	writeState                  *writeStatePool
+	fetchAttempt                *fetchAttemptPool
 }

--- a/client/session_util.go
+++ b/client/session_util.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/m3db/m3db/topology"
+)
+
+func writeConsistencyAchieved(
+	level topology.ConsistencyLevel,
+	majority, enqueued, success int,
+) bool {
+	switch level {
+	case topology.ConsistencyLevelAll:
+		if success == enqueued { // Meets all
+			return true
+		}
+	case topology.ConsistencyLevelMajority:
+		if success >= majority { // Meets majority
+			return true
+		}
+	case topology.ConsistencyLevelOne:
+		if success > 0 { // Meets one
+			return true
+		}
+	default:
+		panic(fmt.Errorf("unrecognized consistency level: %s", level.String()))
+	}
+	return false
+}
+
+func readConsistencyAchieved(
+	level topology.ReadConsistencyLevel,
+	majority, enqueued, success int,
+) bool {
+	switch level {
+	case topology.ReadConsistencyLevelAll:
+		if success == enqueued { // Meets all
+			return true
+		}
+	case topology.ReadConsistencyLevelMajority:
+		if success >= majority { // Meets majority
+			return true
+		}
+	case topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority:
+		if success > 0 { // Meets one
+			return true
+		}
+	case topology.ReadConsistencyLevelNone:
+		return true // Always meets none
+	default:
+		panic(fmt.Errorf("unrecognized consistency level: %s", level.String()))
+	}
+	return false
+}

--- a/client/session_write_tagged_test.go
+++ b/client/session_write_tagged_test.go
@@ -67,7 +67,7 @@ func TestSessionWriteTagged(t *testing.T) {
 	mockEncoder.EXPECT().Finalize().AnyTimes()
 	mockEncoderPool := serialize.NewMockTagEncoderPool(ctrl)
 	mockEncoderPool.EXPECT().Get().Return(mockEncoder).AnyTimes()
-	session.tagEncoderPool = mockEncoderPool
+	session.pools.tagEncoder = mockEncoderPool
 
 	var completionFn completionFn
 	enqueueWg := mockHostQueues(ctrl, session, sessionTestReplicas, []testEnqueueFn{func(idx int, op op) {
@@ -250,7 +250,7 @@ func TestSessionWriteTaggedRetry(t *testing.T) {
 	mockEncoder.EXPECT().Finalize().AnyTimes()
 	mockEncoderPool := serialize.NewMockTagEncoderPool(ctrl)
 	mockEncoderPool.EXPECT().Get().Return(mockEncoder).AnyTimes()
-	session.tagEncoderPool = mockEncoderPool
+	session.pools.tagEncoder = mockEncoderPool
 
 	var hosts []topology.Host
 	var completionFn completionFn

--- a/client/types.go
+++ b/client/types.go
@@ -73,10 +73,10 @@ type Session interface {
 	FetchIDs(namespace ident.ID, ids ident.Iterator, startInclusive, endExclusive time.Time) (encoding.SeriesIterators, error)
 
 	// FetchTagged resolves the provided query to known IDs, and fetches the data for them.
-	FetchTagged(index.Query, index.QueryOptions) (results encoding.SeriesIterators, exhaustive bool, err error)
+	FetchTagged(q index.Query, opts index.QueryOptions) (results encoding.SeriesIterators, exhaustive bool, err error)
 
 	// FetchTaggedIDs resolves the provided query to known IDs.
-	FetchTaggedIDs(index.Query, index.QueryOptions) (index.QueryResults, error)
+	FetchTaggedIDs(q index.Query, opts index.QueryOptions) (index.QueryResults, error)
 
 	// ShardID returns the given shard for an ID for callers
 	// to easily discern what shard is failing when operations

--- a/client/write_tagged_test.go
+++ b/client/write_tagged_test.go
@@ -125,17 +125,17 @@ func TestShardNotAvailableTagged(t *testing.T) {
 // utils
 
 func getWriteTaggedState(ctrl *gomock.Controller, s *session, w writeTaggedStub) *writeState {
-	wState := s.writeStatePool.Get()
+	wState := s.pools.writeState.Get()
 	s.state.RLock()
 	wState.consistencyLevel = s.state.writeLevel
 	wState.topoMap = s.state.topoMap
 	s.state.RUnlock()
-	o := s.writeTaggedOperationPool.Get()
+	o := s.pools.writeTaggedOperation.Get()
 	o.shardID = 0 // Any valid shardID
 	wState.op = o
 	wState.nsID = w.ns
 	wState.tsID = w.id
-	wState.tagEncoder = s.tagEncoderPool.Get()
+	wState.tagEncoder = s.pools.tagEncoder.Get()
 	return wState
 }
 

--- a/client/write_test.go
+++ b/client/write_test.go
@@ -126,12 +126,12 @@ func TestShardNotAvailable(t *testing.T) {
 // utils
 
 func getWriteState(s *session, w writeStub) *writeState {
-	wState := s.writeStatePool.Get()
+	wState := s.pools.writeState.Get()
 	s.state.RLock()
 	wState.consistencyLevel = s.state.writeLevel
 	wState.topoMap = s.state.topoMap
 	s.state.RUnlock()
-	o := s.writeOperationPool.Get()
+	o := s.pools.writeOperation.Get()
 	o.shardID = 0 // Any valid shardID
 	wState.op = o
 	wState.nsID = w.ns


### PR DESCRIPTION
Only cosmetic changes included, no functionality has changed in this PR. It's broken off the fetch tagged one to keep it shorter, changes:
- Refactor `session.pools` into it's own struct 
- Break up host queue tests into files per RPC endpoint
- Extract `writeConsistencyAchieved` and `readConsistencyAchieved` methods from `session`
