### PR TITLE
Fix flaky tests: TestConfig and TestEmbeddedConfig

### DIFF
--- a/src/cmd/services/m3dbnode/main/common_test.go
+++ b/src/cmd/services/m3dbnode/main/common_test.go
@@ -1,5 +1,4 @@
 // +build big
-//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cmd/services/m3dbnode/main/common_test.go
+++ b/src/cmd/services/m3dbnode/main/common_test.go
@@ -1,4 +1,5 @@
 // +build big
+//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -1,5 +1,4 @@
 // +build big
-//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -51,9 +51,6 @@ import (
 
 // TestIndexEnabledServer tests booting a server using file based configuration.
 func TestIndexEnabledServer(t *testing.T) {
-	// Temporarily skip while we debug flakiness
-	t.SkipNow()
-
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -1,4 +1,5 @@
 // +build big
+//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -649,7 +649,6 @@ func waitUntilAllShardsAreAvailable(t *testing.T, session client.AdminSession) {
 		)
 
 		if len(hostShardSets) == 0 {
-			fmt.Println("no host shard sets")
 			// We haven't received an actual topology yet.
 			continue
 		}

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -1,5 +1,4 @@
 // +build big
-//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -1,4 +1,5 @@
 // +build big
+//
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -715,17 +715,17 @@ func (mr *MockAdminSessionMockRecorder) Replicas() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replicas", reflect.TypeOf((*MockAdminSession)(nil).Replicas))
 }
 
-// Topology mocks base method
-func (m *MockAdminSession) Topology() (topology.Topology, error) {
-	ret := m.ctrl.Call(m, "Topology")
-	ret0, _ := ret[0].(topology.Topology)
+// TopologyMap mocks base method
+func (m *MockAdminSession) TopologyMap() (topology.Map, error) {
+	ret := m.ctrl.Call(m, "TopologyMap")
+	ret0, _ := ret[0].(topology.Map)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Topology indicates an expected call of Topology
-func (mr *MockAdminSessionMockRecorder) Topology() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Topology", reflect.TypeOf((*MockAdminSession)(nil).Topology))
+// TopologyMap indicates an expected call of TopologyMap
+func (mr *MockAdminSessionMockRecorder) TopologyMap() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopologyMap", reflect.TypeOf((*MockAdminSession)(nil).TopologyMap))
 }
 
 // Truncate mocks base method
@@ -3210,17 +3210,17 @@ func (mr *MockclientSessionMockRecorder) Replicas() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replicas", reflect.TypeOf((*MockclientSession)(nil).Replicas))
 }
 
-// Topology mocks base method
-func (m *MockclientSession) Topology() (topology.Topology, error) {
-	ret := m.ctrl.Call(m, "Topology")
-	ret0, _ := ret[0].(topology.Topology)
+// TopologyMap mocks base method
+func (m *MockclientSession) TopologyMap() (topology.Map, error) {
+	ret := m.ctrl.Call(m, "TopologyMap")
+	ret0, _ := ret[0].(topology.Map)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Topology indicates an expected call of Topology
-func (mr *MockclientSessionMockRecorder) Topology() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Topology", reflect.TypeOf((*MockclientSession)(nil).Topology))
+// TopologyMap indicates an expected call of TopologyMap
+func (mr *MockclientSessionMockRecorder) TopologyMap() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopologyMap", reflect.TypeOf((*MockclientSession)(nil).TopologyMap))
 }
 
 // Truncate mocks base method

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -129,7 +129,7 @@ var (
 	errUnableToEncodeTags = errors.New("unable to include tags")
 	// errNoTopology is returned when the session does not have a topology. Should never happen
 	// in practice.
-	errNoTopology = fmt.Errorf("%s session does not have a topology", instrument.InvariantViolatedMetricName)
+	errNoTopologyMap = fmt.Errorf("%s session does not have a topology map", instrument.InvariantViolatedMetricName)
 )
 
 // sessionState is volatile state that is protected by a
@@ -1571,22 +1571,22 @@ func (s *session) Replicas() int {
 	return v
 }
 
-func (s *session) Topology() (topology.Topology, error) {
+func (s *session) TopologyMap() (topology.Map, error) {
 	s.state.RLock()
 	status := s.state.status
-	topology := s.state.topo
+	topoMap := s.state.topoMap
 	s.state.RUnlock()
 
 	// Make sure the session is open, as thats what sets the initial topology.
 	if status != statusOpen {
 		return nil, errSessionStatusNotOpen
 	}
-	if topology == nil {
+	if topoMap == nil {
 		// Should never happen.
-		return nil, errNoTopology
+		return nil, errNoTopologyMap
 	}
 
-	return topology, nil
+	return topoMap, nil
 }
 
 func (s *session) Truncate(namespace ident.ID) (int64, error) {

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -127,7 +127,7 @@ var (
 	// errUnableToEncodeTags is raised when the server is unable to encode provided tags
 	// to be sent over the wire.
 	errUnableToEncodeTags = errors.New("unable to include tags")
-	// errNoTopology is returned when the session does not have a topology. Should never happen
+	// errNoTopologyMap is returned when the session does not have a topology. Should never happen
 	// in practice.
 	errNoTopologyMap = fmt.Errorf("%s session does not have a topology map", instrument.InvariantViolatedMetricName)
 )

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -154,7 +154,7 @@ type AdminSession interface {
 	// Replicas returns the replication factor
 	Replicas() int
 
-	// TopologyMap returns the current topology MAP
+	// TopologyMap returns the current topology map
 	TopologyMap() (topology.Map, error)
 
 	// Truncate will truncate the namespace for a given shard

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -154,8 +154,8 @@ type AdminSession interface {
 	// Replicas returns the replication factor
 	Replicas() int
 
-	// Topology returns the current topology
-	Topology() (topology.Topology, error)
+	// TopologyMap returns the current topology MAP
+	TopologyMap() (topology.Map, error)
 
 	// Truncate will truncate the namespace for a given shard
 	Truncate(namespace ident.ID) (int64, error)

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -799,13 +799,12 @@ func initialTopologyState(opts Options) (topologyState, error) {
 		return topologyState{}, err
 	}
 
-	topology, err := session.Topology()
+	topoMap, err := session.TopologyMap()
 	if err != nil {
 		return topologyState{}, err
 	}
 
 	var (
-		topoMap       = topology.Get()
 		hostShardSets = topoMap.HostShardSets()
 		topologyState = topologyState{
 			majorityReplicas: topoMap.MajorityReplicas(),

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -89,15 +89,10 @@ func newValidMockClient(t *testing.T, ctrl *gomock.Controller) *client.MockAdmin
 	mockMap.EXPECT().HostShardSets().Return(hostShardSets).AnyTimes()
 	mockMap.EXPECT().MajorityReplicas().Return(3).AnyTimes()
 
-	mockTopology := topology.NewMockTopology(ctrl)
-	mockTopology.EXPECT().
-		Get().
-		Return(mockMap)
-
 	mockAdminSession := client.NewMockAdminSession(ctrl)
 	mockAdminSession.EXPECT().
-		Topology().
-		Return(mockTopology, nil)
+		TopologyMap().
+		Return(mockMap, nil)
 
 	mockClient := client.NewMockAdminClient(ctrl)
 	mockClient.EXPECT().

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_index_test.go
@@ -405,10 +405,10 @@ func TestBootstrapIndexErr(t *testing.T) {
 	require.NoError(t, err)
 	topoOpts := topology.NewStaticOptions().
 		SetShardSet(shardSet)
-	topo := topology.NewStaticTopology(topoOpts)
+	topoMap := topology.NewStaticTopology(topoOpts).Get()
 
 	mockAdminSession := client.NewMockAdminSession(ctrl)
-	mockAdminSession.EXPECT().Topology().Return(topo, nil)
+	mockAdminSession.EXPECT().TopologyMap().Return(topoMap, nil)
 	mockAdminSessionCalls := []*gomock.Call{}
 
 	for blockStart := start; blockStart.Before(end); blockStart = blockStart.Add(blockSize) {

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -198,15 +198,10 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			mockMap.EXPECT().HostShardSets().Return(hostShardSets).AnyTimes()
 			mockMap.EXPECT().MajorityReplicas().Return(replicaMajority).AnyTimes()
 
-			mockTopology := topology.NewMockTopology(ctrl)
-			mockTopology.EXPECT().
-				Get().
-				Return(mockMap)
-
 			mockAdminSession := client.NewMockAdminSession(ctrl)
 			mockAdminSession.EXPECT().
-				Topology().
-				Return(mockTopology, nil)
+				TopologyMap().
+				Return(mockMap, nil)
 
 			mockClient := client.NewMockAdminClient(ctrl)
 			mockClient.EXPECT().


### PR DESCRIPTION
- [X] Refactor the admin session interface to return a topology.Map instead of topology.Topology (we need a static view of the sessions topology map state, we can't use our own Topology watch)
- [X] Wait for all shards to be available in the session before attempting writes in the flaky tests