### PR TITLE
Use the same timestamp for all Tick() logic as we do for Flush() logic

### DIFF
--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -681,7 +681,7 @@ func TestDatabaseNamespaceIndexFunctions(t *testing.T) {
 
 	ns := dbAddNewMockNamespace(ctrl, d, "testns")
 	ns.EXPECT().GetOwnedShards().Return([]databaseShard{}).AnyTimes()
-	ns.EXPECT().Tick(gomock.Any()).Return(nil).AnyTimes()
+	ns.EXPECT().Tick(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ns.EXPECT().BootstrapState().Return(ShardBootstrapStates{}).AnyTimes()
 	require.NoError(t, d.Open())
 

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -450,12 +450,11 @@ func (i *nsIndex) Bootstrap(
 	return multiErr.FinalError()
 }
 
-func (i *nsIndex) Tick(c context.Cancellable) (namespaceIndexTickResult, error) {
+func (i *nsIndex) Tick(c context.Cancellable, tickStart time.Time) (namespaceIndexTickResult, error) {
 	var (
 		result                     = namespaceIndexTickResult{}
-		now                        = i.nowFn()
-		earliestBlockStartToRetain = retention.FlushTimeStartForRetentionPeriod(i.retentionPeriod, i.blockSize, now)
-		lastSealableBlockStart     = retention.FlushTimeEndForBlockSize(i.blockSize, now.Add(-i.bufferPast))
+		earliestBlockStartToRetain = retention.FlushTimeStartForRetentionPeriod(i.retentionPeriod, i.blockSize, tickStart)
+		lastSealableBlockStart     = retention.FlushTimeEndForBlockSize(i.blockSize, tickStart.Add(-i.bufferPast))
 	)
 
 	i.state.Lock()

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -482,7 +482,7 @@ func (i *nsIndex) Tick(c context.Cancellable, tickStart time.Time) (namespaceInd
 		}
 
 		// tick any blocks we're going to retain
-		blockTickResult, tickErr := block.Tick(c)
+		blockTickResult, tickErr := block.Tick(c, tickStart)
 		multiErr = multiErr.Add(tickErr)
 		result.NumSegments += blockTickResult.NumSegments
 		result.NumTotalDocs += blockTickResult.NumDocs

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -369,7 +369,7 @@ func (b *block) AddResults(
 	return multiErr.FinalError()
 }
 
-func (b *block) Tick(c context.Cancellable) (BlockTickResult, error) {
+func (b *block) Tick(c context.Cancellable, tickStart time.Time) (BlockTickResult, error) {
 	b.RLock()
 	defer b.RUnlock()
 	result := BlockTickResult{}

--- a/src/dbnode/storage/index/block_test.go
+++ b/src/dbnode/storage/index/block_test.go
@@ -915,7 +915,7 @@ func TestBlockTickSingleSegment(t *testing.T) {
 	b.activeSegment = seg1
 	seg1.EXPECT().Size().Return(int64(10))
 
-	result, err := blk.Tick(nil)
+	result, err := blk.Tick(nil, start)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), result.NumSegments)
 	require.Equal(t, int64(10), result.NumDocs)
@@ -943,7 +943,7 @@ func TestBlockTickMultipleSegment(t *testing.T) {
 		result.NewIndexBlock(start, []segment.Segment{seg2},
 			result.NewShardTimeRanges(start, start.Add(time.Hour), 1, 2, 3))))
 
-	result, err := blk.Tick(nil)
+	result, err := blk.Tick(nil, start)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), result.NumSegments)
 	require.Equal(t, int64(30), result.NumDocs)
@@ -966,7 +966,7 @@ func TestBlockTickAfterSeal(t *testing.T) {
 	b.activeSegment = seg1
 	seg1.EXPECT().Size().Return(int64(10))
 
-	result, err := blk.Tick(nil)
+	result, err := blk.Tick(nil, start)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), result.NumSegments)
 	require.Equal(t, int64(10), result.NumDocs)
@@ -982,7 +982,7 @@ func TestBlockTickAfterClose(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, blk.Close())
 
-	_, err = blk.Tick(nil)
+	_, err = blk.Tick(nil, start)
 	require.Error(t, err)
 }
 

--- a/src/dbnode/storage/index/index_mock.go
+++ b/src/dbnode/storage/index/index_mock.go
@@ -264,16 +264,16 @@ func (mr *MockBlockMockRecorder) StartTime() *gomock.Call {
 }
 
 // Tick mocks base method
-func (m *MockBlock) Tick(arg0 context.Cancellable) (BlockTickResult, error) {
-	ret := m.ctrl.Call(m, "Tick", arg0)
+func (m *MockBlock) Tick(arg0 context.Cancellable, arg1 time.Time) (BlockTickResult, error) {
+	ret := m.ctrl.Call(m, "Tick", arg0, arg1)
 	ret0, _ := ret[0].(BlockTickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MockBlockMockRecorder) Tick(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockBlock)(nil).Tick), arg0)
+func (mr *MockBlockMockRecorder) Tick(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockBlock)(nil).Tick), arg0, arg1)
 }
 
 // WriteBatch mocks base method

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -149,7 +149,7 @@ type Block interface {
 	AddResults(results result.IndexBlock) error
 
 	// Tick does internal house keeping operations.
-	Tick(c context.Cancellable) (BlockTickResult, error)
+	Tick(c context.Cancellable, tickStart time.Time) (BlockTickResult, error)
 
 	// Seal prevents the block from taking any more writes, but, it still permits
 	// addition of segments via Bootstrap().

--- a/src/dbnode/storage/index_block_test.go
+++ b/src/dbnode/storage/index_block_test.go
@@ -346,7 +346,7 @@ func TestNamespaceIndexTickExpire(t *testing.T) {
 
 	c := context.NewCancellable()
 	b0.EXPECT().Close().Return(nil)
-	result, err := idx.Tick(c)
+	result, err := idx.Tick(c, now)
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocksEvicted: 1,
@@ -387,7 +387,7 @@ func TestNamespaceIndexTick(t *testing.T) {
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)
-	result, err := idx.Tick(c)
+	result, err := idx.Tick(c, now)
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocks:    1,
@@ -405,7 +405,7 @@ func TestNamespaceIndexTick(t *testing.T) {
 	}, nil)
 	b0.EXPECT().IsSealed().Return(false)
 	b0.EXPECT().Seal().Return(nil)
-	result, err = idx.Tick(c)
+	result, err = idx.Tick(c, now)
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocks:       1,
@@ -419,7 +419,7 @@ func TestNamespaceIndexTick(t *testing.T) {
 		NumSegments: 2,
 	}, nil)
 	b0.EXPECT().IsSealed().Return(true)
-	result, err = idx.Tick(c)
+	result, err = idx.Tick(c, nowFn())
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocks:    1,

--- a/src/dbnode/storage/index_block_test.go
+++ b/src/dbnode/storage/index_block_test.go
@@ -346,7 +346,7 @@ func TestNamespaceIndexTickExpire(t *testing.T) {
 
 	c := context.NewCancellable()
 	b0.EXPECT().Close().Return(nil)
-	result, err := idx.Tick(c, now)
+	result, err := idx.Tick(c, nowFn())
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocksEvicted: 1,
@@ -383,11 +383,11 @@ func TestNamespaceIndexTick(t *testing.T) {
 	require.NoError(t, err)
 
 	c := context.NewCancellable()
-	b0.EXPECT().Tick(c).Return(index.BlockTickResult{
+	b0.EXPECT().Tick(c, nowFn()).Return(index.BlockTickResult{
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)
-	result, err := idx.Tick(c, now)
+	result, err := idx.Tick(c, nowFn())
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocks:    1,
@@ -399,13 +399,13 @@ func TestNamespaceIndexTick(t *testing.T) {
 	now = now.Add(2 * blockSize)
 	nowLock.Unlock()
 
-	b0.EXPECT().Tick(c).Return(index.BlockTickResult{
+	b0.EXPECT().Tick(c, nowFn()).Return(index.BlockTickResult{
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)
 	b0.EXPECT().IsSealed().Return(false)
 	b0.EXPECT().Seal().Return(nil)
-	result, err = idx.Tick(c, now)
+	result, err = idx.Tick(c, nowFn())
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{
 		NumBlocks:       1,
@@ -414,7 +414,7 @@ func TestNamespaceIndexTick(t *testing.T) {
 		NumTotalDocs:    10,
 	}, result)
 
-	b0.EXPECT().Tick(c).Return(index.BlockTickResult{
+	b0.EXPECT().Tick(c, nowFn()).Return(index.BlockTickResult{
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -452,7 +452,7 @@ func (n *dbNamespace) closeShards(shards []databaseShard, blockUntilClosed bool)
 	}
 }
 
-func (n *dbNamespace) Tick(c context.Cancellable) error {
+func (n *dbNamespace) Tick(c context.Cancellable, tickStart time.Time) error {
 	// Allow the reader cache to tick
 	n.namespaceReaderMgr.tick()
 
@@ -479,7 +479,7 @@ func (n *dbNamespace) Tick(c context.Cancellable) error {
 				return
 			}
 
-			shardResult, err := shard.Tick(c)
+			shardResult, err := shard.Tick(c, tickStart)
 
 			l.Lock()
 			r = r.merge(shardResult)
@@ -496,7 +496,7 @@ func (n *dbNamespace) Tick(c context.Cancellable) error {
 		err              error
 	)
 	if idx := n.reverseIndex; idx != nil {
-		indexTickResults, err = idx.Tick(c)
+		indexTickResults, err = idx.Tick(c, tickStart)
 		if err != nil {
 			multiErr = multiErr.Add(err)
 		}

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -100,12 +100,12 @@ func TestNamespaceTick(t *testing.T) {
 	defer closer()
 	for i := range testShardIDs {
 		shard := NewMockdatabaseShard(ctrl)
-		shard.EXPECT().Tick(context.NewNoOpCanncellable()).Return(tickResult{}, nil)
+		shard.EXPECT().Tick(context.NewNoOpCanncellable(), gomock.Any()).Return(tickResult{}, nil)
 		ns.shards[testShardIDs[i].ID()] = shard
 	}
 
 	// Only asserting the expected methods are called
-	require.NoError(t, ns.Tick(context.NewNoOpCanncellable()))
+	require.NoError(t, ns.Tick(context.NewNoOpCanncellable(), time.Time{}))
 }
 
 func TestNamespaceTickError(t *testing.T) {
@@ -119,14 +119,14 @@ func TestNamespaceTickError(t *testing.T) {
 	for i := range testShardIDs {
 		shard := NewMockdatabaseShard(ctrl)
 		if i == 0 {
-			shard.EXPECT().Tick(context.NewNoOpCanncellable()).Return(tickResult{}, fakeErr)
+			shard.EXPECT().Tick(context.NewNoOpCanncellable(), gomock.Any()).Return(tickResult{}, fakeErr)
 		} else {
-			shard.EXPECT().Tick(context.NewNoOpCanncellable()).Return(tickResult{}, nil)
+			shard.EXPECT().Tick(context.NewNoOpCanncellable(), gomock.Any()).Return(tickResult{}, nil)
 		}
 		ns.shards[testShardIDs[i].ID()] = shard
 	}
 
-	err := ns.Tick(context.NewNoOpCanncellable())
+	err := ns.Tick(context.NewNoOpCanncellable(), time.Time{})
 	require.NotNil(t, err)
 	require.Equal(t, fakeErr.Error(), err.Error())
 }
@@ -1136,8 +1136,8 @@ func TestNamespaceTicksIndex(t *testing.T) {
 	defer closer()
 
 	ctx := context.NewCancellable()
-	idx.EXPECT().Tick(ctx).Return(namespaceIndexTickResult{}, nil)
-	err := ns.Tick(ctx)
+	idx.EXPECT().Tick(ctx, gomock.Any()).Return(namespaceIndexTickResult{}, nil)
+	err := ns.Tick(ctx, time.Time{})
 	require.NoError(t, err)
 }
 

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -105,7 +105,7 @@ func TestNamespaceTick(t *testing.T) {
 	}
 
 	// Only asserting the expected methods are called
-	require.NoError(t, ns.Tick(context.NewNoOpCanncellable(), time.Time{}))
+	require.NoError(t, ns.Tick(context.NewNoOpCanncellable(), time.Now()))
 }
 
 func TestNamespaceTickError(t *testing.T) {
@@ -126,7 +126,7 @@ func TestNamespaceTickError(t *testing.T) {
 		ns.shards[testShardIDs[i].ID()] = shard
 	}
 
-	err := ns.Tick(context.NewNoOpCanncellable(), time.Time{})
+	err := ns.Tick(context.NewNoOpCanncellable(), time.Now())
 	require.NotNil(t, err)
 	require.Equal(t, fakeErr.Error(), err.Error())
 }
@@ -1137,7 +1137,7 @@ func TestNamespaceTicksIndex(t *testing.T) {
 
 	ctx := context.NewCancellable()
 	idx.EXPECT().Tick(ctx, gomock.Any()).Return(namespaceIndexTickResult{}, nil)
-	err := ns.Tick(ctx, time.Time{})
+	err := ns.Tick(ctx, time.Now())
 	require.NoError(t, err)
 }
 

--- a/src/dbnode/storage/shard_foreachentry_prop_test.go
+++ b/src/dbnode/storage/shard_foreachentry_prop_test.go
@@ -123,7 +123,7 @@ func testShardConcurrentForEachTick(
 
 	go func() {
 		<-barrier
-		shard.Tick(context.NewNoOpCanncellable(), time.Time{})
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		wg.Done()
 	}()
 

--- a/src/dbnode/storage/shard_foreachentry_prop_test.go
+++ b/src/dbnode/storage/shard_foreachentry_prop_test.go
@@ -123,7 +123,7 @@ func testShardConcurrentForEachTick(
 
 	go func() {
 		<-barrier
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Time{})
 		wg.Done()
 	}()
 

--- a/src/dbnode/storage/shard_race_prop_test.go
+++ b/src/dbnode/storage/shard_race_prop_test.go
@@ -78,7 +78,7 @@ func testShardTickReadFnRace(t *testing.T, ids []ident.ID, tickBatchSize int, fn
 
 	wg.Add(2)
 	go func() {
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		wg.Done()
 	}()
 
@@ -175,7 +175,7 @@ func TestShardTickWriteRace(t *testing.T) {
 
 	go func() {
 		<-barrier
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		wg.Done()
 	}()
 

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -458,7 +458,7 @@ func TestShardTick(t *testing.T) {
 	shard.Write(ctx, ident.StringID("bar"), nowFn(), 2.0, xtime.Second, nil)
 	shard.Write(ctx, ident.StringID("baz"), nowFn(), 3.0, xtime.Second, nil)
 
-	r, err := shard.Tick(context.NewNoOpCanncellable(), now)
+	r, err := shard.Tick(context.NewNoOpCanncellable(), nowFn())
 	require.NoError(t, err)
 	require.Equal(t, 3, r.activeSeries)
 	require.Equal(t, 0, r.expiredSeries)

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -458,7 +458,7 @@ func TestShardTick(t *testing.T) {
 	shard.Write(ctx, ident.StringID("bar"), nowFn(), 2.0, xtime.Second, nil)
 	shard.Write(ctx, ident.StringID("baz"), nowFn(), 3.0, xtime.Second, nil)
 
-	r, err := shard.Tick(context.NewNoOpCanncellable())
+	r, err := shard.Tick(context.NewNoOpCanncellable(), now)
 	require.NoError(t, err)
 	require.Equal(t, 3, r.activeSeries)
 	require.Equal(t, 0, r.expiredSeries)
@@ -542,7 +542,7 @@ func TestShardWriteAsync(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	r, err := shard.Tick(context.NewNoOpCanncellable())
+	r, err := shard.Tick(context.NewNoOpCanncellable(), nowFn())
 	require.NoError(t, err)
 	require.Equal(t, 3, r.activeSeries)
 	require.Equal(t, 0, r.expiredSeries)
@@ -565,12 +565,12 @@ func TestShardTickRace(t *testing.T) {
 
 	wg.Add(2)
 	go func() {
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		wg.Done()
 	}()
 
 	go func() {
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		wg.Done()
 	}()
 
@@ -588,7 +588,7 @@ func TestShardTickCleanupSmallBatchSize(t *testing.T) {
 	opts := testDatabaseOptions()
 	shard := testDatabaseShard(t, opts)
 	addTestSeries(shard, ident.StringID("foo"))
-	shard.Tick(context.NewNoOpCanncellable())
+	shard.Tick(context.NewNoOpCanncellable(), time.Now())
 	require.Equal(t, 0, shard.lookup.Len())
 }
 
@@ -620,14 +620,14 @@ func TestShardReturnsErrorForConcurrentTicks(t *testing.T) {
 	}).Return(series.TickResult{}, nil)
 
 	go func() {
-		_, err := shard.Tick(context.NewNoOpCanncellable())
+		_, err := shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		require.NoError(t, err)
 		closeWg.Done()
 	}()
 
 	go func() {
 		tick1Wg.Wait()
-		_, err := shard.Tick(context.NewNoOpCanncellable())
+		_, err := shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		require.Error(t, err)
 		tick2Wg.Done()
 		closeWg.Done()
@@ -691,7 +691,7 @@ func TestShardTicksStopWhenClosing(t *testing.T) {
 
 	closeWg.Add(2)
 	go func() {
-		shard.Tick(context.NewNoOpCanncellable())
+		shard.Tick(context.NewNoOpCanncellable(), time.Now())
 		closeWg.Done()
 	}()
 
@@ -712,7 +712,7 @@ func TestPurgeExpiredSeriesEmptySeries(t *testing.T) {
 
 	addTestSeries(shard, ident.StringID("foo"))
 
-	shard.Tick(context.NewNoOpCanncellable())
+	shard.Tick(context.NewNoOpCanncellable(), time.Now())
 
 	shard.RLock()
 	require.Equal(t, 0, shard.lookup.Len())

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -48,6 +48,7 @@ import (
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+	sync0 "github.com/m3db/m3x/sync"
 	time0 "github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"
@@ -832,15 +833,15 @@ func (mr *MockdatabaseNamespaceMockRecorder) GetIndex() *gomock.Call {
 }
 
 // Tick mocks base method
-func (m *MockdatabaseNamespace) Tick(c context.Cancellable) error {
-	ret := m.ctrl.Call(m, "Tick", c)
+func (m *MockdatabaseNamespace) Tick(c context.Cancellable, timeBeforeTickStart time.Time) error {
+	ret := m.ctrl.Call(m, "Tick", c, timeBeforeTickStart)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MockdatabaseNamespaceMockRecorder) Tick(c interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseNamespace)(nil).Tick), c)
+func (mr *MockdatabaseNamespaceMockRecorder) Tick(c, timeBeforeTickStart interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseNamespace)(nil).Tick), c, timeBeforeTickStart)
 }
 
 // Write mocks base method
@@ -1196,16 +1197,16 @@ func (mr *MockdatabaseShardMockRecorder) Close() *gomock.Call {
 }
 
 // Tick mocks base method
-func (m *MockdatabaseShard) Tick(c context.Cancellable) (tickResult, error) {
-	ret := m.ctrl.Call(m, "Tick", c)
+func (m *MockdatabaseShard) Tick(c context.Cancellable, tickStart time.Time) (tickResult, error) {
+	ret := m.ctrl.Call(m, "Tick", c, tickStart)
 	ret0, _ := ret[0].(tickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MockdatabaseShardMockRecorder) Tick(c interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseShard)(nil).Tick), c)
+func (mr *MockdatabaseShardMockRecorder) Tick(c, tickStart interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseShard)(nil).Tick), c, tickStart)
 }
 
 // Write mocks base method
@@ -1469,16 +1470,16 @@ func (mr *MocknamespaceIndexMockRecorder) CleanupExpiredFileSets(t interface{}) 
 }
 
 // Tick mocks base method
-func (m *MocknamespaceIndex) Tick(c context.Cancellable) (namespaceIndexTickResult, error) {
-	ret := m.ctrl.Call(m, "Tick", c)
+func (m *MocknamespaceIndex) Tick(c context.Cancellable, tickStart time.Time) (namespaceIndexTickResult, error) {
+	ret := m.ctrl.Call(m, "Tick", c, tickStart)
 	ret0, _ := ret[0].(namespaceIndexTickResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MocknamespaceIndexMockRecorder) Tick(c interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MocknamespaceIndex)(nil).Tick), c)
+func (mr *MocknamespaceIndexMockRecorder) Tick(c, tickStart interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MocknamespaceIndex)(nil).Tick), c, tickStart)
 }
 
 // Flush mocks base method
@@ -1954,15 +1955,15 @@ func (m *MockdatabaseTickManager) EXPECT() *MockdatabaseTickManagerMockRecorder 
 }
 
 // Tick mocks base method
-func (m *MockdatabaseTickManager) Tick(forceType forceType) error {
-	ret := m.ctrl.Call(m, "Tick", forceType)
+func (m *MockdatabaseTickManager) Tick(forceType forceType, tickStart time.Time) error {
+	ret := m.ctrl.Call(m, "Tick", forceType, tickStart)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MockdatabaseTickManagerMockRecorder) Tick(forceType interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseTickManager)(nil).Tick), forceType)
+func (mr *MockdatabaseTickManagerMockRecorder) Tick(forceType, tickStart interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseTickManager)(nil).Tick), forceType, tickStart)
 }
 
 // MockdatabaseMediator is a mock of databaseMediator interface
@@ -2890,4 +2891,28 @@ func (m *MockOptions) FetchBlocksMetadataResultsPool() block.FetchBlocksMetadata
 // FetchBlocksMetadataResultsPool indicates an expected call of FetchBlocksMetadataResultsPool
 func (mr *MockOptionsMockRecorder) FetchBlocksMetadataResultsPool() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBlocksMetadataResultsPool", reflect.TypeOf((*MockOptions)(nil).FetchBlocksMetadataResultsPool))
+}
+
+// SetQueryIDsWorkerPool mocks base method
+func (m *MockOptions) SetQueryIDsWorkerPool(value sync0.WorkerPool) Options {
+	ret := m.ctrl.Call(m, "SetQueryIDsWorkerPool", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetQueryIDsWorkerPool indicates an expected call of SetQueryIDsWorkerPool
+func (mr *MockOptionsMockRecorder) SetQueryIDsWorkerPool(value interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueryIDsWorkerPool", reflect.TypeOf((*MockOptions)(nil).SetQueryIDsWorkerPool), value)
+}
+
+// QueryIDsWorkerPool mocks base method
+func (m *MockOptions) QueryIDsWorkerPool() sync0.WorkerPool {
+	ret := m.ctrl.Call(m, "QueryIDsWorkerPool")
+	ret0, _ := ret[0].(sync0.WorkerPool)
+	return ret0
+}
+
+// QueryIDsWorkerPool indicates an expected call of QueryIDsWorkerPool
+func (mr *MockOptionsMockRecorder) QueryIDsWorkerPool() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryIDsWorkerPool", reflect.TypeOf((*MockOptions)(nil).QueryIDsWorkerPool))
 }

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -833,15 +833,15 @@ func (mr *MockdatabaseNamespaceMockRecorder) GetIndex() *gomock.Call {
 }
 
 // Tick mocks base method
-func (m *MockdatabaseNamespace) Tick(c context.Cancellable, timeBeforeTickStart time.Time) error {
-	ret := m.ctrl.Call(m, "Tick", c, timeBeforeTickStart)
+func (m *MockdatabaseNamespace) Tick(c context.Cancellable, tickStart time.Time) error {
+	ret := m.ctrl.Call(m, "Tick", c, tickStart)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Tick indicates an expected call of Tick
-func (mr *MockdatabaseNamespaceMockRecorder) Tick(c, timeBeforeTickStart interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseNamespace)(nil).Tick), c, timeBeforeTickStart)
+func (mr *MockdatabaseNamespaceMockRecorder) Tick(c, tickStart interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseNamespace)(nil).Tick), c, tickStart)
 }
 
 // Write mocks base method

--- a/src/dbnode/storage/tick.go
+++ b/src/dbnode/storage/tick.go
@@ -123,7 +123,7 @@ func (mgr *tickManager) SetRuntimeOptions(opts runtime.Options) {
 	})
 }
 
-func (mgr *tickManager) Tick(forceType forceType) error {
+func (mgr *tickManager) Tick(forceType forceType, tickStart time.Time) error {
 	if forceType == force {
 		acquired := false
 		waiter := time.NewTicker(tokenCheckInterval)
@@ -165,7 +165,7 @@ func (mgr *tickManager) Tick(forceType forceType) error {
 		multiErr xerrors.MultiError
 	)
 	for _, n := range namespaces {
-		multiErr = multiErr.Add(n.Tick(mgr.c))
+		multiErr = multiErr.Add(n.Tick(mgr.c, tickStart))
 	}
 
 	// NB(r): Always sleep for some constant period since ticking

--- a/src/dbnode/storage/tick_test.go
+++ b/src/dbnode/storage/tick_test.go
@@ -163,7 +163,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 			ch1 <- struct{}{}
 			<-ch2
 		}),
-		namespace.EXPECT().Tick(c, time.Now()),
+		namespace.EXPECT().Tick(c, gomock.Any()),
 	)
 	db := newMockdatabase(ctrl, namespace)
 

--- a/src/dbnode/storage/tick_test.go
+++ b/src/dbnode/storage/tick_test.go
@@ -40,14 +40,14 @@ func TestTickManagerTickNormalFlow(t *testing.T) {
 	c := context.NewCancellable()
 
 	namespace := NewMockdatabaseNamespace(ctrl)
-	namespace.EXPECT().Tick(c)
+	namespace.EXPECT().Tick(c, gomock.Any())
 	db := newMockdatabase(ctrl, namespace)
 
 	tm := newTickManager(db, opts).(*tickManager)
 	tm.c = c
 	tm.sleepFn = func(time.Duration) {}
 
-	require.NoError(t, tm.Tick(noForce))
+	require.NoError(t, tm.Tick(noForce, time.Time{}))
 	require.Equal(t, 1, len(tm.tokenCh))
 }
 
@@ -62,7 +62,7 @@ func TestTickManagerTickCancelled(t *testing.T) {
 	c := context.NewCancellable()
 
 	namespace := NewMockdatabaseNamespace(ctrl)
-	namespace.EXPECT().Tick(c).Do(func(context.Cancellable) {
+	namespace.EXPECT().Tick(c, gomock.Any()).Do(func(context.Cancellable, time.Time) {
 		ch1 <- struct{}{}
 		<-ch2
 	})
@@ -76,7 +76,7 @@ func TestTickManagerTickCancelled(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.Equal(t, errTickCancelled, tm.Tick(noForce))
+		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Time{}))
 		require.Equal(t, 1, len(tm.tokenCh))
 	}()
 
@@ -96,14 +96,14 @@ func TestTickManagerTickErrorFlow(t *testing.T) {
 
 	fakeErr := errors.New("fake error")
 	namespace := NewMockdatabaseNamespace(ctrl)
-	namespace.EXPECT().Tick(c).Return(fakeErr)
+	namespace.EXPECT().Tick(c, gomock.Any()).Return(fakeErr)
 	db := newMockdatabase(ctrl, namespace)
 
 	tm := newTickManager(db, opts).(*tickManager)
 	tm.c = c
 	tm.sleepFn = func(time.Duration) {}
 
-	err := tm.Tick(noForce)
+	err := tm.Tick(noForce, time.Time{})
 	require.Error(t, err)
 	require.Equal(t, fakeErr.Error(), err.Error())
 	require.Equal(t, 1, len(tm.tokenCh))
@@ -120,7 +120,7 @@ func TestTickManagerNonForcedTickDuringOngoingTick(t *testing.T) {
 	c := context.NewCancellable()
 
 	namespace := NewMockdatabaseNamespace(ctrl)
-	namespace.EXPECT().Tick(c).Do(func(context.Cancellable) {
+	namespace.EXPECT().Tick(c, gomock.Any()).Do(func(context.Cancellable, time.Time) {
 		ch1 <- struct{}{}
 		<-ch2
 	})
@@ -134,12 +134,12 @@ func TestTickManagerNonForcedTickDuringOngoingTick(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.NoError(t, tm.Tick(noForce))
+		require.NoError(t, tm.Tick(noForce, time.Time{}))
 	}()
 
 	// Wait for tick to start
 	<-ch1
-	require.Equal(t, errTickInProgress, tm.Tick(noForce))
+	require.Equal(t, errTickInProgress, tm.Tick(noForce, time.Time{}))
 
 	ch2 <- struct{}{}
 	wg.Wait()
@@ -159,11 +159,11 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 
 	namespace := NewMockdatabaseNamespace(ctrl)
 	gomock.InOrder(
-		namespace.EXPECT().Tick(c).Do(func(context.Cancellable) {
+		namespace.EXPECT().Tick(c, gomock.Any()).Do(func(context.Cancellable, time.Time) {
 			ch1 <- struct{}{}
 			<-ch2
 		}),
-		namespace.EXPECT().Tick(c),
+		namespace.EXPECT().Tick(c, time.Time{}),
 	)
 	db := newMockdatabase(ctrl, namespace)
 
@@ -175,7 +175,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.Equal(t, errTickCancelled, tm.Tick(noForce))
+		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Time{}))
 	}()
 
 	go func() {
@@ -183,7 +183,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 
 		// Wait for tick to start
 		<-ch1
-		require.NoError(t, tm.Tick(force))
+		require.NoError(t, tm.Tick(force, time.Time{}))
 	}()
 
 	go func() {

--- a/src/dbnode/storage/tick_test.go
+++ b/src/dbnode/storage/tick_test.go
@@ -47,7 +47,7 @@ func TestTickManagerTickNormalFlow(t *testing.T) {
 	tm.c = c
 	tm.sleepFn = func(time.Duration) {}
 
-	require.NoError(t, tm.Tick(noForce, time.Time{}))
+	require.NoError(t, tm.Tick(noForce, time.Now()))
 	require.Equal(t, 1, len(tm.tokenCh))
 }
 
@@ -76,7 +76,7 @@ func TestTickManagerTickCancelled(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Time{}))
+		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Now()))
 		require.Equal(t, 1, len(tm.tokenCh))
 	}()
 
@@ -103,7 +103,7 @@ func TestTickManagerTickErrorFlow(t *testing.T) {
 	tm.c = c
 	tm.sleepFn = func(time.Duration) {}
 
-	err := tm.Tick(noForce, time.Time{})
+	err := tm.Tick(noForce, time.Now())
 	require.Error(t, err)
 	require.Equal(t, fakeErr.Error(), err.Error())
 	require.Equal(t, 1, len(tm.tokenCh))
@@ -134,12 +134,12 @@ func TestTickManagerNonForcedTickDuringOngoingTick(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.NoError(t, tm.Tick(noForce, time.Time{}))
+		require.NoError(t, tm.Tick(noForce, time.Now()))
 	}()
 
 	// Wait for tick to start
 	<-ch1
-	require.Equal(t, errTickInProgress, tm.Tick(noForce, time.Time{}))
+	require.Equal(t, errTickInProgress, tm.Tick(noForce, time.Now()))
 
 	ch2 <- struct{}{}
 	wg.Wait()
@@ -163,7 +163,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 			ch1 <- struct{}{}
 			<-ch2
 		}),
-		namespace.EXPECT().Tick(c, time.Time{}),
+		namespace.EXPECT().Tick(c, time.Now()),
 	)
 	db := newMockdatabase(ctrl, namespace)
 
@@ -175,7 +175,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Time{}))
+		require.Equal(t, errTickCancelled, tm.Tick(noForce, time.Now()))
 	}()
 
 	go func() {
@@ -183,7 +183,7 @@ func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
 
 		// Wait for tick to start
 		<-ch1
-		require.NoError(t, tm.Tick(force, time.Time{}))
+		require.NoError(t, tm.Tick(force, time.Now()))
 	}()
 
 	go func() {

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -224,7 +224,7 @@ type databaseNamespace interface {
 	GetIndex() (namespaceIndex, error)
 
 	// Tick performs any regular maintenance operations
-	Tick(c context.Cancellable) error
+	Tick(c context.Cancellable, timeBeforeTickStart time.Time) error
 
 	// Write writes a data point
 	Write(
@@ -349,7 +349,7 @@ type databaseShard interface {
 	Close() error
 
 	// Tick performs any updates to ensure series drain their buffers and blocks are flushed, etc
-	Tick(c context.Cancellable) (tickResult, error)
+	Tick(c context.Cancellable, tickStart time.Time) (tickResult, error)
 
 	Write(
 		ctx context.Context,
@@ -467,7 +467,7 @@ type namespaceIndex interface {
 
 	// Tick performs internal house keeping in the index, including block rotation,
 	// data eviction, and so on.
-	Tick(c context.Cancellable) (namespaceIndexTickResult, error)
+	Tick(c context.Cancellable, tickStart time.Time) (namespaceIndexTickResult, error)
 
 	// Flush performs any flushes that the index has outstanding using
 	// the owned shards of the database.
@@ -601,7 +601,7 @@ type databaseTickManager interface {
 	// Tick performs maintenance operations, restarting the current
 	// tick if force is true. It returns nil if a new tick has
 	// completed successfully, and an error otherwise.
-	Tick(forceType forceType) error
+	Tick(forceType forceType, tickStart time.Time) error
 }
 
 // databaseMediator mediates actions among various database managers

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -224,7 +224,7 @@ type databaseNamespace interface {
 	GetIndex() (namespaceIndex, error)
 
 	// Tick performs any regular maintenance operations
-	Tick(c context.Cancellable, timeBeforeTickStart time.Time) error
+	Tick(c context.Cancellable, tickStart time.Time) error
 
 	// Write writes a data point
 	Write(


### PR DESCRIPTION
There is currently a bug in the interaction between the Tick logic and Flush logic. Sequence of events:

1.  Tick() runs, and sometime during the tick the current time reaches the threshold such that calls to shard.removeAnyFlushStatesTooEarly() can remove the flush state for the oldest block.
2. After tick completes, Flush() runs, but its using the pre-stick timestamp in which the oldest block is still valid. It will detect that their is no flush state for the oldest block for some of the shards and attempt to flush it.
3. Shard tries to flush oldest block (which it doesn't have any data for anyways) and fails because the file still exists on disk, but hasn't been cleaned up yet.

To address the issue, I've flowed the tickStart timestamp through the tick logic as well. I additionally flowed it into some tick functions where its not needed, just so that if we ever change those functions to require a timestamp its already there and developers are more likely to use that than a (possibly buggy) usage of time.Now()
