### PR TITLE
Undo index<->namespace block restrictions

### DIFF
--- a/storage/namespace/index_options.go
+++ b/storage/namespace/index_options.go
@@ -21,6 +21,7 @@
 package namespace
 
 import (
+	"errors"
 	"time"
 )
 
@@ -30,6 +31,10 @@ var (
 
 	// defaultIndexBlockSize is the default block size for index blocks.
 	defaultIndexBlockSize = 2 * time.Hour
+)
+
+var (
+	errIndexBlockSizePositive = errors.New("index block size must positive")
 )
 
 type indexOpts struct {
@@ -43,6 +48,15 @@ func NewIndexOptions() IndexOptions {
 		enabled:   defaultIndexEnabled,
 		blockSize: defaultIndexBlockSize,
 	}
+}
+func (i *indexOpts) Validate() error {
+	if !i.enabled {
+		return nil
+	}
+	if i.blockSize <= 0 {
+		return errIndexBlockSizePositive
+	}
+	return nil
 }
 
 func (i *indexOpts) Equal(value IndexOptions) bool {

--- a/storage/namespace/index_options_test.go
+++ b/storage/namespace/index_options_test.go
@@ -35,6 +35,20 @@ func TestIndexOptionsEqual(t *testing.T) {
 		opts.SetBlockSize(time.Hour*2)))
 }
 
+func TestIndexOptionsValidate(t *testing.T) {
+	opts := NewIndexOptions()
+	require.NoError(t, opts.Validate())
+
+	opts = opts.SetBlockSize(-time.Minute).SetEnabled(true)
+	require.Error(t, opts.Validate())
+
+	opts = opts.SetEnabled(false)
+	require.NoError(t, opts.Validate())
+
+	opts = opts.SetEnabled(true).SetBlockSize(time.Hour)
+	require.NoError(t, opts.Validate())
+}
+
 func TestIndexOptionsEnabled(t *testing.T) {
 	opts := NewIndexOptions()
 	require.True(t, opts.SetEnabled(true).Enabled())

--- a/storage/namespace/namespace_mock.go
+++ b/storage/namespace/namespace_mock.go
@@ -298,6 +298,18 @@ func (m *MockIndexOptions) EXPECT() *MockIndexOptionsMockRecorder {
 	return m.recorder
 }
 
+// Validate mocks base method
+func (m *MockIndexOptions) Validate() error {
+	ret := m.ctrl.Call(m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate
+func (mr *MockIndexOptionsMockRecorder) Validate() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockIndexOptions)(nil).Validate))
+}
+
 // Equal mocks base method
 func (m *MockIndexOptions) Equal(value IndexOptions) bool {
 	ret := m.ctrl.Call(m, "Equal", value)

--- a/storage/namespace/options_test.go
+++ b/storage/namespace/options_test.go
@@ -87,25 +87,53 @@ func TestOptionsValidate(t *testing.T) {
 		SetRetentionOptions(rOpts).
 		SetIndexOptions(iOpts)
 
-	iOpts.EXPECT().Enabled().Return(true).AnyTimes()
-
+	iOpts.EXPECT().Enabled().Return(true)
+	iOpts.EXPECT().Validate().Return(nil)
 	rOpts.EXPECT().Validate().Return(nil)
 	rOpts.EXPECT().RetentionPeriod().Return(time.Hour)
-	rOpts.EXPECT().BlockSize().Return(time.Hour)
+	rOpts.EXPECT().BufferFuture().Return(time.Hour)
+	rOpts.EXPECT().BufferPast().Return(time.Hour)
 	iOpts.EXPECT().BlockSize().Return(time.Hour)
 	require.NoError(t, o1.Validate())
+}
 
+func TestOptionsValidateError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rOpts := retention.NewMockOptions(ctrl)
+	iOpts := NewMockIndexOptions(ctrl)
+	o1 := NewOptions().
+		SetRetentionOptions(rOpts).
+		SetIndexOptions(iOpts)
+
+	rOpts.EXPECT().Validate().Return(nil)
+	iOpts.EXPECT().Enabled().Return(true)
+	iOpts.EXPECT().Validate().Return(fmt.Errorf("err"))
+	require.Error(t, o1.Validate())
+}
+
+func TestOptionsValidateBlockSizeLessThanBufferPast(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rOpts := retention.NewMockOptions(ctrl)
+	iOpts := NewMockIndexOptions(ctrl)
+	o1 := NewOptions().
+		SetRetentionOptions(rOpts).
+		SetIndexOptions(iOpts)
+
+	iOpts.EXPECT().Enabled().Return(true)
+	iOpts.EXPECT().Validate().Return(nil)
 	rOpts.EXPECT().Validate().Return(nil)
 	rOpts.EXPECT().RetentionPeriod().Return(time.Hour)
-	rOpts.EXPECT().BlockSize().Return(time.Hour)
-	iOpts.EXPECT().BlockSize().Return(2 * time.Hour)
-	require.Error(t, o1.Validate())
-
-	rOpts.EXPECT().Validate().Return(fmt.Errorf("test error"))
+	rOpts.EXPECT().BufferFuture().Return(time.Hour)
+	rOpts.EXPECT().BufferPast().Return(2 * time.Hour)
+	iOpts.EXPECT().BlockSize().Return(time.Hour)
 	require.Error(t, o1.Validate())
 }
 
-func TestOptionsValidateBlockSizeMustBeMultiple(t *testing.T) {
+func TestOptionsValidateBlockSizeLessThanBufferFuture(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -115,37 +143,12 @@ func TestOptionsValidateBlockSizeMustBeMultiple(t *testing.T) {
 		SetRetentionOptions(rOpts).
 		SetIndexOptions(iOpts)
 
-	iOpts.EXPECT().Enabled().Return(true).AnyTimes()
-
+	iOpts.EXPECT().Enabled().Return(true)
+	iOpts.EXPECT().Validate().Return(nil)
 	rOpts.EXPECT().Validate().Return(nil)
-	rOpts.EXPECT().RetentionPeriod().Return(4 * time.Hour).AnyTimes()
-	rOpts.EXPECT().BlockSize().Return(2 * time.Hour).AnyTimes()
-	iOpts.EXPECT().BlockSize().Return(3 * time.Hour).AnyTimes()
-	require.Error(t, o1.Validate())
-}
-
-func TestOptionsValidateBlockSizePositive(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	rOpts := retention.NewMockOptions(ctrl)
-	iOpts := NewMockIndexOptions(ctrl)
-	o1 := NewOptions().
-		SetRetentionOptions(rOpts).
-		SetIndexOptions(iOpts)
-
-	iOpts.EXPECT().Enabled().Return(true).AnyTimes()
-
-	rOpts.EXPECT().Validate().Return(nil)
-	rOpts.EXPECT().RetentionPeriod().Return(4 * time.Hour).AnyTimes()
-	rOpts.EXPECT().BlockSize().Return(2 * time.Hour).AnyTimes()
-	iOpts.EXPECT().BlockSize().Return(0 * time.Hour).AnyTimes()
-	require.Error(t, o1.Validate())
-
-	rOpts.EXPECT().Validate().Return(nil)
-	rOpts.EXPECT().RetentionPeriod().Return(4 * time.Hour).AnyTimes()
-	rOpts.EXPECT().BlockSize().Return(2 * time.Hour).AnyTimes()
-	iOpts.EXPECT().BlockSize().Return(-2 * time.Hour).AnyTimes()
+	rOpts.EXPECT().RetentionPeriod().Return(time.Hour)
+	rOpts.EXPECT().BufferFuture().Return(2 * time.Hour)
+	iOpts.EXPECT().BlockSize().Return(time.Hour)
 	require.Error(t, o1.Validate())
 }
 

--- a/storage/namespace/types.go
+++ b/storage/namespace/types.go
@@ -88,6 +88,9 @@ type Options interface {
 
 // IndexOptions controls the indexing options for a namespace.
 type IndexOptions interface {
+	// Validate validates the options.
+	Validate() error
+
 	// Equal returns true if the provide value is equal to this one.
 	Equal(value IndexOptions) bool
 


### PR DESCRIPTION
Will need to do the n-way expansion during the bootstrap result construction as a result of this change. 

Need it for having the flexibility to make index blocks smaller based on memory constraints. 