### PR TITLE
Remove `deadcode` from static-analysis

### DIFF
--- a/.metalinter.json
+++ b/.metalinter.json
@@ -14,8 +14,7 @@
     }
   },
   "Enable":
-    [ "deadcode"
-    , "varcheck"
+    [ "varcheck"
     , "structcheck"
     , "goconst"
     , "ineffassign"

--- a/client/consistency_level.go
+++ b/client/consistency_level.go
@@ -51,7 +51,7 @@ type sessionReadRuntimeReadConsistencyLevel struct {
 	s *session
 }
 
-// nolint: deadcode,unused
+// nolint: unused
 func newSessionReadRuntimeReadConsistencyLevel(
 	s *session,
 ) runtimeReadConsistencyLevel {

--- a/digest/test_util.go
+++ b/digest/test_util.go
@@ -49,7 +49,6 @@ func (md *mockDigest) Size() int           { return 0 }
 func (md *mockDigest) BlockSize() int      { return 0 }
 func (md *mockDigest) Sum32() uint32       { return md.digest }
 
-// nolint: deadcode
 func createTestFdWithDigest(t *testing.T) (*os.File, *mockDigest) {
 	fd := createTempFile(t)
 	md := &mockDigest{}

--- a/integration/bootstrap_helpers.go
+++ b/integration/bootstrap_helpers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/m3db/m3db/storage/namespace"
 )
 
-// nolint: deadcode
 func newTestBootstrapperSource(
 	opts testBootstrapperSourceOptions,
 	resultOpts result.Options,

--- a/integration/client.go
+++ b/integration/client.go
@@ -187,7 +187,6 @@ func m3dbClientTruncate(c client.Client, req *rpc.TruncateRequest) (int64, error
 	return adminSession.Truncate(ident.BinaryID(checked.NewBytes(req.NameSpace, nil)))
 }
 
-// nolint: deadcode
 func m3dbClientFetchBlocksMetadata(
 	c client.AdminClient,
 	namespace ident.ID,

--- a/integration/commitlog_bootstrap_helpers.go
+++ b/integration/commitlog_bootstrap_helpers.go
@@ -74,7 +74,6 @@ func randStringRunes(n int) string {
 	return string(b)
 }
 
-// nolint: deadcode
 func generateSeriesMaps(numBlocks int, starts ...time.Time) generate.SeriesBlocksByStart {
 	blockConfig := []generate.BlockConfig{}
 	for i := 0; i < numBlocks; i++ {
@@ -93,7 +92,6 @@ func generateSeriesMaps(numBlocks int, starts ...time.Time) generate.SeriesBlock
 	return generate.BlocksByStart(blockConfig)
 }
 
-// nolint: deadcode
 func writeCommitLogData(
 	t *testing.T,
 	s *testSetup,
@@ -104,7 +102,6 @@ func writeCommitLogData(
 	writeCommitLogDataBase(t, s, opts, data, namespace, nil)
 }
 
-// nolint: deadcode
 func writeCommitLogDataSpecifiedTS(
 	t *testing.T,
 	s *testSetup,
@@ -116,7 +113,6 @@ func writeCommitLogDataSpecifiedTS(
 	writeCommitLogDataBase(t, s, opts, data, namespace, &ts)
 }
 
-// nolint: deadcode
 func writeCommitLogDataBase(
 	t *testing.T,
 	s *testSetup,

--- a/integration/data.go
+++ b/integration/data.go
@@ -116,7 +116,6 @@ func writeVerifyDebugOutput(t *testing.T, filePath string, start, end time.Time,
 	require.NoError(t, w.Close())
 }
 
-// nolint: deadcode
 func verifySeriesMaps(
 	t *testing.T,
 	ts *testSetup,
@@ -151,7 +150,6 @@ func createFileIfPrefixSet(t *testing.T, prefix, suffix string) string {
 	return filePath
 }
 
-// nolint: deadcode
 func compareSeriesList(
 	t *testing.T,
 	expected generate.SeriesBlock,

--- a/integration/disk_cleanup_helpers.go
+++ b/integration/disk_cleanup_helpers.go
@@ -41,20 +41,18 @@ var (
 	errDataCleanupTimedOut = errors.New("cleaning up data files took too long")
 )
 
-// nolint: deadcode, unused
+// nolint: unused
 func newNamespaceDir(storageOpts storage.Options, md namespace.Metadata) string {
 	fsOpts := storageOpts.CommitLogOptions().FilesystemOptions()
 	filePathPrefix := fsOpts.FilePathPrefix()
 	return fs.NamespaceDataDirPath(filePathPrefix, md.ID())
 }
 
-// nolint: deadcode
 func newDataFileSetWriter(storageOpts storage.Options) (fs.DataFileSetWriter, error) {
 	fsOpts := storageOpts.CommitLogOptions().FilesystemOptions()
 	return fs.NewWriter(fsOpts)
 }
 
-// nolint: deadcode
 func writeFileSetFiles(t *testing.T, storageOpts storage.Options, md namespace.Metadata, shard uint32, fileTimes []time.Time) {
 	rOpts := md.Options().RetentionOptions()
 	writer, err := newDataFileSetWriter(storageOpts)
@@ -73,7 +71,6 @@ func writeFileSetFiles(t *testing.T, storageOpts storage.Options, md namespace.M
 	}
 }
 
-// nolint: deadcode
 func writeCommitLogs(t *testing.T, filePathPrefix string, fileTimes []time.Time) {
 	for _, start := range fileTimes {
 		commitLogFile, _ := fs.NextCommitLogsFile(filePathPrefix, start)
@@ -157,7 +154,7 @@ func waitUntilDataCleanedUpExtended(
 	return errDataCleanupTimedOut
 }
 
-// nolint: deadcode, unused
+// nolint: unused
 func waitUntilNamespacesCleanedUp(filePathPrefix string, namespace ident.ID, waitTimeout time.Duration) error {
 	dataCleanedUp := func() bool {
 		namespaceDir := fs.NamespaceDataDirPath(filePathPrefix, namespace)
@@ -170,7 +167,7 @@ func waitUntilNamespacesCleanedUp(filePathPrefix string, namespace ident.ID, wai
 	return errDataCleanupTimedOut
 }
 
-// nolint: deadcode, unused
+// nolint: unused
 func waitUntilNamespacesHaveReset(testSetup *testSetup, newNamespaces []namespace.Metadata, newShardSet sharding.ShardSet) (*testSetup, error) {
 	err := testSetup.stopServer()
 	if err != nil {
@@ -194,7 +191,7 @@ func waitUntilNamespacesHaveReset(testSetup *testSetup, newNamespaces []namespac
 	return resetSetup, nil
 }
 
-// nolint: deadcode, unused
+// nolint: unused
 func waitUntilDataFileSetsCleanedUp(filePathPrefix string, namespaces []storage.Namespace, extraShard uint32, waitTimeout time.Duration) error {
 	dataCleanedUp := func() bool {
 		for _, n := range namespaces {
@@ -212,7 +209,6 @@ func waitUntilDataFileSetsCleanedUp(filePathPrefix string, namespaces []storage.
 	return errDataCleanupTimedOut
 }
 
-// nolint: deadcode
 func waitUntilDataCleanedUp(filePathPrefix string, namespace ident.ID, shard uint32, toDelete time.Time, timeout time.Duration) error {
 	return waitUntilDataCleanedUpExtended(
 		[]cleanupTimesFileSet{
@@ -230,7 +226,6 @@ func waitUntilDataCleanedUp(filePathPrefix string, namespace ident.ID, shard uin
 		timeout)
 }
 
-// nolint: deadcode
 func getTimes(start time.Time, end time.Time, intervalSize time.Duration) []time.Time {
 	totalPeriod := end.Sub(start)
 	numPeriods := int(totalPeriod / intervalSize)

--- a/integration/disk_flush_helpers.go
+++ b/integration/disk_flush_helpers.go
@@ -45,7 +45,6 @@ var (
 	errDiskFlushTimedOut = errors.New("flushing data to disk took too long")
 )
 
-// nolint: deadcode
 func waitUntilSnapshotFilesFlushed(
 	filePathPrefix string,
 	shardSet sharding.ShardSet,
@@ -74,7 +73,6 @@ func waitUntilSnapshotFilesFlushed(
 	return errDiskFlushTimedOut
 }
 
-// nolint: deadcode
 func waitUntilDataFilesFlushed(
 	filePathPrefix string,
 	shardSet sharding.ShardSet,
@@ -169,7 +167,6 @@ func verifyForTime(
 	compareSeriesList(t, expected, actual)
 }
 
-// nolint: deadcode
 func verifyFlushedDataFiles(
 	t *testing.T,
 	shardSet sharding.ShardSet,
@@ -188,7 +185,6 @@ func verifyFlushedDataFiles(
 	}
 }
 
-// nolint: deadcode
 func verifySnapshottedDataFiles(
 	t *testing.T,
 	shardSet sharding.ShardSet,

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -270,7 +270,6 @@ func newDefaultBootstrappableTestSetups(
 	}
 }
 
-// nolint: deadcode
 func writeTestDataToDisk(
 	metadata namespace.Metadata,
 	setup *testSetup,
@@ -281,23 +280,19 @@ func writeTestDataToDisk(
 	return writer.Write(metadata.ID(), setup.shardSet, seriesMaps)
 }
 
-// nolint: deadcode
 func concatShards(a, b shard.Shards) shard.Shards {
 	all := append(a.All(), b.All()...)
 	return shard.NewShards(all)
 }
 
-// nolint: deadcode
 func newClusterShardsRange(from, to uint32, s shard.State) shard.Shards {
 	return shard.NewShards(testutil.ShardsRange(from, to, s))
 }
 
-// nolint: deadcode
 func newClusterEmptyShardsRange() shard.Shards {
 	return shard.NewShards(testutil.Shards(nil, shard.Available))
 }
 
-// nolint: deadcode
 func waitUntilHasBootstrappedShardsExactly(
 	db storage.Database,
 	shards []uint32,

--- a/integration/setup.go
+++ b/integration/setup.go
@@ -597,7 +597,6 @@ func (ts testSetups) parallel(fn func(s *testSetup)) {
 }
 
 // node generates service instances with reasonable defaults
-// nolint: deadcode
 func node(t *testing.T, n int, shards shard.Shards) services.ServiceInstance {
 	require.True(t, n < 250) // keep ports sensible
 	return services.NewServiceInstance().
@@ -607,7 +606,6 @@ func node(t *testing.T, n int, shards shard.Shards) services.ServiceInstance {
 }
 
 // newNodes creates a set of testSetups with reasonable defaults
-// nolint: deadcode
 func newNodes(
 	t *testing.T,
 	instances []services.ServiceInstance,

--- a/persist/fs/commitlog/commit_log.go
+++ b/persist/fs/commitlog/commit_log.go
@@ -99,7 +99,7 @@ type commitLogMetrics struct {
 
 type valueType int
 
-// nolint: deadcode, varcheck, unused
+// nolint: varcheck, unused
 const (
 	writeValueType valueType = iota
 	flushValueType

--- a/persist/fs/msgpack/schema.go
+++ b/persist/fs/msgpack/schema.go
@@ -54,7 +54,7 @@ const (
 
 type objectType int
 
-// nolint: deadcode, varcheck, unused
+// nolint: varcheck, unused
 const (
 	// Adding any new object types is a backwards-compatible change I.E
 	// the new binary will still be able to read old files, but it is

--- a/storage/cluster/database.go
+++ b/storage/cluster/database.go
@@ -44,7 +44,6 @@ var (
 	errNotWatchingTopology     = errors.New("cluster db is not watching topology")
 )
 
-// nolint: deadcode
 type newStorageDatabaseFn func(
 	shardSet sharding.ShardSet,
 	opts storage.Options,

--- a/storage/repair.go
+++ b/storage/repair.go
@@ -170,7 +170,6 @@ type sleepFn func(d time.Duration)
 
 type repairStatus int
 
-// nolint: deadcode
 const (
 	repairNotStarted repairStatus = iota
 	repairSuccess

--- a/storage/repair/metadata.go
+++ b/storage/repair/metadata.go
@@ -40,7 +40,6 @@ type hostBlockMetadataSlice struct {
 	pool     HostBlockMetadataSlicePool
 }
 
-// nolint: deadcode
 func newHostBlockMetadataSlice() HostBlockMetadataSlice {
 	return &hostBlockMetadataSlice{}
 }

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -1048,7 +1048,7 @@ func (s *dbShard) insertSeriesAsyncBatched(
 
 type insertSyncType uint8
 
-// nolint: deadcode, varcheck, unused
+// nolint: varcheck, unused
 const (
 	insertSync insertSyncType = iota
 	insertSyncIncReaderWriterCount

--- a/storage/types.go
+++ b/storage/types.go
@@ -820,7 +820,6 @@ type ShardBootstrapStates map[uint32]BootstrapState
 // BootstrapState is an enum representing the possible bootstrap states for a shard.
 type BootstrapState int
 
-// nolint: deadcode
 const (
 	BootstrapNotStarted BootstrapState = iota
 	Bootstrapping

--- a/storage/types.go
+++ b/storage/types.go
@@ -821,7 +821,10 @@ type ShardBootstrapStates map[uint32]BootstrapState
 type BootstrapState int
 
 const (
+	// BootstrapNotStarted indicates bootstrap has not been started yet.
 	BootstrapNotStarted BootstrapState = iota
+	// Bootstrapping indicates bootstrap process is in progress.
 	Bootstrapping
+	// Bootstrapped indicates a bootstrap process has completed.
 	Bootstrapped
 )

--- a/topology/consistency_level.go
+++ b/topology/consistency_level.go
@@ -29,7 +29,7 @@ import (
 // ConsistencyLevel is the consistency level for cluster operations
 type ConsistencyLevel int
 
-// nolint: deadcode, varcheck, unused
+// nolint: varcheck, unused
 const (
 	consistencyLevelNone ConsistencyLevel = iota
 

--- a/x/xio/null.go
+++ b/x/xio/null.go
@@ -22,7 +22,6 @@ package xio
 
 import "github.com/m3db/m3db/ts"
 
-// nolint: deadcode
 type nullSegmentReader struct{}
 
 func (r nullSegmentReader) Read(p []byte) (n int, err error) { return 0, nil }


### PR DESCRIPTION
It's only generating noise at this point. `unused` catches all legitimate cases, and handles build tags so has much fewer false positives. 