### PR TITLE
Add metric for blocks pending merge

### DIFF
--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -245,6 +245,13 @@ func (b *dbBlock) Stream(blocker context.Context) (xio.BlockReader, error) {
 	return b.forceMergeWithLock(blocker, stream)
 }
 
+func (b *dbBlock) HasMergeTarget() bool {
+	b.RLock()
+	hasMergeTarget := b.mergeTarget != nil
+	b.RUnlock()
+	return hasMergeTarget
+}
+
 func (b *dbBlock) IsRetrieved() bool {
 	b.RLock()
 	retrieved := b.retriever == nil

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -371,6 +371,18 @@ func (mr *MockDatabaseBlockMockRecorder) Merge(other interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockDatabaseBlock)(nil).Merge), other)
 }
 
+// HasMergeTarget mocks base method
+func (m *MockDatabaseBlock) HasMergeTarget() bool {
+	ret := m.ctrl.Call(m, "HasMergeTarget")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasMergeTarget indicates an expected call of HasMergeTarget
+func (mr *MockDatabaseBlockMockRecorder) HasMergeTarget() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasMergeTarget", reflect.TypeOf((*MockDatabaseBlock)(nil).HasMergeTarget))
+}
+
 // IsRetrieved mocks base method
 func (m *MockDatabaseBlock) IsRetrieved() bool {
 	ret := m.ctrl.Call(m, "IsRetrieved")

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -164,6 +164,10 @@ type DatabaseBlock interface {
 	// rather than merging three blocks together.
 	Merge(other DatabaseBlock) error
 
+	// HasMergeTarget returns whether the block requires multiple blocks to be
+	// merged during Stream().
+	HasMergeTarget() bool
+
 	// IsRetrieved returns whether the block is already retrieved. Only
 	// meaningful in the context of the CacheAllMetadata series caching policy.
 	IsRetrieved() bool

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -171,6 +171,7 @@ type databaseNamespaceTickMetrics struct {
 	openBlocks             tally.Gauge
 	wiredBlocks            tally.Gauge
 	unwiredBlocks          tally.Gauge
+	pendingMergeBlocks     tally.Gauge
 	madeUnwiredBlocks      tally.Counter
 	madeExpiredBlocks      tally.Counter
 	mergedOutOfOrderBlocks tally.Counter
@@ -234,6 +235,7 @@ func newDatabaseNamespaceMetrics(scope tally.Scope, samplingRate float64) databa
 			openBlocks:             tickScope.Gauge("open-blocks"),
 			wiredBlocks:            tickScope.Gauge("wired-blocks"),
 			unwiredBlocks:          tickScope.Gauge("unwired-blocks"),
+			pendingMergeBlocks:     tickScope.Gauge("pending-merge-blocks"),
 			madeUnwiredBlocks:      tickScope.Counter("made-unwired-blocks"),
 			madeExpiredBlocks:      tickScope.Counter("made-expired-blocks"),
 			mergedOutOfOrderBlocks: tickScope.Counter("merged-out-of-order-blocks"),
@@ -524,6 +526,7 @@ func (n *dbNamespace) Tick(c context.Cancellable, tickStart time.Time) error {
 	n.metrics.tick.openBlocks.Update(float64(r.openBlocks))
 	n.metrics.tick.wiredBlocks.Update(float64(r.wiredBlocks))
 	n.metrics.tick.unwiredBlocks.Update(float64(r.unwiredBlocks))
+	n.metrics.tick.pendingMergeBlocks.Update(float64(r.pendingMergeBlocks))
 	n.metrics.tick.madeExpiredBlocks.Inc(int64(r.madeExpiredBlocks))
 	n.metrics.tick.madeUnwiredBlocks.Inc(int64(r.madeUnwiredBlocks))
 	n.metrics.tick.mergedOutOfOrderBlocks.Inc(int64(r.mergedOutOfOrderBlocks))

--- a/src/dbnode/storage/result.go
+++ b/src/dbnode/storage/result.go
@@ -27,6 +27,7 @@ type tickResult struct {
 	openBlocks             int
 	wiredBlocks            int
 	unwiredBlocks          int
+	pendingMergeBlocks     int
 	madeExpiredBlocks      int
 	madeUnwiredBlocks      int
 	mergedOutOfOrderBlocks int
@@ -40,6 +41,7 @@ func (r tickResult) merge(other tickResult) tickResult {
 		activeBlocks:           r.activeBlocks + other.activeBlocks,
 		openBlocks:             r.openBlocks + other.openBlocks,
 		wiredBlocks:            r.wiredBlocks + other.wiredBlocks,
+		pendingMergeBlocks:     r.pendingMergeBlocks + other.pendingMergeBlocks,
 		unwiredBlocks:          r.unwiredBlocks + other.unwiredBlocks,
 		madeExpiredBlocks:      r.madeExpiredBlocks + other.madeExpiredBlocks,
 		madeUnwiredBlocks:      r.madeUnwiredBlocks + other.madeUnwiredBlocks,

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -265,6 +265,9 @@ func (s *dbSeries) updateBlocksWithLock() (updateBlocksResult, error) {
 			result.UnwiredBlocks++
 		} else {
 			result.WiredBlocks++
+			if currBlock.HasMergeTarget() {
+				result.PendingMergeBlocks++
+			}
 		}
 	}
 

--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -142,6 +142,8 @@ type TickStatus struct {
 	WiredBlocks int
 	// UnwiredBlocks is the number of blocks unwired (data kept on disk)
 	UnwiredBlocks int
+	// PendingMergeBlocks is the number of blocks pending merges
+	PendingMergeBlocks int
 }
 
 // TickResult is a set of results from a tick

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -638,6 +638,7 @@ func (s *dbShard) tickAndExpire(
 			r.openBlocks += result.OpenBlocks
 			r.wiredBlocks += result.WiredBlocks
 			r.unwiredBlocks += result.UnwiredBlocks
+			r.pendingMergeBlocks += result.PendingMergeBlocks
 			r.madeExpiredBlocks += result.MadeExpiredBlocks
 			r.madeUnwiredBlocks += result.MadeUnwiredBlocks
 			r.mergedOutOfOrderBlocks += result.MergedOutOfOrderBlocks


### PR DESCRIPTION
This would have been useful to diagnose an issue with a double free in blocks pending merge. 