### PR TITLE
Make cmd unit tests run again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ SERVICES :=     \
 	m3coordinator
 
 SUBDIRS :=    \
+	cmd         \
 	dbnode      \
 	coordinator
 

--- a/src/cmd/services/m3coordinator/handler/namespace/add_test.go
+++ b/src/cmd/services/m3coordinator/handler/namespace/add_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 func TestNamespaceAddHandler(t *testing.T) {
-	mockKV, _ := SetupNamespaceTest(t)
-	addHandler := NewAddHandler(mockKV)
+	mockClient, mockKV, _ := SetupNamespaceTest(t)
+	addHandler := NewAddHandler(mockClient)
 
 	// Error case where required fields are not set
 	w := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestNamespaceAddHandler(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "all attributes must be set\n", string(body))
+	assert.Equal(t, "{\"Error\":\"all attributes must be set\"}\n", string(body))
 
 	// Test good case. Note: there is no way to tell the difference between a boolean
 	// being false and it not being set by a user.

--- a/src/cmd/services/m3coordinator/handler/namespace/add_test.go
+++ b/src/cmd/services/m3coordinator/handler/namespace/add_test.go
@@ -42,13 +42,13 @@ func TestNamespaceAddHandler(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	jsonInput := `
-		{
-			"name": "testNamespace",
-			"retention_period": "48h",
-			"block_size": "2h",
-			"needs_fileset_cleanup": false
-		}
-	`
+        {
+            "name": "testNamespace",
+            "retention_period": "48h",
+            "block_size": "2h",
+            "needs_fileset_cleanup": false
+        }
+    `
 
 	req := httptest.NewRequest("POST", "/namespace/add", strings.NewReader(jsonInput))
 	require.NotNil(t, req)
@@ -61,25 +61,36 @@ func TestNamespaceAddHandler(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "{\"Error\":\"all attributes must be set\"}\n", string(body))
+	assert.Equal(t, "{\"Error\":\"namespace options must be set\"}\n", string(body))
 
 	// Test good case. Note: there is no way to tell the difference between a boolean
 	// being false and it not being set by a user.
 	w = httptest.NewRecorder()
 
 	jsonInput = `
-		{
+        {
             "name": "testNamespace",
-            "retention_period": "48h",
-            "block_size": "2h",
-            "buffer_future": "10m",
-            "buffer_past": "10m",
-            "block_data_expiry": true,
-            "block_data_expiry_period": "4h",
-            "needs_bootstrap": true,
-            "needs_fileset_cleanup": false
-		}
-	`
+            "options": {
+              "bootstrapEnabled": true,
+              "flushEnabled": true,
+              "writesToCommitLog": true,
+              "enabledEnabled": true,
+              "retentionOptions": {
+                "retentionPeriodNanos": 172800000000000,
+                "blockSizeNanos": 7200000000000,
+                "bufferFutureNanos": 600000000000,
+                "bufferPastNanos": 600000000000,
+                "blockDataExpiry": true,
+                "blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
+              },
+              "snapshotEnabled": false,
+              "indexOptions": {
+                "enabled": true,
+                "blockSizeNanos": 7200000000000
+              }
+            }
+        }
+    `
 
 	req = httptest.NewRequest("POST", "/namespace/add", strings.NewReader(jsonInput))
 	require.NotNil(t, req)
@@ -91,5 +102,5 @@ func TestNamespaceAddHandler(t *testing.T) {
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"testNamespace\":{\"bootstrapEnabled\":false,\"flushEnabled\":false,\"writesToCommitLog\":false,\"cleanupEnabled\":false,\"repairEnabled\":false,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"14400000000000\"},\"snapshotEnabled\":true,\"indexOptions\":{\"enabled\":false,\"blockSizeNanos\":\"7200000000000\"}}}}}", string(body))
+	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"testNamespace\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":false,\"repairEnabled\":false,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"300000000000\"},\"snapshotEnabled\":false,\"indexOptions\":{\"enabled\":true,\"blockSizeNanos\":\"7200000000000\"}}}}}", string(body))
 }

--- a/src/cmd/services/m3coordinator/handler/namespace/delete_test.go
+++ b/src/cmd/services/m3coordinator/handler/namespace/delete_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func TestNamespaceDeleteHandlerNotFound(t *testing.T) {
-	mockKV, _ := SetupNamespaceTest(t)
-	deleteHandler := NewDeleteHandler(mockKV)
+	mockClient, mockKV, _ := SetupNamespaceTest(t)
+	deleteHandler := NewDeleteHandler(mockClient)
 
 	w := httptest.NewRecorder()
 
@@ -51,12 +51,12 @@ func TestNamespaceDeleteHandlerNotFound(t *testing.T) {
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "unable to find a namespace with specified name\n", string(body))
+	assert.Equal(t, "{\"Error\":\"unable to find a namespace with specified name\"}\n", string(body))
 }
 
 func TestNamespaceDeleteHandlerDeleteAll(t *testing.T) {
-	mockKV, ctrl := SetupNamespaceTest(t)
-	deleteHandler := NewDeleteHandler(mockKV)
+	mockClient, mockKV, ctrl := SetupNamespaceTest(t)
+	deleteHandler := NewDeleteHandler(mockClient)
 
 	w := httptest.NewRecorder()
 
@@ -96,12 +96,12 @@ func TestNamespaceDeleteHandlerDeleteAll(t *testing.T) {
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "", string(body))
+	assert.Equal(t, "{\"Deleted\":true}\n", string(body))
 }
 
 func TestNamespaceDeleteHandler(t *testing.T) {
-	mockKV, ctrl := SetupNamespaceTest(t)
-	deleteHandler := NewDeleteHandler(mockKV)
+	mockClient, mockKV, ctrl := SetupNamespaceTest(t)
+	deleteHandler := NewDeleteHandler(mockClient)
 
 	w := httptest.NewRecorder()
 
@@ -156,5 +156,5 @@ func TestNamespaceDeleteHandler(t *testing.T) {
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "", string(body))
+	assert.Equal(t, "{\"Deleted\":true}\n", string(body))
 }

--- a/src/cmd/services/m3coordinator/handler/placement/add_test.go
+++ b/src/cmd/services/m3coordinator/handler/placement/add_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3db/src/cmd/services/m3coordinator/config"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -36,8 +37,8 @@ import (
 )
 
 func TestPlacementAddHandler(t *testing.T) {
-	mockPlacementService := SetupPlacementTest(t)
-	handler := NewAddHandler(mockPlacementService)
+	mockClient, mockPlacementService := SetupPlacementTest(t)
+	handler := NewAddHandler(mockClient, config.Configuration{})
 
 	// Test add failure
 	w := httptest.NewRecorder()
@@ -50,7 +51,7 @@ func TestPlacementAddHandler(t *testing.T) {
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-	assert.Equal(t, "no new instances found in the valid zone\n", string(body))
+	assert.Equal(t, "{\"Error\":\"no new instances found in the valid zone\"}\n", string(body))
 
 	// Test add success
 	w = httptest.NewRecorder()

--- a/src/cmd/services/m3coordinator/handler/placement/delete_all_test.go
+++ b/src/cmd/services/m3coordinator/handler/placement/delete_all_test.go
@@ -26,13 +26,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/m3db/m3db/src/cmd/services/m3coordinator/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPlacementDeleteAllHandler(t *testing.T) {
-	mockPlacementService := SetupPlacementTest(t)
-	handler := NewDeleteAllHandler(mockPlacementService)
+	mockClient, mockPlacementService := SetupPlacementTest(t)
+	handler := NewDeleteAllHandler(mockClient, config.Configuration{})
 
 	// Test delete success
 	w := httptest.NewRecorder()

--- a/src/cmd/services/m3coordinator/handler/placement/delete_test.go
+++ b/src/cmd/services/m3coordinator/handler/placement/delete_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3db/src/cmd/services/m3coordinator/config"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,8 @@ import (
 )
 
 func TestPlacementDeleteHandler(t *testing.T) {
-	mockPlacementService := SetupPlacementTest(t)
-	handler := NewDeleteHandler(mockPlacementService)
+	mockClient, mockPlacementService := SetupPlacementTest(t)
+	handler := NewDeleteHandler(mockClient, config.Configuration{})
 
 	// Test remove success
 	w := httptest.NewRecorder()
@@ -64,5 +65,5 @@ func TestPlacementDeleteHandler(t *testing.T) {
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-	assert.Equal(t, "ID does not exist\n", string(body))
+	assert.Equal(t, "{\"Error\":\"ID does not exist\"}\n", string(body))
 }

--- a/src/cmd/services/m3coordinator/handler/placement/get_test.go
+++ b/src/cmd/services/m3coordinator/handler/placement/get_test.go
@@ -115,5 +115,5 @@ func TestPlacementGetHandler(t *testing.T) {
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "{\"Message\":\"no placement found\"}\n", string(body))
+	assert.Equal(t, "{\"Result\":\"no placement found\"}\n", string(body))
 }

--- a/src/cmd/services/m3coordinator/handler/placement/init_test.go
+++ b/src/cmd/services/m3coordinator/handler/placement/init_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3cluster/generated/proto/placementpb"
 	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3db/src/cmd/services/m3coordinator/config"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -37,8 +38,8 @@ import (
 )
 
 func TestPlacementInitHandler(t *testing.T) {
-	mockPlacementService := SetupPlacementTest(t)
-	handler := NewInitHandler(mockPlacementService)
+	mockClient, mockPlacementService := SetupPlacementTest(t)
+	handler := NewInitHandler(mockClient, config.Configuration{})
 
 	// Test placement init success
 	w := httptest.NewRecorder()
@@ -89,5 +90,5 @@ func TestPlacementInitHandler(t *testing.T) {
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-	assert.Equal(t, "unable to build initial placement\n", string(body))
+	assert.Equal(t, "{\"Error\":\"unable to build initial placement\"}\n", string(body))
 }

--- a/src/cmd/services/m3coordinator/handler/prometheus/native/read_test.go
+++ b/src/cmd/services/m3coordinator/handler/prometheus/native/read_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3db/src/coordinator/executor"
 	"github.com/m3db/m3db/src/cmd/services/m3coordinator/handler/prometheus"
+	"github.com/m3db/m3db/src/coordinator/executor"
 	"github.com/m3db/m3db/src/coordinator/test/local"
 	"github.com/m3db/m3db/src/coordinator/util/logging"
 
@@ -66,7 +66,7 @@ func TestPromReadNotImplemented(t *testing.T) {
 	r, parseErr := promRead.parseRequest(req)
 	require.Nil(t, parseErr, "unable to parse request")
 	_, err := promRead.read(context.TODO(), httptest.NewRecorder(), r, &prometheus.RequestParams{Timeout: time.Hour})
-	require.NotNil(t, err, "not implemented")
+	require.NotNil(t, err, "{\"Error\":\"not implemented\"}\n")
 }
 
 // NB(braskin): will replace this test once the server actually returns something
@@ -81,7 +81,7 @@ func TestPromReadEndpoint(t *testing.T) {
 	promRead := &PromReadHandler{engine: engine}
 
 	promRead.ServeHTTP(res, req)
-	require.Equal(t, "not implemented\n", res.Body.String())
+	require.Equal(t, "{\"Error\":\"not implemented\"}\n", res.Body.String())
 }
 
 func createURL() *bytes.Buffer {


### PR DESCRIPTION
* Have unit tests in `src/cmd/` run again - add two more jobs to CI after landing this PR
  1. `NPROC=4 TEST_TIMEOUT_SCALE=20 PACKAGE=github.com/m3db/m3db make test-ci-unit-cmd`
  1. `TEST_TIMEOUT_SCALE=20 PACKAGE=github.com/m3db/m3db make test-ci-big-unit-cmd`
* Fix unit tests