### PR TITLE
[WIP] Allow seed nodes to bootstrap placement

### DIFF
--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -57,6 +57,10 @@ type Configuration struct {
 	// Presence of a (etcd) server in this config denotes an embedded cluster
 	SeedNodes *SeedNodesConfig `yaml:"seedNodes"`
 
+	// BootstrapPlacement defines parameters for a seed node optionally
+	// bootstrapping its own placement.
+	BootstrapPlacement *topology.BootstrapPlacementConfig `yaml:"bootstrapPlacement"`
+
 	// NamespaceResolutionTimeout is the maximum time to wait to discover namespaces from KV
 	NamespaceResolutionTimeout time.Duration `yaml:"namespaceResolutionTimeout"`
 
@@ -104,6 +108,7 @@ type ConfigureResults struct {
 	NamespaceInitializer namespace.Initializer
 	TopologyInitializer  topology.Initializer
 	ClusterClient        clusterclient.Client
+	ServiceID            services.ServiceID
 	KVStore              kv.Store
 }
 
@@ -181,6 +186,7 @@ func (c Configuration) configureDynamic(cfgParams ConfigurationParameters) (Conf
 		NamespaceInitializer: nsInit,
 		TopologyInitializer:  topoInit,
 		ClusterClient:        configSvcClient,
+		ServiceID:            serviceID,
 		KVStore:              kv,
 	}, nil
 }

--- a/src/dbnode/topology/bootstrap.go
+++ b/src/dbnode/topology/bootstrap.go
@@ -24,12 +24,12 @@ const (
 // specified in the seed node list. Further placement customizations must be
 // done using the coordinator or some other mechanism.
 type BootstrapPlacementConfig struct {
-	Enabled        bool   `yaml:"enabled"`
 	ReplicaFactor  int    `yaml:"replicaFactor"`
 	NumShards      int    `yaml:"numShards"`
-	IsSharded      bool   `yaml:"isSharded"`
-	NodeWeight     uint32 `yaml:"nodeWeight"`
 	IsolationGroup string `yaml:"isolationGroup"`
+	NodeWeight     uint32 `yaml:"nodeWeight"`
+	IsSharded      bool   `yaml:"isSharded"`
+	Enabled        bool   `yaml:"enabled"`
 }
 
 // BootstrapInstance describes an instance in the placement.

--- a/src/dbnode/topology/bootstrap.go
+++ b/src/dbnode/topology/bootstrap.go
@@ -1,0 +1,144 @@
+package topology
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3cluster/services"
+)
+
+// NodeWeightHeuristic enumerates methods of calculating a node's weight in a
+// placement.
+type NodeWeightHeuristic int
+
+const (
+	// Static indicates the weight will be statically defined in config.
+	Static NodeWeightHeuristic = iota + 1
+)
+
+// BootstrapPlacementConfig configures options for a seed node to bootstrap its
+// own placement. If enabled, the initial placement will only contain the nodes
+// specified in the seed node list. Further placement customizations must be
+// done using the coordinator or some other mechanism.
+type BootstrapPlacementConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	ReplicaFactor  int    `yaml:"replicaFactor"`
+	NumShards      int    `yaml:"numShards"`
+	IsSharded      bool   `yaml:"isSharded"`
+	NodeWeight     uint32 `yaml:"nodeWeight"`
+	IsolationGroup string `yaml:"isolationGroup"`
+}
+
+// BootstrapInstance describes an instance in the placement.
+type BootstrapInstance struct {
+	// ID is a user-friendly ID for the instance.
+	ID string
+	// Address is an address reachable on the network (can be an IP or
+	// hostname).
+	Address string
+}
+
+// BootstrapConfigOption configures dynamically generated (not statically
+// defined in YAML) bootstrap placement options.
+type BootstrapConfigOption func(*bootstrapOptions)
+
+// WithInstances accepts a list of hostnames that will be part of the
+// bootstrapped placement. This should be strictly equal to the list of seed
+// hostnames. Each instance in the generated placement will have an ID equal to
+// its hostname, an endpoint of <hostname>:<port>.
+func WithInstances(instances []BootstrapInstance) BootstrapConfigOption {
+	return func(o *bootstrapOptions) {
+		o.instances = instances
+	}
+}
+
+// WithPort defines the cluster listen port.
+func WithPort(port uint32) BootstrapConfigOption {
+	return func(o *bootstrapOptions) {
+		o.port = port
+	}
+}
+
+// WithClient sets the m3cluster client.
+func WithClient(cl client.Client) BootstrapConfigOption {
+	return func(o *bootstrapOptions) {
+		o.client = cl
+	}
+}
+
+// WithServiceID sets the service ID to bootstrap the placement for.
+func WithServiceID(sid services.ServiceID) BootstrapConfigOption {
+	return func(o *bootstrapOptions) {
+		o.serviceID = sid
+	}
+}
+
+// WithBootstrapConfig sets the bootstrap configuration.
+func WithBootstrapConfig(bc BootstrapPlacementConfig) BootstrapConfigOption {
+	return func(o *bootstrapOptions) {
+		o.bootstrapConfig = bc
+	}
+}
+
+type bootstrapOptions struct {
+	client          client.Client
+	serviceID       services.ServiceID
+	bootstrapConfig BootstrapPlacementConfig
+	instances       []BootstrapInstance
+	port            uint32
+}
+
+func (o *bootstrapOptions) getPlacementSvc() (placement.Service, error) {
+	// TODO(schallert): figure out namespace overrides here
+	svcs, err := o.client.Services(services.NewOverrideOptions())
+	if err != nil {
+		return nil, fmt.Errorf("services init err: %v", err)
+	}
+
+	po := placement.NewOptions().SetValidZone(o.serviceID.Zone())
+	return svcs.PlacementService(o.serviceID, po)
+}
+
+func (o *bootstrapOptions) buildInstances() []placement.Instance {
+	insts := make([]placement.Instance, len(o.instances))
+	for i, bo := range o.instances {
+		ep := net.JoinHostPort(bo.Address, strconv.Itoa(int(o.port)))
+		insts[i] = placement.NewInstance().
+			SetEndpoint(ep).
+			SetPort(o.port).
+			SetZone(o.serviceID.Zone()).
+			SetID(bo.ID).
+			SetHostname(bo.ID).
+			SetIsolationGroup(o.bootstrapConfig.IsolationGroup).
+			SetWeight(o.bootstrapConfig.NodeWeight)
+	}
+
+	return insts
+}
+
+// BootstrapPlacement attempts to create an initial placement per the defined
+// config.
+func BootstrapPlacement(bOpts ...BootstrapConfigOption) error {
+	opts := bootstrapOptions{}
+	for _, f := range bOpts {
+		f(&opts)
+	}
+
+	psvc, err := opts.getPlacementSvc()
+	if err != nil {
+		return fmt.Errorf("placement svc init err: %v", err)
+	}
+
+	insts := opts.buildInstances()
+
+	// TODO(mschalle): catch the case where another seed node beat us to the
+	// atomic swap and don't fatal error
+	_, err = psvc.BuildInitialPlacement(insts,
+		opts.bootstrapConfig.NumShards,
+		opts.bootstrapConfig.ReplicaFactor)
+
+	return err
+}


### PR DESCRIPTION
We currently have a circular dependency issue when bootstrapping a new
seed-noded cluster. The seed nodes themselves will die if they don't get
a placement update within 30 seconds. Getting that placement update
requires an initial placement being built, which requires the
coordinator being up. The coordinator being up requires that a db client
has been made.

Yes, we could break this cycle in other ways. We could remove the hard
dependency on the coordinator, increase the placement timeout, etc.
There will presumably still be some manual effort required by the
operator to inform the coordinator of the initial placement.

This PR is a proof of concept for a way to break this dependency cycle
somewhat differently: by allowing the seed nodes to bootstrap their own
placement. If so configured, the seed nodes will race to create a
placement containing themselves, and the db node will continue to be
able to boot.

I've tested this as a proof of concept on bare metal and an orchestrator
and this seems to be a feasible holdover. However either way it's a
stop-gap solution until we figure out a more robust bootstrap story.

**PR IS WIP**. If we think this is an okay temporary approach I'll clean
it up, fix some bugs, and add some tests.