### PR TITLE
Mark shards available in batch

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3bdc7dceff2d471019201754a12f378190c68363d7975d60ffc74504fb7091b9
-updated: 2018-05-30T13:32:27.215185-04:00
+hash: a71cd8f819a596abf5768009cbd643737f823ca7afad13dae23b00268142ed36
+updated: 2018-05-27T22:31:42.473198-07:00
 imports:
 - name: github.com/apache/thrift
   version: c2fb1c4e8c931d22617bebb0bf388cb4d5e6fcff
@@ -186,7 +186,7 @@ imports:
 - name: github.com/m3db/bloom
   version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
 - name: github.com/m3db/m3cluster
-  version: 2096f1ed16154b3ce05c9b596c5fd1a8fa485c1b
+  version: b4935c48a00f47c6f16f71d15d94e1c24785297d
   subpackages:
   - client
   - client/etcd

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
   - ident
 
 - package: github.com/m3db/m3cluster
-  version: 2096f1ed16154b3ce05c9b596c5fd1a8fa485c1b
+  version: b4935c48a00f47c6f16f71d15d94e1c24785297d
   subpackages:
   - client
   - services

--- a/src/dbnode/integration/fake/cluster_services.go
+++ b/src/dbnode/integration/fake/cluster_services.go
@@ -271,10 +271,10 @@ func (s *m3ClusterPlacementService) ReplaceInstances(
 ) (placement.Placement, []placement.Instance, error) {
 	return nil, nil, fmt.Errorf("not implemented")
 }
-func (s *m3ClusterPlacementService) MarkShardAvailable(
-	instanceID string, shardID uint32,
+func (s *m3ClusterPlacementService) MarkShardsAvailable(
+	instanceID string, shardIDs ...uint32,
 ) error {
-	s.markedAvailable[instanceID] = append(s.markedAvailable[instanceID], shardID)
+	s.markedAvailable[instanceID] = append(s.markedAvailable[instanceID], shardIDs...)
 	return nil
 }
 func (s *m3ClusterPlacementService) MarkAllShardsAvailable() (placement.Placement, error) {

--- a/src/dbnode/storage/cluster/database_test.go
+++ b/src/dbnode/storage/cluster/database_test.go
@@ -168,10 +168,6 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 		MarkShardsAvailable("testhost0", gomock.Any()).
 		Do(onMarkShardsAvailable).
 		AnyTimes()
-	props.topology.EXPECT().
-		MarkShardsAvailable("testhost0", gomock.Any(), gomock.Any()).
-		Do(onMarkShardsAvailable).
-		AnyTimes()
 
 	// Enqueue the update
 	viewsCh <- testutil.NewTopologyView(1, updatedView)

--- a/src/dbnode/storage/cluster/database_test.go
+++ b/src/dbnode/storage/cluster/database_test.go
@@ -140,15 +140,10 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	mockStorageDB.EXPECT().Namespaces().Return(expectNamespaces)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(1)
 	props.topology.EXPECT().
-		MarkShardAvailable("testhost0", uint32(2)).
-		Do(func(hostID string, shardID uint32) {
-			wg.Done()
-		})
-	props.topology.EXPECT().
-		MarkShardAvailable("testhost0", uint32(3)).
-		Do(func(hostID string, shardID uint32) {
+		MarkShardsAvailable("testhost0", uint32(2), uint32(3)).
+		Do(func(hostID string, shardIDs ...uint32) {
 			wg.Done()
 		})
 

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -173,16 +173,16 @@ func (t *dynamicTopology) Close() {
 	t.watchable.Close()
 }
 
-func (t *dynamicTopology) MarkShardAvailable(
+func (t *dynamicTopology) MarkShardsAvailable(
 	instanceID string,
-	shardID uint32,
+	shardIDs ...uint32,
 ) error {
 	opts := placement.NewOptions()
 	ps, err := t.services.PlacementService(t.opts.ServiceID(), opts)
 	if err != nil {
 		return err
 	}
-	return ps.MarkShardAvailable(instanceID, shardID)
+	return ps.MarkShardsAvailable(instanceID, shardIDs...)
 }
 
 func waitOnInit(w services.Watch, d time.Duration) error {

--- a/src/dbnode/topology/topology_mock.go
+++ b/src/dbnode/topology/topology_mock.go
@@ -295,16 +295,21 @@ func (mr *MockDynamicTopologyMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDynamicTopology)(nil).Close))
 }
 
-// MarkShardAvailable mocks base method
-func (m *MockDynamicTopology) MarkShardAvailable(instanceID string, shardID uint32) error {
-	ret := m.ctrl.Call(m, "MarkShardAvailable", instanceID, shardID)
+// MarkShardsAvailable mocks base method
+func (m *MockDynamicTopology) MarkShardsAvailable(instanceID string, shardIDs ...uint32) error {
+	varargs := []interface{}{instanceID}
+	for _, a := range shardIDs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MarkShardsAvailable", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// MarkShardAvailable indicates an expected call of MarkShardAvailable
-func (mr *MockDynamicTopologyMockRecorder) MarkShardAvailable(instanceID, shardID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkShardAvailable", reflect.TypeOf((*MockDynamicTopology)(nil).MarkShardAvailable), instanceID, shardID)
+// MarkShardsAvailable indicates an expected call of MarkShardsAvailable
+func (mr *MockDynamicTopologyMockRecorder) MarkShardsAvailable(instanceID interface{}, shardIDs ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{instanceID}, shardIDs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkShardsAvailable", reflect.TypeOf((*MockDynamicTopology)(nil).MarkShardsAvailable), varargs...)
 }
 
 // MockMapWatch is a mock of MapWatch interface

--- a/src/dbnode/topology/types.go
+++ b/src/dbnode/topology/types.go
@@ -75,8 +75,8 @@ type Topology interface {
 type DynamicTopology interface {
 	Topology
 
-	// MarkShardAvailable marks a shard with the state of initializing as available
-	MarkShardAvailable(instanceID string, shardID uint32) error
+	// MarkShardsAvailable marks a shard with the state of initializing as available
+	MarkShardsAvailable(instanceID string, shardIDs ...uint32) error
 }
 
 // MapWatch is a watch on a topology map


### PR DESCRIPTION
When a cluster comes online it needs to mark a lot of shards as available, this change marks multiple shards as available in one go to help reduce the RPCs required when a new node with a lot of shards comes online.

~Note: still need to update m3cluster to a ref from master once https://github.com/m3db/m3cluster/pull/226 is merged.~