### PR TITLE
[namespace] Default disable snapshotting

### DIFF
--- a/src/dbnode/storage/namespace/options.go
+++ b/src/dbnode/storage/namespace/options.go
@@ -33,8 +33,8 @@ const (
 	// Namespace requires flushing by default
 	defaultFlushEnabled = true
 
-	// Namespace requires snapshotting by default
-	defaultSnapshotEnabled = true
+	// Namespace requires snapshotting disabled by default
+	defaultSnapshotEnabled = false
 
 	// Namespace writes go to commit logs by default
 	defaultWritesToCommitLog = true


### PR DESCRIPTION
Snapshotting is enabled by default but isn't quite ready yet. This makes
it confusing when users initialize a new namespace: they don't
explicitly enable snapshotting yet they see errors in their logs.