### PR TITLE
Add a target which grabs the .ci submodule in case it wasn't retrieved with git clone --recursive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+# Grab necessary submodules, in case the repo was cloned without --recursive
+$(SELF_DIR)/.ci/common.mk:
+	git submodule update --init --recursive
+
 include $(SELF_DIR)/.ci/common.mk
 
 SHELL=/bin/bash -o pipefail


### PR DESCRIPTION
This is a small convenience Makefile change which adds a target to grabs all needed git submodules if they haven't already been downloaded (h/t to an approach I've seen elsewhere at Uber). Since we have an include on `$(SELF_DIR)/.ci/common.mk` , it should end up running the first time `make` does, and not after. 

I've tested this out against a fresh clone--`make m3dbnode` works with it, and `make ci-test-unit` mostly works with it (looks like there may be unrelated failures).