### PR TITLE
Fix meta linter warnings

### DIFF
--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -336,12 +336,9 @@ func (o *options) Validate() error {
 	); err != nil {
 		return err
 	}
-	if err := topology.ValidateConnectConsistencyLevel(
+	return topology.ValidateConnectConsistencyLevel(
 		o.clusterConnectConsistencyLevel,
-	); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 func (o *options) SetEncodingM3TSZ() Options {

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -157,11 +157,7 @@ func (r *blockRetriever) CacheShardIndices(shards []uint32) error {
 	if r.status != blockRetrieverOpen {
 		return errBlockRetrieverNotOpen
 	}
-
-	if err := r.seekerMgr.CacheShardIndices(shards); err != nil {
-		return err
-	}
-	return nil
+	return r.seekerMgr.CacheShardIndices(shards)
 }
 
 func (r *blockRetriever) fetchLoop(seekerMgr DataFileSetSeekerManager) {


### PR DESCRIPTION
Running `make` fails due to metalinter warnings 

```
src/dbnode/client/options.go:339:2:warning: redundant if ...; err != nil check, just return error instead. (golint)
src/dbnode/persist/fs/retriever.go:161:2:warning: redundant if ...; err != nil check, just return error instead. (golint)
```