### PR TITLE
Extract topology construction utilities

### DIFF
--- a/integration/cluster_add_one_node_test.go
+++ b/integration/cluster_add_one_node_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3db/retention"
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
 	"github.com/m3db/m3x/ident"
 	xlog "github.com/m3db/m3x/log"
 	xtime "github.com/m3db/m3x/time"
@@ -210,7 +211,7 @@ func TestClusterAddOneNode(t *testing.T) {
 	log.Debug("resharding to initialize shards on second node")
 	svc.SetInstances(instances.add)
 	svcs.NotifyServiceUpdate("m3db")
-	waitUntilHasBootstrappedShardsExactly(setups[1].db, newShardsRange(midShard+1, maxShard))
+	waitUntilHasBootstrappedShardsExactly(setups[1].db, testutil.Uint32Range(midShard+1, maxShard))
 
 	log.Debug("waiting for shards to be marked initialized")
 	allMarkedAvailable := func(
@@ -248,8 +249,8 @@ func TestClusterAddOneNode(t *testing.T) {
 	log.Debug("resharding to shed shards from first node")
 	svc.SetInstances(instances.added)
 	svcs.NotifyServiceUpdate("m3db")
-	waitUntilHasBootstrappedShardsExactly(setups[0].db, newShardsRange(minShard, midShard))
-	waitUntilHasBootstrappedShardsExactly(setups[1].db, newShardsRange(midShard+1, maxShard))
+	waitUntilHasBootstrappedShardsExactly(setups[0].db, testutil.Uint32Range(minShard, midShard))
+	waitUntilHasBootstrappedShardsExactly(setups[1].db, testutil.Uint32Range(midShard+1, maxShard))
 
 	log.Debug("verifying data in servers matches expected data set")
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3db/storage/namespace"
 	"github.com/m3db/m3db/storage/series"
 	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
 	xmetrics "github.com/m3db/m3db/x/metrics"
 	"github.com/m3db/m3x/instrument"
 	xlog "github.com/m3db/m3x/log"
@@ -287,30 +288,14 @@ func concatShards(a, b shard.Shards) shard.Shards {
 	return shard.NewShards(all)
 }
 
-func newShardsRange(from, to uint32) []uint32 {
-	var ids []uint32
-	for i := from; i <= to; i++ {
-		ids = append(ids, i)
-	}
-	return ids
-}
-
-func newClusterShards(ids []uint32, s shard.State) shard.Shards {
-	var shards []shard.Shard
-	for _, id := range ids {
-		shards = append(shards, shard.NewShard(id).SetState(s))
-	}
-	return shard.NewShards(shards)
-}
-
 // nolint: deadcode
 func newClusterShardsRange(from, to uint32, s shard.State) shard.Shards {
-	return newClusterShards(newShardsRange(from, to), s)
+	return shard.NewShards(testutil.ShardsRange(from, to, s))
 }
 
 // nolint: deadcode
 func newClusterEmptyShardsRange() shard.Shards {
-	return newClusterShards(nil, shard.Available)
+	return shard.NewShards(testutil.Shards(nil, shard.Available))
 }
 
 // nolint: deadcode

--- a/storage/cluster/database_test.go
+++ b/storage/cluster/database_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3db/sharding"
 	"github.com/m3db/m3db/storage"
 	"github.com/m3db/m3db/topology"
+	"github.com/m3db/m3db/topology/testutil"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -51,10 +52,10 @@ func TestDatabaseOpenClose(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost": sharding.NewShards([]uint32{0, 1, 2}, shard.Available),
 	})
 
@@ -79,10 +80,10 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost0": sharding.NewShards([]uint32{0, 1}, shard.Available),
 		"testhost1": sharding.NewShards([]uint32{2, 3}, shard.Available),
 	})
@@ -152,7 +153,7 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 		})
 
 	// Enqueue the update
-	viewsCh <- newTopoView(1, updatedView)
+	viewsCh <- testutil.NewTopologyView(1, updatedView)
 
 	// Wait for the update to propagate, consume the first notification
 	// from the initial read and then the second that should come after
@@ -176,10 +177,10 @@ func TestDatabaseOpenUpdatesShardSetBeforeOpen(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost0": append(sharding.NewShards([]uint32{0, 1}, shard.Available),
 			sharding.NewShards([]uint32{2, 3}, shard.Leaving)...),
 		"testhost1": sharding.NewShards([]uint32{2, 3}, shard.Initializing),
@@ -208,7 +209,7 @@ func TestDatabaseOpenUpdatesShardSetBeforeOpen(t *testing.T) {
 		})
 
 	// Enqueue the update
-	viewsCh <- newTopoView(1, updatedView)
+	viewsCh <- testutil.NewTopologyView(1, updatedView)
 
 	// Wait for the update to propagate, consume the first notification
 	// from the initial read and then the second that should come after
@@ -244,10 +245,10 @@ func TestDatabaseEmptyShardSet(t *testing.T) {
 	})
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost0": sharding.NewShards([]uint32{0}, shard.Available),
 		"testhost1": sharding.NewShards([]uint32{1}, shard.Available),
 		"testhost2": sharding.NewShards([]uint32{2}, shard.Available),
@@ -266,10 +267,10 @@ func TestDatabaseOpenTwiceError(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost": sharding.NewShards([]uint32{0, 1, 2}, shard.Available),
 	})
 
@@ -299,10 +300,10 @@ func TestDatabaseCloseTwiceError(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost": sharding.NewShards([]uint32{0, 1, 2}, shard.Available),
 	})
 
@@ -332,10 +333,10 @@ func TestDatabaseOpenCanRetry(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost": sharding.NewShards([]uint32{0, 1, 2}, shard.Available),
 	})
 
@@ -368,10 +369,10 @@ func TestDatabaseCloseCanRetry(t *testing.T) {
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
 	defer restore()
 
-	viewsCh := make(chan topoView, 64)
+	viewsCh := make(chan testutil.TopologyView, 64)
 	defer close(viewsCh)
 
-	viewsCh <- newTopoView(1, map[string][]shard.Shard{
+	viewsCh <- testutil.NewTopologyView(1, map[string][]shard.Shard{
 		"testhost": sharding.NewShards([]uint32{0, 1, 2}, shard.Available),
 	})
 

--- a/topology/testutil/shard.go
+++ b/topology/testutil/shard.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutil
+
+import (
+	"github.com/m3db/m3cluster/shard"
+)
+
+// Uint32Range returns a slice of all values between [from, to].
+func Uint32Range(from, to uint32) []uint32 {
+	var ids []uint32
+	for i := from; i <= to; i++ {
+		ids = append(ids, i)
+	}
+	return ids
+}
+
+// Shards returns a slice of shards with provided ids and state `s`.
+func Shards(ids []uint32, s shard.State) []shard.Shard {
+	var shards []shard.Shard
+	for _, id := range ids {
+		shards = append(shards, shard.NewShard(id).SetState(s))
+	}
+	return shards
+}
+
+// ShardsRange returns a slice of shards for all ids between [from, to],
+// with shard state `s`.
+func ShardsRange(from, to uint32, s shard.State) []shard.Shard {
+	return Shards(Uint32Range(from, to), s)
+}

--- a/topology/testutil/topology.go
+++ b/topology/testutil/topology.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3db/sharding"
+	"github.com/m3db/m3db/topology"
+)
+
+// MustNewTopologyMap returns a new topology.Map with provided parameters.
+// It's a utility method to make tests easier to write.
+func MustNewTopologyMap(
+	replicas int,
+	assignment map[string][]shard.Shard,
+) topology.Map {
+	v := NewTopologyView(replicas, assignment)
+	m, err := v.Map()
+	if err != nil {
+		panic(err.Error())
+	}
+	return m
+}
+
+// NewTopologyView returns a new TopologyView with provided parameters.
+// It's a utility method to make tests easier to write.
+func NewTopologyView(
+	replicas int,
+	assignment map[string][]shard.Shard,
+) TopologyView {
+	total := 0
+	for _, shards := range assignment {
+		total += len(shards)
+	}
+
+	return TopologyView{
+		HashFn:     sharding.DefaultHashFn(total / replicas),
+		Replicas:   replicas,
+		Assignment: assignment,
+	}
+}
+
+// TopologyView represents a snaphshot view of a topology.Map.
+type TopologyView struct {
+	HashFn     sharding.HashFn
+	Replicas   int
+	Assignment map[string][]shard.Shard
+}
+
+// Map returns the topology.Map corresponding to a TopologyView.
+func (v TopologyView) Map() (topology.Map, error) {
+	var (
+		hostShardSets []topology.HostShardSet
+		allShards     []shard.Shard
+		unique        = make(map[uint32]struct{})
+	)
+
+	for hostID, assignedShards := range v.Assignment {
+		shardSet, _ := sharding.NewShardSet(assignedShards, v.HashFn)
+		host := topology.NewHost(hostID, fmt.Sprintf("%s:9000", hostID))
+		hostShardSet := topology.NewHostShardSet(host, shardSet)
+		hostShardSets = append(hostShardSets, hostShardSet)
+		for _, s := range assignedShards {
+			if _, ok := unique[s.ID()]; !ok {
+				unique[s.ID()] = struct{}{}
+				uniqueShard := shard.NewShard(s.ID()).SetState(shard.Available)
+				allShards = append(allShards, uniqueShard)
+			}
+		}
+	}
+
+	shardSet, err := sharding.NewShardSet(allShards, v.HashFn)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := topology.NewStaticOptions().
+		SetHostShardSets(hostShardSets).
+		SetReplicas(v.Replicas).
+		SetShardSet(shardSet)
+
+	return topology.NewStaticMap(opts), nil
+}


### PR DESCRIPTION
No functionality changes in this PR. It's a refactor to extract some common testing utilities out of a package. 

NB: the coverage drops because this PR is taking code out of a `_test.go` file into a non-test file. in a sub-package Go doesn't calculate coverage for test files so the original code wasn't covered, it's being covered now, and we only do package level coverage checks in the files that use this code, so we loose coverage :( 