### PR TITLE
Add filesystem inspection and use it in commitlog bootstrapper

### DIFF
--- a/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -110,7 +110,9 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 	bootstrapCommitlogOpts := bcl.NewOptions().
 		SetResultOptions(bootstrapOpts).
 		SetCommitLogOptions(commitLogOpts)
-	commitlogBootstrapperProvider, err := bcl.NewCommitLogBootstrapperProvider(bootstrapCommitlogOpts, nil)
+	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
+	commitlogBootstrapperProvider, err := bcl.NewCommitLogBootstrapperProvider(
+		bootstrapCommitlogOpts, mustInspectFilesystem(fsOpts), nil)
 	require.NoError(t, err)
 
 	// Setup the test bootstrapper to only return success when a signal is sent.

--- a/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -123,7 +123,9 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 	bootstrapCommitlogOpts := bcl.NewOptions().
 		SetResultOptions(bootstrapOpts).
 		SetCommitLogOptions(commitLogOpts)
-	commitlogBootstrapperProvider, err := bcl.NewCommitLogBootstrapperProvider(bootstrapCommitlogOpts, nil)
+	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
+	commitlogBootstrapperProvider, err := bcl.NewCommitLogBootstrapperProvider(
+		bootstrapCommitlogOpts, mustInspectFilesystem(fsOpts), nil)
 	require.NoError(t, err)
 
 	// Setup the test bootstrapper to only return success when a signal is sent.

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -171,7 +171,6 @@ func writeCommitLogDataBase(
 	}
 }
 
-// nolint: deadcode
 func mustInspectFilesystem(fsOpts fs.Options) fs.Inspection {
 	inspection, err := fs.InspectFilesystem(fsOpts)
 	if err != nil {

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3db/integration/generate"
+	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/persist/fs/commitlog"
 	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
@@ -168,4 +169,14 @@ func writeCommitLogDataBase(
 		// ensure writes finished
 		require.NoError(t, commitLog.Close())
 	}
+}
+
+// nolint: deadcode
+func mustInspectFilesystem(fsOpts fs.Options) fs.Inspection {
+	inspection, err := fs.InspectFilesystem(fsOpts)
+	if err != nil {
+		panic(err)
+	}
+
+	return inspection
 }

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -127,7 +127,8 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 		SetCommitLogOptions(commitLogOpts)
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
 
-	commitLogBootstrapper, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
+	commitLogBootstrapper, err := bcl.NewCommitLogBootstrapperProvider(
+		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
 	// fs bootstrapper
 	filePathPrefix := fsOpts.FilePathPrefix()
@@ -135,7 +136,7 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 		SetResultOptions(bsOpts).
 		SetFilesystemOptions(fsOpts).
 		SetDatabaseBlockRetrieverManager(setup.storageOpts.DatabaseBlockRetrieverManager())
-	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(filePathPrefix, bfsOpts, commitLogBootstrapper)
+	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
 	// bootstrapper storage opts
 	process := bootstrap.NewProcessProvider(fsBootstrapper, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -120,7 +120,7 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 	writeCommitLogData(t, setup, commitLogOpts, commitlogSeriesMaps, ns1.ID())
 
 	// commit log bootstrapper (must be after writing out commitlog files so inspection finds files)
-	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
 	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
 	bclOpts := bcl.NewOptions().
 		SetResultOptions(bsOpts).
@@ -135,10 +135,10 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 		SetResultOptions(bsOpts).
 		SetFilesystemOptions(fsOpts).
 		SetDatabaseBlockRetrieverManager(setup.storageOpts.DatabaseBlockRetrieverManager())
-	fsBootstrapper := fs.NewFileSystemBootstrapper(filePathPrefix, bfsOpts, commitLogBootstrapper)
+	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(filePathPrefix, bfsOpts, commitLogBootstrapper)
 	// bootstrapper storage opts
-	process := bootstrap.NewProcess(fsBootstrapper, bsOpts)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+	process := bootstrap.NewProcessProvider(fsBootstrapper, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	log.Info("moving time forward and starting server")
 	setup.setNowFn(t3)

--- a/integration/commitlog_bootstrap_merge_test.go
+++ b/integration/commitlog_bootstrap_merge_test.go
@@ -131,7 +131,6 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
 	// fs bootstrapper
-	filePathPrefix := fsOpts.FilePathPrefix()
 	bfsOpts := fs.NewOptions().
 		SetResultOptions(bsOpts).
 		SetFilesystemOptions(fsOpts).

--- a/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/integration/commitlog_bootstrap_multi_ns_test.go
@@ -106,7 +106,8 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 		SetResultOptions(bsOpts).
 		SetCommitLogOptions(commitLogOpts)
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
+	bs, err := bcl.NewCommitLogBootstrapperProvider(
+		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
 	process := bootstrap.NewProcessProvider(bs, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)

--- a/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/integration/commitlog_bootstrap_multi_ns_test.go
@@ -100,7 +100,7 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	log.Info("written data - ns2")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it
-	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
 	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
 	bclOpts := bcl.NewOptions().
 		SetResultOptions(bsOpts).
@@ -108,8 +108,8 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
 	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcess(bs, bsOpts)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+	process := bootstrap.NewProcessProvider(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	later := now.Add(4 * ns1BlockSize)
 	setup.setNowFn(later)

--- a/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -90,7 +90,7 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 	log.Info("finished writing data to commitlog file with out of range timestamp")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
 	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
 	bclOpts := bcl.NewOptions().
 		SetResultOptions(bsOpts).
@@ -98,8 +98,8 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
 	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcess(bs, bsOpts)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+	process := bootstrap.NewProcessProvider(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -96,7 +96,8 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 		SetResultOptions(bsOpts).
 		SetCommitLogOptions(commitLogOpts)
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
+	bs, err := bcl.NewCommitLogBootstrapperProvider(
+		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
 	process := bootstrap.NewProcessProvider(bs, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)

--- a/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -60,16 +60,6 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 		SetFlushInterval(defaultIntegrationTestFlushInterval)
 	setup.storageOpts = setup.storageOpts.SetCommitLogOptions(commitLogOpts)
 
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, noOpAll)
-	require.NoError(t, err)
-	processProvider := bootstrap.NewProcessProvider(bs, bsOpts)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(processProvider)
-
 	log := setup.storageOpts.InstrumentOptions().Logger()
 	log.Info("commit log bootstrap test")
 
@@ -98,6 +88,18 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 		now.Add(-2*ropts.RetentionPeriod()),
 	)
 	log.Info("finished writing data to commitlog file with out of range timestamp")
+
+	// Setup bootstrapper after writing data so filesystem inspection can find it.
+	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
+	bclOpts := bcl.NewOptions().
+		SetResultOptions(bsOpts).
+		SetCommitLogOptions(commitLogOpts)
+	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
+	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
+	require.NoError(t, err)
+	process := bootstrap.NewProcess(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/integration/commitlog_bootstrap_test.go
+++ b/integration/commitlog_bootstrap_test.go
@@ -75,16 +75,17 @@ func TestCommitLogBootstrap(t *testing.T) {
 	log.Info("finished writing data")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapper()
+	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
 	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
 	bclOpts := bcl.NewOptions().
 		SetResultOptions(bsOpts).
 		SetCommitLogOptions(commitLogOpts)
 	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
+	bs, err := bcl.NewCommitLogBootstrapperProvider(
+		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcess(bs, bsOpts)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcess(process)
+	process := bootstrap.NewProcessProvider(bs, bsOpts)
+	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/integration/mixed_mode_read_write_test.go
+++ b/integration/mixed_mode_read_write_test.go
@@ -229,8 +229,7 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 		SetResultOptions(bsOpts).
 		SetFilesystemOptions(fsOpts).
 		SetDatabaseBlockRetrieverManager(setup.storageOpts.DatabaseBlockRetrieverManager())
-	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(
-		sbfsOpts, mustInspectFilesystem(fsOpts), commitLogBootstrapper)
+	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
 
 	// bootstrapper storage opts
 	processProvider := bootstrap.NewProcessProvider(fsBootstrapper, bsOpts)

--- a/integration/mixed_mode_read_write_test.go
+++ b/integration/mixed_mode_read_write_test.go
@@ -219,7 +219,9 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 	bclOpts := bcl.NewOptions().
 		SetResultOptions(bsOpts).
 		SetCommitLogOptions(commitLogOpts)
-	commitLogBootstrapper, err := bcl.NewCommitLogBootstrapperProvider(bclOpts, noOpAll)
+
+	commitLogBootstrapper, err := bcl.NewCommitLogBootstrapperProvider(
+		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
 
 	// fs bootstrapper
@@ -227,7 +229,8 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 		SetResultOptions(bsOpts).
 		SetFilesystemOptions(fsOpts).
 		SetDatabaseBlockRetrieverManager(setup.storageOpts.DatabaseBlockRetrieverManager())
-	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
+	fsBootstrapper := fs.NewFileSystemBootstrapperProvider(
+		sbfsOpts, mustInspectFilesystem(fsOpts), commitLogBootstrapper)
 
 	// bootstrapper storage opts
 	processProvider := bootstrap.NewProcessProvider(fsBootstrapper, bsOpts)

--- a/integration/mixed_mode_read_write_test.go
+++ b/integration/mixed_mode_read_write_test.go
@@ -78,7 +78,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 
 	// startup server
 	log.Debug("starting server")
-	require.NoError(t, setup.startServer())
+	startServerWthNewInspection(t, opts, setup)
 	log.Debug("server is now up")
 
 	// Stop the server
@@ -134,7 +134,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 	// recreate the db from the data files and commit log
 	// should contain data from 15:30 - 17:59 on disk and 18:00 - 18:50 in mem
 	log.Infof("re-opening database & bootstrapping")
-	require.NoError(t, setup.startServer())
+	startServerWthNewInspection(t, opts, setup)
 	log.Infof("verifying data in database equals expected data")
 	verifySeriesMaps(t, setup, nsID, expectedSeriesMap)
 	log.Infof("verified data in database equals expected data")
@@ -153,7 +153,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 
 	// recreate the db from the data files and commit log
 	log.Infof("re-opening database & bootstrapping")
-	require.NoError(t, setup.startServer())
+	startServerWthNewInspection(t, opts, setup)
 
 	// verify in-memory data matches what we expect
 	// should contain data from 16:00 - 17:59 on disk and 18:00 - 18:50 in mem
@@ -161,6 +161,17 @@ func TestMixedModeReadWrite(t *testing.T) {
 	log.Infof("verifying data in database equals expected data")
 	verifySeriesMaps(t, setup, nsID, expectedSeriesMap)
 	log.Infof("verified data in database equals expected data")
+}
+
+// We use this helper method to start the server so that a new filesystem
+// inspection and commitlog bootstrapper are generated each time.
+func startServerWthNewInspection(
+	t *testing.T,
+	opts testOptions,
+	setup *testSetup,
+) {
+	setCommitLogAndFilesystemBootstrapper(t, opts, setup)
+	require.NoError(t, setup.startServer())
 }
 
 func waitUntilFileSetFilesCleanedUp(
@@ -189,6 +200,12 @@ func newTestSetupWithCommitLogAndFilesystemBootstrapper(t *testing.T, opts testO
 	setup, err := newTestSetup(t, opts, nil)
 	require.NoError(t, err)
 
+	setCommitLogAndFilesystemBootstrapper(t, opts, setup)
+
+	return setup
+}
+
+func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup *testSetup) *testSetup {
 	commitLogOpts := setup.storageOpts.CommitLogOptions()
 	fsOpts := commitLogOpts.FilesystemOptions()
 

--- a/integration/mixed_mode_read_write_test.go
+++ b/integration/mixed_mode_read_write_test.go
@@ -78,7 +78,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 
 	// startup server
 	log.Debug("starting server")
-	startServerWthNewInspection(t, opts, setup)
+	startServerWithNewInspection(t, opts, setup)
 	log.Debug("server is now up")
 
 	// Stop the server
@@ -134,7 +134,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 	// recreate the db from the data files and commit log
 	// should contain data from 15:30 - 17:59 on disk and 18:00 - 18:50 in mem
 	log.Infof("re-opening database & bootstrapping")
-	startServerWthNewInspection(t, opts, setup)
+	startServerWithNewInspection(t, opts, setup)
 	log.Infof("verifying data in database equals expected data")
 	verifySeriesMaps(t, setup, nsID, expectedSeriesMap)
 	log.Infof("verified data in database equals expected data")
@@ -153,7 +153,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 
 	// recreate the db from the data files and commit log
 	log.Infof("re-opening database & bootstrapping")
-	startServerWthNewInspection(t, opts, setup)
+	startServerWithNewInspection(t, opts, setup)
 
 	// verify in-memory data matches what we expect
 	// should contain data from 16:00 - 17:59 on disk and 18:00 - 18:50 in mem
@@ -165,7 +165,7 @@ func TestMixedModeReadWrite(t *testing.T) {
 
 // We use this helper method to start the server so that a new filesystem
 // inspection and commitlog bootstrapper are generated each time.
-func startServerWthNewInspection(
+func startServerWithNewInspection(
 	t *testing.T,
 	opts testOptions,
 	setup *testSetup,

--- a/persist/fs/commitlog/commit_log_test.go
+++ b/persist/fs/commitlog/commit_log_test.go
@@ -200,7 +200,7 @@ func newTestCommitLog(t *testing.T, opts Options) *commitLog {
 
 	// Ensure files present
 	fsopts := opts.FilesystemOptions()
-	files, err := fs.CommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	assert.NoError(t, err)
 	assert.True(t, len(files) == 1)
 
@@ -452,7 +452,7 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 
 	// Assert commitlog file exists and retrieve path
 	fsopts := opts.FilesystemOptions()
-	files, err := fs.CommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(files))
 
@@ -498,12 +498,12 @@ func TestCommitLogIteratorUsesPredicateFilter(t *testing.T) {
 
 	// Make sure multiple commitlog files were generated
 	fsopts := opts.FilesystemOptions()
-	files, err := fs.CommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	assert.NoError(t, err)
 	assert.True(t, len(files) == 3)
 
 	// This predicate should eliminate the first commitlog file
-	commitLogPredicate := func(entryTime time.Time, entryDuration time.Duration) bool {
+	commitLogPredicate := func(_ string, entryTime time.Time, _ time.Duration) bool {
 		return entryTime.After(alignedStart)
 	}
 
@@ -637,7 +637,7 @@ func TestCommitLogExpiresWriter(t *testing.T) {
 
 	// Ensure files present for each block size time window
 	fsopts := opts.FilesystemOptions()
-	files, err := fs.CommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	assert.NoError(t, err)
 	assert.True(t, len(files) == len(writes))
 

--- a/persist/fs/commitlog/iterator.go
+++ b/persist/fs/commitlog/iterator.go
@@ -68,7 +68,7 @@ type iteratorRead struct {
 // ReadAllPredicate can be passed as the ReadCommitLogPredicate for callers
 // that want a convenient way to read all the commitlogs
 func ReadAllPredicate() FileFilterPredicate {
-	return func(entryTime time.Time, entryDuration time.Duration) bool { return true }
+	return func(_ string, _ time.Time, _ time.Duration) bool { return true }
 }
 
 // NewIterator creates a new commit log iterator
@@ -78,7 +78,7 @@ func NewIterator(iterOpts IteratorOpts) (Iterator, error) {
 	iops = iops.SetMetricsScope(iops.MetricsScope().SubScope("iterator"))
 
 	path := fs.CommitLogsDirPath(opts.FilesystemOptions().FilePathPrefix())
-	files, err := fs.CommitLogFiles(path)
+	files, err := fs.SortedCommitLogFiles(path)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func filterFiles(opts Options, files []string, predicate FileFilterPredicate) ([
 			multiErr = multiErr.Add(err)
 			continue
 		}
-		if predicate(start, duration) {
+		if predicate(file, start, duration) {
 			filteredFiles = append(filteredFiles, file)
 		}
 	}

--- a/persist/fs/commitlog/reader.go
+++ b/persist/fs/commitlog/reader.go
@@ -339,7 +339,7 @@ func (r *reader) decoderLoop(inBuf <-chan decoderArg, outBuf chan<- readResponse
 		if !metadata.passedPredicate {
 			// Pass nil for outBuf because we don't want to send a readResponse along since this
 			// was just a series that the caller didn't want us to read.
-			r.handleDecoderLoopIterationEnd(arg, nil, response, nil)
+			r.handleDecoderLoopIterationEnd(arg, nil, readResponse{}, nil)
 			continue
 		}
 

--- a/persist/fs/commitlog/types.go
+++ b/persist/fs/commitlog/types.go
@@ -180,7 +180,7 @@ type Options interface {
 
 // FileFilterPredicate is a predicate that allows the caller to determine
 // which commitlogs the iterator should read from
-type FileFilterPredicate func(entryTime time.Time, entryDuration time.Duration) bool
+type FileFilterPredicate func(name string, entryTime time.Time, entryDuration time.Duration) bool
 
 // SeriesFilterPredicate is a predicate that determines whether datapoints for a given series
 // should be returned from the Commit log reader. The predicate is pushed down to the

--- a/persist/fs/files.go
+++ b/persist/fs/files.go
@@ -460,20 +460,20 @@ func DeleteInactiveDirectories(parentDirectoryPath string, activeDirectories []s
 	return DeleteDirectories(toDelete)
 }
 
-// CommitLogFiles returns all the commit log files in the commit logs directory.
-func CommitLogFiles(commitLogsDir string) ([]string, error) {
-	return commitlogFiles(commitLogsDir, commitLogFilePattern)
+// SortedCommitLogFiles returns all the commit log files in the commit logs directory.
+func SortedCommitLogFiles(commitLogsDir string) ([]string, error) {
+	return sortedCommitlogFiles(commitLogsDir, commitLogFilePattern)
 }
 
 // CommitLogFilesForTime returns all the commit log files for a given time.
 func CommitLogFilesForTime(commitLogsDir string, t time.Time) ([]string, error) {
 	commitLogFileForTimePattern := fmt.Sprintf(commitLogFileForTimeTemplate, t.UnixNano())
-	return commitlogFiles(commitLogsDir, commitLogFileForTimePattern)
+	return sortedCommitlogFiles(commitLogsDir, commitLogFileForTimePattern)
 }
 
-// CommitLogFilesBefore returns all the commit log files whose timestamps are earlier than a given time.
-func CommitLogFilesBefore(commitLogsDir string, t time.Time) ([]string, error) {
-	commitLogs, err := CommitLogFiles(commitLogsDir)
+// SortedCommitLogFilesBefore returns all the commit log files whose timestamps are earlier than a given time.
+func SortedCommitLogFilesBefore(commitLogsDir string, t time.Time) ([]string, error) {
+	commitLogs, err := SortedCommitLogFiles(commitLogsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -631,7 +631,7 @@ func filesetFiles(filePathPrefix string, namespace ident.ID, shard uint32, patte
 	return filesetFiles, nil
 }
 
-func commitlogFiles(commitLogsDir string, pattern string) ([]string, error) {
+func sortedCommitlogFiles(commitLogsDir string, pattern string) ([]string, error) {
 	return findFiles(commitLogsDir, pattern, func(files []string) sort.Interface {
 		return commitlogsByTimeAndIndexAscending(files)
 	})

--- a/persist/fs/files_test.go
+++ b/persist/fs/files_test.go
@@ -535,7 +535,7 @@ func TestSnapshotFileSetExistsAt(t *testing.T) {
 	require.True(t, exists)
 }
 
-func TestCommitLogFilesBefore(t *testing.T) {
+func TestSortedCommitLogFilesBefore(t *testing.T) {
 	iter := 20
 	perSlot := 3
 	dir := createCommitLogFiles(t, iter, perSlot)
@@ -544,7 +544,7 @@ func TestCommitLogFilesBefore(t *testing.T) {
 	cutoffIter := 8
 	cutoff := time.Unix(0, int64(cutoffIter))
 	commitLogsDir := CommitLogsDirPath(dir)
-	files, err := CommitLogFilesBefore(commitLogsDir, cutoff)
+	files, err := SortedCommitLogFilesBefore(commitLogsDir, cutoff)
 	require.NoError(t, err)
 	require.Equal(t, cutoffIter*perSlot, len(files))
 	for i := 0; i < cutoffIter; i++ {
@@ -571,7 +571,7 @@ func TestCommitLogFilesForTime(t *testing.T) {
 	}
 }
 
-func TestCommitLogFiles(t *testing.T) {
+func TestSortedCommitLogFiles(t *testing.T) {
 	iter := 20
 	perSlot := 3
 	dir := createCommitLogFiles(t, iter, perSlot)
@@ -582,7 +582,7 @@ func TestCommitLogFiles(t *testing.T) {
 	createFile(t, path.Join(dir, strconv.Itoa(iter+1)+separator+strconv.Itoa(perSlot+1)+fileSuffix), nil)
 	createFile(t, path.Join(dir, separator+strconv.Itoa(iter+1)+separator+strconv.Itoa(perSlot+1)+fileSuffix), nil)
 
-	files, err := CommitLogFiles(CommitLogsDirPath(dir))
+	files, err := SortedCommitLogFiles(CommitLogsDirPath(dir))
 	require.NoError(t, err)
 	require.Equal(t, iter*perSlot, len(files))
 

--- a/persist/fs/inspection.go
+++ b/persist/fs/inspection.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fs
+
+// Inspection contains the outcome of a filesystem inspection.
+type Inspection struct {
+	// SortedCommitLogFiles contains all commitlog filenames that existed
+	// before the node began accepting writes.
+	SortedCommitLogFiles []string
+}
+
+// CommitLogFilesSet generates a set of unique commitlog files.
+func (f Inspection) CommitLogFilesSet() map[string]struct{} {
+	set := make(map[string]struct{}, len(f.SortedCommitLogFiles))
+	for _, file := range f.SortedCommitLogFiles {
+		set[file] = struct{}{}
+	}
+
+	return set
+}
+
+// InspectFilesystem scans the filesystem and generates a Inspection
+// which the commitlog bootstrapper needs to avoid reading commitlog files that
+// were written *after* the process has already started. I.E in order to distinguish
+// between files that were already on disk before the process started, and those that
+// were written by the process itself once it started accepting writes (but before
+// bootstrapping had complete) we export a function which can be called during node
+// startup.
+func InspectFilesystem(fsOpts Options) (Inspection, error) {
+	path := CommitLogsDirPath(fsOpts.FilePathPrefix())
+	files, err := SortedCommitLogFiles(path)
+	if err != nil {
+		return Inspection{}, err
+	}
+
+	return Inspection{
+		SortedCommitLogFiles: files,
+	}, nil
+}

--- a/persist/fs/inspection_test.go
+++ b/persist/fs/inspection_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectFilesystem(t *testing.T) {
+	dir := createCommitLogFiles(t, 20, 1)
+	opts := NewOptions().SetFilePathPrefix(dir)
+	inspection, err := InspectFilesystem(opts)
+	require.NoError(t, err)
+
+	sorted, err := SortedCommitLogFiles(CommitLogsDirPath(dir))
+	require.NoError(t, err)
+	require.Equal(t, sorted, inspection.SortedCommitLogFiles)
+
+	set := inspection.CommitLogFilesSet()
+	require.Equal(t, len(sorted), len(set))
+	for _, file := range sorted {
+		_, ok := set[file]
+		require.True(t, ok)
+	}
+}

--- a/services/m3dbnode/config/bootstrap.go
+++ b/services/m3dbnode/config/bootstrap.go
@@ -107,7 +107,7 @@ func (bsc BootstrapConfiguration) New(
 		case bootstrapper.NoOpAllBootstrapperName:
 			bs = bootstrapper.NewNoOpAllBootstrapperProvider()
 		case bootstrapper.NoOpNoneBootstrapperName:
-			bs = bootstrapper.NewNoOpNoneBootstrapper()
+			bs = bootstrapper.NewNoOpNoneBootstrapperProvider()
 		case bfs.FileSystemBootstrapperName:
 			filePathPrefix := fsOpts.FilePathPrefix()
 			fsbopts := bfs.NewOptions().
@@ -115,7 +115,7 @@ func (bsc BootstrapConfiguration) New(
 				SetFilesystemOptions(fsOpts).
 				SetNumProcessors(bsc.fsNumProcessors()).
 				SetDatabaseBlockRetrieverManager(opts.DatabaseBlockRetrieverManager())
-			bs = bfs.NewFileSystemBootstrapper(filePathPrefix, fsbopts, bs)
+			bs = bfs.NewFileSystemBootstrapperProvider(filePathPrefix, fsbopts, bs)
 		case commitlog.CommitLogBootstrapperName:
 			copts := commitlog.NewOptions().
 				SetResultOptions(rsOpts).

--- a/services/m3dbnode/config/bootstrap.go
+++ b/services/m3dbnode/config/bootstrap.go
@@ -115,7 +115,7 @@ func (bsc BootstrapConfiguration) New(
 				SetFilesystemOptions(fsOpts).
 				SetNumProcessors(bsc.fsNumProcessors()).
 				SetDatabaseBlockRetrieverManager(opts.DatabaseBlockRetrieverManager())
-			bs = bfs.NewFileSystemBootstrapperProvider(filePathPrefix, fsbopts, bs)
+			bs = bfs.NewFileSystemBootstrapperProvider(fsbopts, bs)
 		case commitlog.CommitLogBootstrapperName:
 			copts := commitlog.NewOptions().
 				SetResultOptions(rsOpts).

--- a/services/m3dbnode/config/bootstrap.go
+++ b/services/m3dbnode/config/bootstrap.go
@@ -144,5 +144,5 @@ func (bsc BootstrapConfiguration) New(
 		}
 	}
 
-	return bootstrap.NewProcessProvider(bs, rsopts), nil
+	return bootstrap.NewProcessProvider(bs, rsOpts), nil
 }

--- a/services/m3dbnode/config/bootstrap.go
+++ b/services/m3dbnode/config/bootstrap.go
@@ -109,7 +109,6 @@ func (bsc BootstrapConfiguration) New(
 		case bootstrapper.NoOpNoneBootstrapperName:
 			bs = bootstrapper.NewNoOpNoneBootstrapperProvider()
 		case bfs.FileSystemBootstrapperName:
-			filePathPrefix := fsOpts.FilePathPrefix()
 			fsbopts := bfs.NewOptions().
 				SetResultOptions(rsOpts).
 				SetFilesystemOptions(fsOpts).

--- a/storage/block/block_test.go
+++ b/storage/block/block_test.go
@@ -21,7 +21,6 @@
 package block
 
 import (
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -223,7 +222,6 @@ func TestDatabaseBlockMerge(t *testing.T) {
 
 	// Try and read the data back and verify it looks good
 	depCtx := block1.opts.ContextPool().Get()
-	fmt.Println("streaming!")
 	stream, err := block1.Stream(depCtx)
 	require.NoError(t, err)
 	seg, err = stream.Segment()
@@ -317,7 +315,6 @@ func TestDatabaseBlockMergeChained(t *testing.T) {
 
 	// Try and read the data back and verify it looks good
 	depCtx := block1.opts.ContextPool().Get()
-	fmt.Println("streaming!")
 	stream, err := block1.Stream(depCtx)
 	require.NoError(t, err)
 	seg, err = stream.Segment()

--- a/storage/bootstrap/bootstrapper/commitlog/commit_log.go
+++ b/storage/bootstrap/bootstrapper/commitlog/commit_log.go
@@ -21,6 +21,7 @@
 package commitlog
 
 import (
+	"github.com/m3db/m3db/persist/fs"
 	"github.com/m3db/m3db/storage/bootstrap"
 	"github.com/m3db/m3db/storage/bootstrap/bootstrapper"
 )
@@ -31,14 +32,16 @@ const (
 )
 
 type commitLogBootstrapperProvider struct {
-	opts Options
-	next bootstrap.BootstrapperProvider
+	opts       Options
+	inspection fs.Inspection
+	next       bootstrap.BootstrapperProvider
 }
 
 // NewCommitLogBootstrapperProvider creates a new bootstrapper provider
 // to bootstrap from commit log files.
 func NewCommitLogBootstrapperProvider(
 	opts Options,
+	inspection fs.Inspection,
 	next bootstrap.BootstrapperProvider,
 ) (bootstrap.BootstrapperProvider, error) {
 	if err := opts.Validate(); err != nil {
@@ -52,7 +55,7 @@ func NewCommitLogBootstrapperProvider(
 
 func (p commitLogBootstrapperProvider) Provide() bootstrap.Bootstrapper {
 	var (
-		src  = newCommitLogSource(p.opts)
+		src  = newCommitLogSource(p.opts, p.inspection)
 		b    = &commitLogBootstrapper{}
 		next bootstrap.Bootstrapper
 	)

--- a/storage/bootstrap/bootstrapper/commitlog/commit_log.go
+++ b/storage/bootstrap/bootstrapper/commitlog/commit_log.go
@@ -48,8 +48,9 @@ func NewCommitLogBootstrapperProvider(
 		return nil, err
 	}
 	return commitLogBootstrapperProvider{
-		opts: opts,
-		next: next,
+		opts:       opts,
+		inspection: inspection,
+		next:       next,
 	}, nil
 }
 

--- a/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -65,6 +65,7 @@ func newCommitLogSource(opts Options, inspection fs.Inspection) bootstrap.Source
 		newIteratorFn: commitlog.NewIterator,
 	}
 }
+
 func (s *commitLogSource) Can(strategy bootstrap.Strategy) bool {
 	switch strategy {
 	case bootstrap.BootstrapSequential:
@@ -92,7 +93,8 @@ func (s *commitLogSource) ReadData(
 		return result.NewDataBootstrapResult(), nil
 	}
 
-	readCommitLogPredicate := newReadCommitLogPredicate(ns, shardsTimeRanges, s.opts, s.inspection)
+	readCommitLogPredicate := newReadCommitLogPredicate(
+		ns, shardsTimeRanges, s.opts, s.inspection)
 	readSeriesPredicate := newReadSeriesPredicate(ns)
 	iterOpts := commitlog.IteratorOpts{
 		CommitLogOptions:      s.opts.CommitLogOptions(),

--- a/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -97,7 +97,7 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 			if err != nil {
 				return false, err
 			}
-			source, err := NewCommitLogBootstrapperProvider(bootstrapOpts, inspection, nil)
+			provider, err := NewCommitLogBootstrapperProvider(bootstrapOpts, inspection, nil)
 			if err != nil {
 				return false, err
 			}

--- a/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -1,5 +1,3 @@
-// +build big
-
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -66,9 +64,10 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 			}()
 
 			// Configure the commitlog to use the test directory and set the blocksize
+			fsOpts := fs.NewOptions().SetFilePathPrefix(dir)
 			commitLogOpts := commitlog.NewOptions().
 				SetBlockSize(2 * time.Hour).
-				SetFilesystemOptions(fs.NewOptions().SetFilePathPrefix(dir))
+				SetFilesystemOptions(fsOpts)
 			bootstrapOpts := testOptions().SetCommitLogOptions(commitLogOpts)
 
 			// Instantiate commitlog
@@ -94,7 +93,11 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 			}
 
 			// Instantiate a commitlog source
-			provider, err := NewCommitLogBootstrapperProvider(bootstrapOpts, nil)
+			inspection, err := fs.InspectFilesystem(fsOpts)
+			if err != nil {
+				return false, err
+			}
+			source, err := NewCommitLogBootstrapperProvider(bootstrapOpts, inspection, nil)
 			if err != nil {
 				return false, err
 			}

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -69,7 +69,7 @@ func newCleanupManager(database database, scope tally.Scope) databaseCleanupMana
 		nowFn:                       opts.ClockOptions().NowFn(),
 		filePathPrefix:              filePathPrefix,
 		commitLogsDir:               commitLogsDir,
-		commitLogFilesBeforeFn:      fs.CommitLogFilesBefore,
+		commitLogFilesBeforeFn:      fs.SortedCommitLogFilesBefore,
 		commitLogFilesForTimeFn:     fs.CommitLogFilesForTime,
 		deleteFilesFn:               fs.DeleteFiles,
 		deleteInactiveDirectoriesFn: fs.DeleteInactiveDirectories,

--- a/tools/verify_commitlogs/main/main.go
+++ b/tools/verify_commitlogs/main/main.go
@@ -238,7 +238,11 @@ func main() {
 
 	// Don't bootstrap anything else
 	next := bootstrapper.NewNoOpAllBootstrapperProvider()
-	provider, err := commitlogsrc.NewCommitLogBootstrapperProvider(opts, next)
+	inspection, err := fs.InspectFilesystem(fsOpts)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	provider, err := commitlogsrc.NewCommitLogBootstrapperProvider(opts, inspection, next)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
Adds the concept of a FilesystemInspection which can be used by the commitlog reader to avoid reading commitlog files that were generated since the process started.

Also fixes case where the commitlog bootstrapper could deadlock because it was not returning a resource to a cyclical pool (if a datapoint didn't pass the readSeries predicate we would not return the byte slice to the buffer channel).