### PR TITLE
FetchTagged followups [1/n]

### DIFF
--- a/client/fetch_state.go
+++ b/client/fetch_state.go
@@ -58,7 +58,7 @@ type fetchState struct {
 
 func newFetchState(pool fetchStatePool) *fetchState {
 	f := &fetchState{
-		tagResultAccumulator: fetchTaggedResultAccumulator{},
+		tagResultAccumulator: newFetchTaggedResultAccumulator(),
 		pool:                 pool,
 	}
 	f.destructorFn = f.close // Set refCounter completion as close

--- a/client/fetch_tagged_results_accumulator_consistency_prop_test.go
+++ b/client/fetch_tagged_results_accumulator_consistency_prop_test.go
@@ -1,0 +1,309 @@
+// +build big
+//
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/require"
+)
+
+const maxNumHostsPropTest = 10
+
+func TestFetchTaggedResultsAccumulatorGenerativeConsistencyCheck(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	seed := time.Now().UnixNano()
+	parameters.MinSuccessfulTests = 40
+	parameters.MaxSize = 40
+	parameters.Rng = rand.New(rand.NewSource(seed))
+	parameters.Workers = 1
+	properties := gopter.NewProperties(parameters)
+
+	properties.Property("accumulator handles read consistency level correctly", prop.ForAll(
+		func(input topoAndHostResponses, lvl topology.ReadConsistencyLevel) *gopter.PropResult {
+			topoMap := input.topoMap
+			success := input.success
+			numHosts := topoMap.HostsLen()
+			if numHosts > len(success) {
+				panic("invalid test setup")
+			}
+
+			situationMeetsLevel := input.meetsConsistencyCheckForLevel(t, lvl)
+
+			accum := newFetchTaggedResultAccumulator()
+			majority := topoMap.MajorityReplicas()
+			accum.Clear()
+			accum.Reset(testStartTime, testEndTime, topoMap, majority, lvl)
+			var (
+				done bool
+				err  error
+			)
+			for idx, host := range topoMap.Hosts() {
+				var hostErr error
+				opts := fetchTaggedResultAccumulatorOpts{host: host}
+				if success[idx] {
+					opts.response = &rpc.FetchTaggedResult_{}
+				} else {
+					hostErr = fmt.Errorf("random err")
+				}
+				done, err = accum.Add(opts, hostErr)
+				if done {
+					break
+				}
+			}
+			require.True(t, done)
+
+			if situationMeetsLevel {
+				if err != nil {
+					// something's fked
+					return &gopter.PropResult{
+						Error:  fmt.Errorf("situationMeetsLvl but err=%v", err),
+						Status: gopter.PropError,
+					}
+				}
+				return &gopter.PropResult{Status: gopter.PropTrue}
+			}
+			// i.e. !situationMeetsLevel
+			if err == nil {
+				return &gopter.PropResult{
+					Error:  fmt.Errorf("!situationMeetsLevel && err == nil"),
+					Status: gopter.PropError,
+				}
+			}
+			return &gopter.PropResult{Status: gopter.PropTrue}
+		},
+		genTopologyAndResponse(t),
+		gen.OneConstOf(
+			topology.ReadConsistencyLevelAll,
+			topology.ReadConsistencyLevelMajority,
+			topology.ReadConsistencyLevelOne,
+			topology.ReadConsistencyLevelUnstrictMajority,
+		),
+	))
+
+	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)
+	if !properties.Run(reporter) {
+		t.Errorf("failed with initial seed: %d", seed)
+	}
+}
+
+type topoAndHostResponses struct {
+	topoMap topology.Map
+	success []bool
+}
+
+func (res topoAndHostResponses) meetsConsistencyCheckForLevel(
+	t *testing.T,
+	lvl topology.ReadConsistencyLevel,
+) bool {
+	topoMap := res.topoMap
+	rf, majority, numHosts := topoMap.Replicas(), topoMap.MajorityReplicas(), topoMap.HostsLen()
+	successes := res.success
+
+	var requiredNumSuccessResponsePerShard int
+	switch lvl {
+	case topology.ReadConsistencyLevelAll:
+		requiredNumSuccessResponsePerShard = rf
+	case topology.ReadConsistencyLevelMajority:
+		requiredNumSuccessResponsePerShard = majority
+	case topology.ReadConsistencyLevelUnstrictMajority:
+		fallthrough
+	case topology.ReadConsistencyLevelOne:
+		requiredNumSuccessResponsePerShard = 1
+	}
+
+	// map from hostID -> idx in the hosts array
+	hostsIdxMap := make(map[string]int, numHosts)
+	for idx, h := range topoMap.Hosts() {
+		hostsIdxMap[h.ID()] = idx
+	}
+
+	// map from shard -> numSuccess responses
+	shardResponses := make(map[uint32]int)
+	shards := topoMap.ShardSet()
+	for _, s := range shards.AllIDs() {
+		shardResponses[s] = 0
+		hosts, err := topoMap.RouteShard(s)
+		require.NoError(t, err)
+		for _, h := range hosts {
+			idx, ok := hostsIdxMap[h.ID()]
+			require.True(t, ok)
+			if successes[idx] {
+				shardResponses[s]++
+			}
+		}
+	}
+
+	// ensure all shards have at least `requiredNumSuccessResponsePerShard` responses
+	for _, num := range shardResponses {
+		if num < requiredNumSuccessResponsePerShard {
+			return false
+		}
+	}
+
+	return true
+}
+
+func genTopologyAndResponse(t *testing.T) gopter.Gen {
+	return gopter.CombineGens(
+		genTopology(t),
+		gen.SliceOfN(maxNumHostsPropTest, gen.Bool()),
+	).Map(func(values []interface{}) topoAndHostResponses {
+		return topoAndHostResponses{
+			topoMap: values[0].(topology.Map),
+			success: values[1].([]bool),
+		}
+	})
+}
+
+func genTopology(t *testing.T) gopter.Gen {
+	var dummyMap topology.Map
+	divceil := func(i, j int) int { return int(math.Ceil(float64(i) / float64(j))) }
+	hostid := func(i int) string { return fmt.Sprintf("host%d", i) }
+	dummyValue := gopter.NewEmptyResult(reflect.TypeOf(dummyMap))
+	return func(params *gopter.GenParameters) *gopter.GenResult {
+		// gopter hackery to chain generators. can't use Map/FlatMap/MapResult because the
+		// composing generator still needs access to the gen.Parameters, and this way, we
+		// can re-use the shrinkers from native types, which is massively useful.
+		// NB: this isn't thread-safe because it generates data in a part of the lifecycle
+		// where gopter workers aren't typically supposed to, so we have to set workers == 1
+		// otherwise we see races in the Rng.
+		genTopoParamsResult := genTopoGenParam()(params)
+		genTopoParamsRes, ok := genTopoParamsResult.Retrieve()
+		if !ok {
+			return dummyValue
+		}
+		genTopoParams, ok := genTopoParamsRes.(topoGenParams)
+		if !ok {
+			return dummyValue
+		}
+
+		var (
+			rf        = genTopoParams.rf
+			numHosts  = genTopoParams.numHosts
+			numShards = genTopoParams.numShards
+		)
+
+		// create a slice of all shards, i.e. [0, numShards) * rf
+		numTotalShards := rf * numShards
+		allShards := make([]uint32, 0, numTotalShards)
+		for i := 0; i < rf; i++ {
+			for j := 0; j < numShards; j++ {
+				allShards = append(allShards, uint32(j))
+			}
+		}
+		// yates shuffle the slice to get a random permutation
+		shuffleSlice(allShards).shuffle(params.Rng)
+
+		// initialize host -> shard map
+		numShardsPerHost := divceil(numTotalShards, numHosts)
+		hostShardAssignment := make(map[string]map[uint32]struct{}, numHosts)
+		for i := 0; i < numHosts; i++ {
+			hostShardAssignment[hostid(i)] = make(map[uint32]struct{}, numShardsPerHost)
+		}
+
+		// iterate through shuffled array and assign upto numShardsPerHost shards
+		// to each host, ensuring each shard goes to a host at most one time.
+		host := 0
+		for len(allShards) > 0 {
+			shard := allShards[0]
+			hostn := hostid(host)
+			host = (host + 1) % numHosts
+
+			// i.e host has already received too many shards, skip it
+			if len(hostShardAssignment[hostn]) > numShardsPerHost {
+				continue
+			}
+
+			hss, ok := hostShardAssignment[hostn]
+			require.True(t, ok)
+			// skip if host already has the current shard
+			if _, ok := hss[shard]; ok {
+				continue
+			}
+
+			// all good, we can assign the shard to the host
+			hss[shard] = struct{}{}
+			allShards = allShards[1:]
+		}
+
+		// create topology map parameters
+		assign := make(map[string][]shard.Shard, len(hostShardAssignment))
+		for hostid, shardset := range hostShardAssignment {
+			shards := make([]shard.Shard, 0, len(shardset))
+			for id := range shardset {
+				shards = append(shards, shard.NewShard(id).SetState(shard.Available))
+			}
+			assign[hostid] = shards
+		}
+
+		// finally create topology and return
+		topoMap := testutil.MustNewTopologyMap(rf, assign)
+		return gopter.NewGenResult(topoMap, genTopoParamsResult.Shrinker)
+	}
+}
+
+type topoGenParams struct {
+	rf        int
+	numHosts  int
+	numShards int
+}
+
+func genTopoGenParam() gopter.Gen {
+	return gopter.CombineGens(
+		gen.IntRange(1, 3),                   // RF
+		gen.IntRange(3, maxNumHostsPropTest), // Num Hosts
+		gen.IntRange(7, 30),                  // Num Shards
+	).Map(func(values []interface{}) topoGenParams {
+		return topoGenParams{
+			rf:        values[0].(int),
+			numHosts:  values[1].(int),
+			numShards: values[2].(int),
+		}
+	})
+}
+
+type shuffleSlice []uint32
+
+func (s shuffleSlice) shuffle(rng *rand.Rand) {
+	// Start from the last element and swap one by one.
+	// NB: We don't need to run for the first element that's why i > 0
+	for i := len(s) - 1; i > 0; i-- {
+		j := rng.Intn(i)
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/client/fetch_tagged_results_accumulator_consistency_test.go
+++ b/client/fetch_tagged_results_accumulator_consistency_test.go
@@ -1,0 +1,419 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
+)
+
+var (
+	testStartTime, testEndTime     time.Time
+	testFetchTaggedSuccessResponse = rpc.FetchTaggedResult_{}
+	errTestFetchTagged             = fmt.Errorf("random error")
+)
+
+func TestFetchTaggedResultsAccumulatorAnyResponseShouldTerminateConsistencyLevelOneSimpleTopo(t *testing.T) {
+	// rf=3, 30 shards total; three identical hosts
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	// any response should satisfy consistency lvl one
+	for i := 0; i < 3; i++ {
+		testFetchTaggedWorkflow{
+			t:       t,
+			topoMap: topoMap,
+			level:   topology.ReadConsistencyLevelOne,
+			steps: []testFetchTaggedWorklowStep{
+				testFetchTaggedWorklowStep{
+					hostname:     fmt.Sprintf("testhost%d", i),
+					response:     &testFetchTaggedSuccessResponse,
+					expectedDone: true,
+				},
+			},
+		}.run()
+	}
+
+	// should terminate only after all failures, and say it failed
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelOne,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorShardAvailabilityIsEnforced(t *testing.T) {
+	// rf=3, 30 shards total; three identical hosts
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Initializing),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	// responses from testhost1 should not count towards success
+	// for consistency level 1
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelOne,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: false,
+			},
+		},
+	}.run()
+
+	// for consistency level unstrict majority
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost2",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+
+	// for consistency level majority
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost2",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+
+	// for consistency level all
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelAll,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost2",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorAnyResponseShouldTerminateConsistencyLevelOneComplexTopo(t *testing.T) {
+	// rf=3, 30 shards total; 2 identical hosts, one additional host with a subset of all shards
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(10, 20, shard.Available),
+	})
+
+	// a single response from a host with partial shards isn't enough
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelOne,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost2",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: false,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorConsistencyUnstrictMajority(t *testing.T) {
+	// rf=3, 30 shards total; three identical hosts
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	// two success responses should succeed immediately
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: false,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: true,
+			},
+		},
+	}.run()
+
+	// two failures, and one success response should succeed
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     &testFetchTaggedSuccessResponse,
+				expectedDone: true,
+			},
+		},
+	}.run()
+
+	// should terminate only after all failures
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				err:          errTestFetchTagged,
+				expectedErr:  true,
+				expectedDone: true,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorComplextTopoUnstrictMajorityPartialResponses(t *testing.T) {
+	// rf=3, 30 shards total; 2 identical "complete hosts", 2 additional hosts which together comprise a "complete" host.
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(15, 29, shard.Available),
+		"testhost3": testutil.ShardsRange(0, 14, shard.Available),
+	})
+
+	// response from testhost2+testhost3 should be sufficient
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost2",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost3",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorComplexIncompleteTopoUnstrictMajorityPartialResponses(t *testing.T) {
+	// rf=3, 30 shards total; 2 identical "complete hosts", 2 additional hosts which do not comprise a complete host.
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(15, 27, shard.Available),
+		"testhost3": testutil.ShardsRange(0, 14, shard.Available),
+	})
+
+	// response from testhost2+testhost3 should be in-sufficient, as they're not complete together
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost2",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost3",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost0",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+}
+
+func TestFetchTaggedResultsAccumulatorReadConsitencyLevelMajority(t *testing.T) {
+	// rf=3, 30 shards total; three identical hosts
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	// any single success response should not satisfy consistency majority
+	for i := 0; i < 3; i++ {
+		testFetchTaggedWorkflow{
+			t:       t,
+			topoMap: topoMap,
+			level:   topology.ReadConsistencyLevelMajority,
+			steps: []testFetchTaggedWorklowStep{
+				testFetchTaggedWorklowStep{
+					hostname:     fmt.Sprintf("testhost%d", i),
+					response:     &testFetchTaggedSuccessResponse,
+					expectedDone: false,
+				},
+			},
+		}.run()
+	}
+
+	// all responses failing should fail consistency lvl majority
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost2",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+
+	// any two responses failing should fail regardless of third response
+	testFetchTaggedWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelMajority,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				err:      errTestFetchTagged,
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: &testFetchTaggedSuccessResponse,
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost2",
+				err:          errTestFetchTagged,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+}

--- a/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/client/fetch_tagged_results_accumulator_merge_test.go
@@ -1,0 +1,581 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/encoding"
+	"github.com/m3db/m3db/encoding/m3tsz"
+	"github.com/m3db/m3db/generated/thrift/rpc"
+	"github.com/m3db/m3db/network/server/tchannelthrift/convert"
+	"github.com/m3db/m3db/serialize"
+	"github.com/m3db/m3db/storage/index"
+	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
+	"github.com/m3db/m3db/ts"
+	"github.com/m3db/m3db/x/xio"
+	"github.com/m3db/m3x/ident"
+	"github.com/m3db/m3x/pool"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testFetchTaggedTimeUnit = xtime.Millisecond
+)
+
+func TestFetchTaggedResultsAccumulatorIdsMerge(t *testing.T) {
+	// rf=3, 30 shards total; 10 shards shared between each pair
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 19, shard.Available),
+		"testhost1": testutil.ShardsRange(10, 29, shard.Available),
+		"testhost2": append(testutil.ShardsRange(0, 9, shard.Available),
+			testutil.ShardsRange(20, 29, shard.Available)...),
+	})
+
+	th := newTestFetchTaggedHelper(t)
+	ts1 := newTestSeries(1)
+	ts2 := newTestSeries(2)
+	workflow := testFetchTaggedWorkflow{
+		t:         t,
+		topoMap:   topoMap,
+		level:     topology.ReadConsistencyLevelAll,
+		startTime: testStartTime,
+		endTime:   testEndTime,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				response: testSerieses{ts1}.toRPCResult(th, testStartTime, true),
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: testSerieses{ts1, ts2}.toRPCResult(th, testStartTime, true),
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost2",
+				response:     testSerieses{}.toRPCResult(th, testStartTime, true),
+				expectedDone: true,
+			},
+		},
+	}
+
+	accum := workflow.run()
+
+	// not really restricting, ensuring we don't have extra results
+	results, err := accum.AsIndexQueryResults(10, th.pools)
+	require.NoError(t, err)
+	require.True(t, results.Exhaustive)
+	matcher := index.MustNewIteratorMatcher(ts1.matcherOption(), ts2.matcherOption())
+	require.True(t, matcher.Matches(results.Iterator))
+
+	// restrict to 2 elements, i.e. same as above; doing this to check off by ones
+	results, err = accum.AsIndexQueryResults(2, th.pools)
+	require.NoError(t, err)
+	require.True(t, results.Exhaustive)
+	matcher = index.MustNewIteratorMatcher(ts1.matcherOption(), ts2.matcherOption())
+	require.True(t, matcher.Matches(results.Iterator))
+
+	// restrict to 1 elements, ensuring we actually limit the responses
+	results, err = accum.AsIndexQueryResults(1, th.pools)
+	require.NoError(t, err)
+	require.False(t, results.Exhaustive)
+	matcher = index.MustNewIteratorMatcher(ts1.matcherOption())
+	require.True(t, matcher.Matches(results.Iterator))
+}
+
+func TestFetchTaggedResultsAccumulatorIdsMergeUnstrictMajority(t *testing.T) {
+	// rf=3, 3 identical hosts, with same shards
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	th := newTestFetchTaggedHelper(t)
+	workflow := testFetchTaggedWorkflow{
+		t:         t,
+		topoMap:   topoMap,
+		level:     topology.ReadConsistencyLevelUnstrictMajority,
+		startTime: testStartTime,
+		endTime:   testEndTime,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				response: newTestSerieses(1, 10).toRPCResult(th, testStartTime, true),
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     newTestSerieses(5, 15).toRPCResult(th, testStartTime, true),
+				expectedDone: true,
+			},
+		},
+	}
+	accum := workflow.run()
+
+	results, err := accum.AsIndexQueryResults(10, th.pools)
+	require.NoError(t, err)
+	require.False(t, results.Exhaustive)
+	matcher := newTestSerieses(1, 10).indexMatcher()
+	require.True(t, matcher.Matches(results.Iterator))
+}
+
+func TestFetchTaggedResultsAccumulatorIdsMergeReportsExhaustiveCorrectly(t *testing.T) {
+	// rf=3, 3 identical hosts, with same shards
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	th := newTestFetchTaggedHelper(t)
+	workflow := testFetchTaggedWorkflow{
+		t:         t,
+		topoMap:   topoMap,
+		level:     topology.ReadConsistencyLevelUnstrictMajority,
+		startTime: testStartTime,
+		endTime:   testEndTime,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				response: newTestSerieses(1, 10).toRPCResult(th, testStartTime, false),
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     newTestSerieses(5, 15).toRPCResult(th, testStartTime, true),
+				expectedDone: true,
+			},
+		},
+	}
+	accum := workflow.run()
+
+	results, err := accum.AsIndexQueryResults(100, th.pools)
+	require.NoError(t, err)
+	require.False(t, results.Exhaustive)
+	matcher := newTestSerieses(1, 15).indexMatcher()
+	require.True(t, matcher.Matches(results.Iterator))
+
+	iters, exhaust, err := accum.AsEncodingSeriesIterators(100, th.pools)
+	require.NoError(t, err)
+	require.False(t, exhaust)
+	newTestSerieses(1, 15).assertMatchesEncodingIters(t, iters)
+}
+
+func TestFetchTaggedResultsAccumulatorSeriesItersDatapoints(t *testing.T) {
+	// rf=3, 3 identical hosts, with same shards
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	var (
+		sg0 = newTestSerieses(1, 5)
+		sg1 = newTestSerieses(6, 10)
+	)
+
+	var (
+		startTime = time.Now().Add(-time.Hour).Truncate(time.Hour)
+		endTime   = time.Now().Truncate(time.Hour)
+		numPoints = 100
+	)
+	sg0.addDatapoints(numPoints, startTime, endTime)
+	sg1.addDatapoints(numPoints, startTime, endTime)
+
+	th := newTestFetchTaggedHelper(t)
+	workflow := testFetchTaggedWorkflow{
+		t:         t,
+		topoMap:   topoMap,
+		level:     topology.ReadConsistencyLevelUnstrictMajority,
+		startTime: startTime,
+		endTime:   endTime,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				response: sg0.toRPCResult(th, startTime, false),
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost1",
+				response:     sg1.toRPCResult(th, endTime, true),
+				expectedDone: true,
+			},
+		},
+	}
+	accum := workflow.run()
+
+	results, err := accum.AsIndexQueryResults(8, th.pools)
+	require.NoError(t, err)
+	require.False(t, results.Exhaustive)
+	matcher := newTestSerieses(1, 8).indexMatcher()
+	require.True(t, matcher.Matches(results.Iterator))
+
+	iters, exhaust, err := accum.AsEncodingSeriesIterators(10, th.pools)
+	require.NoError(t, err)
+	require.False(t, exhaust)
+	append(sg0, sg1...).assertMatchesEncodingIters(t, iters)
+}
+
+func TestFetchTaggedResultsAccumulatorSeriesItersDatapointsNSplit(t *testing.T) {
+	// rf=3, 3 identical hosts, with same shards
+	topoMap := testutil.MustNewTopologyMap(3, map[string][]shard.Shard{
+		"testhost0": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost1": testutil.ShardsRange(0, 29, shard.Available),
+		"testhost2": testutil.ShardsRange(0, 29, shard.Available),
+	})
+
+	var (
+		sg0       = newTestSerieses(1, 10)
+		startTime = time.Now().Add(-time.Hour).Truncate(time.Hour)
+		endTime   = time.Now().Truncate(time.Hour)
+		numPoints = 100
+	)
+	sg0.addDatapoints(numPoints, startTime, endTime)
+	groups := sg0.nsplit(3)
+
+	th := newTestFetchTaggedHelper(t)
+	workflow := testFetchTaggedWorkflow{
+		t:         t,
+		topoMap:   topoMap,
+		level:     topology.ReadConsistencyLevelAll,
+		startTime: startTime,
+		endTime:   endTime,
+		steps: []testFetchTaggedWorklowStep{
+			testFetchTaggedWorklowStep{
+				hostname: "testhost0",
+				response: groups[0].toRPCResult(th, startTime, true),
+			},
+			testFetchTaggedWorklowStep{
+				hostname: "testhost1",
+				response: groups[1].toRPCResult(th, endTime, true),
+			},
+			testFetchTaggedWorklowStep{
+				hostname:     "testhost2",
+				response:     groups[2].toRPCResult(th, endTime, true),
+				expectedDone: true,
+			},
+		},
+	}
+	accum := workflow.run()
+
+	results, err := accum.AsIndexQueryResults(8, th.pools)
+	require.NoError(t, err)
+	require.False(t, results.Exhaustive)
+	matcher := newTestSerieses(1, 8).indexMatcher()
+	require.True(t, matcher.Matches(results.Iterator))
+
+	iters, exhaust, err := accum.AsEncodingSeriesIterators(10, th.pools)
+	require.NoError(t, err)
+	require.True(t, exhaust)
+	// ensure iters are valid after the lifecycle of the accumulator
+	accum.Clear()
+	sg0.assertMatchesEncodingIters(t, iters)
+}
+
+// debugIter is useful for tests, leaving in for now.
+// nolint
+type debugIter struct {
+	index.Iterator
+}
+
+// nolint
+func (d debugIter) String() string {
+	iter := d.Iterator
+	var buffer bytes.Buffer
+	for iter.Next() {
+		ns, id, tags := iter.Current()
+		buffer.WriteString(fmt.Sprintf("ns: %v\n", ns.String()))
+		buffer.WriteString(fmt.Sprintf("id: %v\n", id.String()))
+		for tags.Next() {
+			t := tags.Current()
+			buffer.WriteString(fmt.Sprintf("tag: [ name = %v, value = %v ]\n", t.Name.String(), t.Value.String()))
+		}
+		if err := tags.Err(); err != nil {
+			buffer.WriteString(fmt.Sprintf("tag-err: %v\n", err))
+		}
+	}
+	if err := iter.Err(); err != nil {
+		buffer.WriteString(fmt.Sprintf("err: %v\n", err))
+	}
+	return buffer.String()
+}
+
+type testFetchTaggedWorkflow struct {
+	t         *testing.T
+	topoMap   topology.Map
+	level     topology.ReadConsistencyLevel
+	startTime time.Time
+	endTime   time.Time
+	steps     []testFetchTaggedWorklowStep
+}
+
+type testFetchTaggedWorklowStep struct {
+	hostname     string
+	response     *rpc.FetchTaggedResult_
+	err          error
+	expectedDone bool
+	expectedErr  bool
+}
+
+func (tm testFetchTaggedWorkflow) run() fetchTaggedResultAccumulator {
+	var accum fetchTaggedResultAccumulator
+	majority := tm.topoMap.MajorityReplicas()
+	accum = newFetchTaggedResultAccumulator()
+	accum.Clear()
+	accum.Reset(tm.startTime, tm.endTime, tm.topoMap, majority, tm.level)
+	for _, s := range tm.steps {
+		opts := fetchTaggedResultAccumulatorOpts{
+			host:     host(tm.t, tm.topoMap, s.hostname),
+			response: s.response,
+		}
+		done, err := accum.Add(opts, s.err)
+		assert.Equal(tm.t, s.expectedDone, done, fmt.Sprintf("%+v", s))
+		assert.Equal(tm.t, s.expectedErr, err != nil, fmt.Sprintf("%+v", s))
+	}
+	return accum
+}
+
+func host(t *testing.T, m topology.Map, id string) topology.Host {
+	hss, ok := m.LookupHostShardSet(id)
+	require.True(t, ok)
+	return hss.Host()
+}
+
+type testSerieses []testSeries
+
+func (ts testSerieses) nsplit(n int) []testSerieses {
+	groups := make([]testSerieses, n)
+	for i := 0; i < len(ts); i++ {
+		si := ts[i]
+		serieses := si.nsplit(n)
+		for j := 0; j < len(serieses); j++ {
+			groups[j] = append(groups[j], serieses[j])
+		}
+	}
+	return groups
+}
+
+func (ts testSerieses) addDatapoints(numPerSeries int, start, end time.Time) {
+	dps := newTestDatapoints(numPerSeries, start, end)
+	for i := range ts {
+		ts[i].datapoints = dps
+	}
+}
+
+func (ts testSerieses) assertMatchesEncodingIters(t *testing.T, iters encoding.SeriesIterators) {
+	require.Equal(t, len(ts), iters.Len())
+	for i := 0; i < len(ts); i++ {
+		ts[i].assertMatchesEncodingIter(t, iters.Iters()[i])
+	}
+}
+
+// nolint
+func (ts testSerieses) indexMatcher() index.IteratorMatcher {
+	opts := make([]index.IteratorMatcherOption, 0, len(ts))
+	for _, s := range ts {
+		opts = append(opts, s.matcherOption())
+	}
+	return index.MustNewIteratorMatcher(opts...)
+}
+
+func (ts testSerieses) toRPCResult(th testFetchTaggedHelper, start time.Time, exhaustive bool) *rpc.FetchTaggedResult_ {
+	res := &rpc.FetchTaggedResult_{}
+	res.Exhaustive = exhaustive
+	res.Elements = make([]*rpc.FetchTaggedIDResult_, 0, len(ts))
+	for _, s := range ts {
+		res.Elements = append(res.Elements, s.toRPCResult(th, start))
+	}
+	return res
+}
+
+func newTestSerieses(i, j int) testSerieses {
+	numSeries := j - i + 1
+	ts := make(testSerieses, 0, numSeries)
+	for k := i; k <= j; k++ {
+		ts = append(ts, newTestSeries(k))
+	}
+	return ts
+}
+
+func newTestSeries(i int) testSeries {
+	return testSeries{
+		ns: ident.StringID("testNs"),
+		id: ident.StringID(fmt.Sprintf("id%03d", i)),
+		tags: ident.Tags{
+			ident.StringTag(
+				fmt.Sprintf("tagName0%d", i),
+				fmt.Sprintf("tagValue0%d", i),
+			),
+			ident.StringTag(
+				fmt.Sprintf("tagName1%d", i),
+				fmt.Sprintf("tagValue1%d", i),
+			),
+		},
+	}
+}
+
+type testSeries struct {
+	ns         ident.ID
+	id         ident.ID
+	tags       ident.Tags
+	datapoints testDatapoints
+}
+
+func (ts testSeries) nsplit(n int) []testSeries {
+	groups := make([]testSeries, n)
+	for i := 0; i < n; i++ {
+		groups[i] = ts
+		groups[i].datapoints = nil
+	}
+
+	for i := 0; i < len(ts.datapoints); i++ {
+		gn := i % n
+		groups[gn].datapoints = append(groups[gn].datapoints, ts.datapoints[i])
+	}
+
+	return groups
+}
+
+func (ts testSeries) assertMatchesEncodingIter(t *testing.T, iter encoding.SeriesIterator) {
+	require.Equal(t, ts.ns.String(), iter.Namespace().String())
+	require.Equal(t, ts.id.String(), iter.ID().String())
+	assertTagsEqual(t, ts.tags, iter.Tags())
+	ts.datapoints.assertMatchesEncodingIter(t, iter)
+}
+
+// TODO(prateek): migrate to m3x
+func assertTagsEqual(t *testing.T, exp ident.Tags, obs ident.TagIterator) {
+	require.Equal(t, len(exp), obs.Remaining())
+	i := 0
+	for obs.Next() {
+		ot := obs.Current()
+		et := exp[i]
+		require.Equal(t, et.Name.String(), ot.Name.String())
+		require.Equal(t, et.Value.String(), ot.Value.String())
+		i++
+	}
+	require.Equal(t, len(exp), i)
+	require.NoError(t, obs.Err())
+}
+
+func (ts testSeries) matcherOption() index.IteratorMatcherOption {
+	tags := make([]string, 0, len(ts.tags)*2)
+	for _, t := range ts.tags {
+		tags = append(tags, t.Name.String(), t.Value.String())
+	}
+	return index.IteratorMatcherOption{
+		Namespace: ts.ns.String(),
+		ID:        ts.id.String(),
+		Tags:      tags,
+	}
+}
+
+func (ts testSeries) toRPCResult(th testFetchTaggedHelper, startTime time.Time) *rpc.FetchTaggedIDResult_ {
+	return &rpc.FetchTaggedIDResult_{
+		NameSpace:   ts.ns.Bytes(),
+		ID:          ts.id.Bytes(),
+		EncodedTags: th.encodeTags(ts.tags),
+		Segments:    ts.datapoints.toRPCSegments(th, startTime),
+	}
+}
+
+type testDatapoints []ts.Datapoint
+
+func newTestDatapoints(num int, start, end time.Time) testDatapoints {
+	dps := make(testDatapoints, 0, num)
+	step := end.Sub(start) / time.Duration(num)
+	for i := 0; i < num; i++ {
+		dps = append(dps, ts.Datapoint{
+			Timestamp: start.Add(step * time.Duration(i)),
+			Value:     float64(i),
+		})
+	}
+	return dps
+}
+
+func (td testDatapoints) assertMatchesEncodingIter(t *testing.T, iter encoding.SeriesIterator) {
+	i := 0
+	for iter.Next() {
+		require.True(t, i < len(td))
+		obs, _, _ := iter.Current()
+		exp := td[i]
+		require.Equal(t, exp.Value, obs.Value)
+		require.Equal(t, exp.Timestamp.UnixNano(), obs.Timestamp.UnixNano())
+		i++
+	}
+	require.Equal(t, len(td), i)
+}
+
+func (td testDatapoints) toRPCSegments(th testFetchTaggedHelper, start time.Time) []*rpc.Segments {
+	enc := th.encPool.Get()
+	enc.Reset(start, len(td))
+	for _, dp := range td {
+		require.NoError(th.t, enc.Encode(dp, testFetchTaggedTimeUnit, nil), fmt.Sprintf("%+v", dp))
+	}
+	reader := enc.Stream()
+	if reader == nil {
+		return nil
+	}
+	res, err := convert.ToSegments([]xio.SegmentReader{reader})
+	require.NoError(th.t, err)
+	return []*rpc.Segments{res.Segments}
+}
+
+func (th testFetchTaggedHelper) encodeTags(tags ident.Tags) []byte {
+	enc := th.tagEncPool.Get()
+	iter := ident.NewTagSliceIterator(tags)
+	require.NoError(th.t, enc.Encode(iter))
+	data, ok := enc.Data()
+	require.True(th.t, ok)
+	return data.Bytes()
+}
+
+type testFetchTaggedHelper struct {
+	t          *testing.T
+	pools      fetchTaggedPools
+	tagEncPool serialize.TagEncoderPool
+	encPool    encoding.EncoderPool
+}
+
+func newTestFetchTaggedHelper(t *testing.T) testFetchTaggedHelper {
+	opts := serialize.NewTagEncoderOptions()
+	popts := pool.NewObjectPoolOptions().SetSize(1)
+	encPool := serialize.NewTagEncoderPool(opts, popts)
+	encPool.Init()
+
+	encoderPool := encoding.NewEncoderPool(nil)
+	encodingOpts := encoding.NewOptions().SetEncoderPool(encoderPool)
+	encoderPool.Init(func() encoding.Encoder {
+		return m3tsz.NewEncoder(time.Time{}, nil, m3tsz.DefaultIntOptimizationEnabled, encodingOpts)
+	})
+
+	return testFetchTaggedHelper{
+		t:          t,
+		pools:      newTestFetchTaggedPools(),
+		tagEncPool: encPool,
+		encPool:    encoderPool,
+	}
+}

--- a/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/client/fetch_tagged_results_accumulator_merge_test.go
@@ -462,23 +462,9 @@ func (ts testSeries) nsplit(n int) []testSeries {
 func (ts testSeries) assertMatchesEncodingIter(t *testing.T, iter encoding.SeriesIterator) {
 	require.Equal(t, ts.ns.String(), iter.Namespace().String())
 	require.Equal(t, ts.id.String(), iter.ID().String())
-	assertTagsEqual(t, ts.tags, iter.Tags())
+	require.True(t, ident.NewTagIterMatcher(
+		ident.NewTagSliceIterator(ts.tags)).Matches(iter.Tags()))
 	ts.datapoints.assertMatchesEncodingIter(t, iter)
-}
-
-// TODO(prateek): migrate to m3x
-func assertTagsEqual(t *testing.T, exp ident.Tags, obs ident.TagIterator) {
-	require.Equal(t, len(exp), obs.Remaining())
-	i := 0
-	for obs.Next() {
-		ot := obs.Current()
-		et := exp[i]
-		require.Equal(t, et.Name.String(), ot.Name.String())
-		require.Equal(t, et.Value.String(), ot.Value.String())
-		i++
-	}
-	require.Equal(t, len(exp), i)
-	require.NoError(t, obs.Err())
 }
 
 func (ts testSeries) matcherOption() index.IteratorMatcherOption {

--- a/client/fetch_tagged_results_index_iterator.go
+++ b/client/fetch_tagged_results_index_iterator.go
@@ -76,6 +76,12 @@ func (i *fetchTaggedResultsIndexIterator) Next() bool {
 	return true
 }
 
+func (i *fetchTaggedResultsIndexIterator) addBacking(nsID, tsID, tags []byte) {
+	i.backing.nses = append(i.backing.nses, nsID)
+	i.backing.ids = append(i.backing.ids, tsID)
+	i.backing.tags = append(i.backing.tags, tags)
+}
+
 func (i *fetchTaggedResultsIndexIterator) asIdent(b []byte) ident.ID {
 	wb := i.pools.CheckedBytesWrapper().Get(b)
 	return i.pools.ID().BinaryID(wb)

--- a/client/fetch_tagged_results_index_iterator_test.go
+++ b/client/fetch_tagged_results_index_iterator_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/m3db/m3db/serialize"
+	"github.com/m3db/m3x/ident"
+	"github.com/m3db/m3x/pool"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchTaggedResultsIndexIterator(t *testing.T) {
+	pools := newTestFetchTaggedPools()
+
+	opts := serialize.NewTagEncoderOptions()
+	popts := pool.NewObjectPoolOptions().SetSize(1)
+	encPool := serialize.NewTagEncoderPool(opts, popts)
+	encPool.Init()
+
+	for _, tc := range []struct {
+		name string
+		nses []ident.ID
+		ids  []ident.ID
+		tags []ident.TagIterator
+	}{
+		{
+			"testcase0",
+			[]ident.ID{ident.StringID("ns0"), ident.StringID("ns1"), ident.StringID("ns2")},
+			[]ident.ID{ident.StringID("id0"), ident.StringID("id1"), ident.StringID("id2")},
+			[]ident.TagIterator{
+				ident.NewTagIterator(ident.StringTag("tn0", "tv0")),
+				ident.NewTagIterator(ident.StringTag("tn0", "tv0"), ident.StringTag("tn1", "tv1")),
+				ident.NewTagIterator(ident.StringTag("tn0", "tv0"), ident.StringTag("tn1", "tv1"), ident.StringTag("tn2", "tv2")),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			iter := newFetchTaggedResultsIndexIterator(pools)
+			// initialize iter
+			for i := range tc.nses {
+				ns := tc.nses[i]
+				id := tc.ids[i]
+				tags := tc.tags[i].Duplicate()
+				enc := encPool.Get()
+				err := enc.Encode(tags)
+				require.NoError(t, err)
+				data, ok := enc.Data()
+				require.True(t, ok)
+				iter.addBacking(ns.Bytes(), id.Bytes(), data.Bytes())
+			}
+
+			// validate iter
+			for i := range tc.nses {
+				require.True(t, iter.Next())
+				obsNs, obsID, obsTags := iter.Current()
+				expNs, expID, expTags := tc.nses[i], tc.ids[i], tc.tags[i].Duplicate()
+				require.Equal(t, expNs.String(), obsNs.String())
+				require.Equal(t, expID.String(), obsID.String())
+				require.True(t, newTagIterMatcher(t, expTags).Matches(obsTags))
+			}
+		})
+	}
+}
+
+// TODO(prateek): migrate this to m3x
+func newTagIterMatcher(t *testing.T, iter ident.TagIterator) ident.TagIterMatcher {
+	tags := make([]string, 0, 2*iter.Remaining())
+	for iter.Next() {
+		t := iter.Current()
+		tags = append(tags, t.Name.String(), t.Value.String())
+	}
+	require.NoError(t, iter.Err())
+	return ident.MustNewTagIterMatcher(tags...)
+}

--- a/client/fetch_tagged_results_index_iterator_test.go
+++ b/client/fetch_tagged_results_index_iterator_test.go
@@ -77,19 +77,8 @@ func TestFetchTaggedResultsIndexIterator(t *testing.T) {
 				expNs, expID, expTags := tc.nses[i], tc.ids[i], tc.tags[i].Duplicate()
 				require.Equal(t, expNs.String(), obsNs.String())
 				require.Equal(t, expID.String(), obsID.String())
-				require.True(t, newTagIterMatcher(t, expTags).Matches(obsTags))
+				require.True(t, ident.NewTagIterMatcher(expTags).Matches(obsTags))
 			}
 		})
 	}
-}
-
-// TODO(prateek): migrate this to m3x
-func newTagIterMatcher(t *testing.T, iter ident.TagIterator) ident.TagIterMatcher {
-	tags := make([]string, 0, 2*iter.Remaining())
-	for iter.Next() {
-		t := iter.Current()
-		tags = append(tags, t.Name.String(), t.Value.String())
-	}
-	require.NoError(t, iter.Err())
-	return ident.MustNewTagIterMatcher(tags...)
 }


### PR DESCRIPTION
Originally I'd wanted to do all the follow-ups to #530 in this PR, but it's already pretty long, going to start chaining again. 

Changes:
- Re-work consistency calculation. Earlier version treated `LeveUnstrictMajority` the same as `LevelOne`. This PR addresses that.
- Fix an issue in the `Exhaustive` calculation: We needed to know if there was data pending being read if we terminated iteration early. Exposed a new parameter in the `forEachID` type to satisfy this.
- Loads of unit test
  - [x] Accumulator generative tests for consistency
  - [x] results index iter unit tests
  - [x] Accumulator <-> results index iter unit tests
  - [x] Accumulator encoding.iter unit tests
  - [x] Accumulator unit tests (data merge path)

NB:
- Subsequent PR for next round of changes: #549 