### PR TITLE
Do not cap attempts to flush with retries, should always attempt to write out

### DIFF
--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -88,7 +88,6 @@ func init() {
 		SetSeriesCachePolicy(series.CacheAll).
 		SetPersistManager(pm).
 		SetRepairEnabled(false).
-		SetMaxFlushRetries(3).
 		SetCommitLogOptions(opts.CommitLogOptions().
 			SetRetentionPeriod(defaultTestCommitlogRetentionPeriod).
 			SetBlockSize(defaultTestCommitlogBlockSize))

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1002,19 +1002,14 @@ func (n *dbNamespace) needsFlushWithLock(alignedInclusiveStart time.Time, aligne
 
 	// NB(prateek): we do not check if any other flush is in progress in this method,
 	// instead relying on the databaseFlushManager to ensure atomicity of flushes.
-	maxRetries := n.opts.MaxFlushRetries()
+
 	// Check for not started or failed that might need a flush
 	for _, shard := range n.shards {
 		if shard == nil {
 			continue
 		}
 		for _, blockStart := range blockStarts {
-
-			state := shard.FlushState(blockStart)
-			if state.Status == fileOpNotStarted {
-				return true
-			}
-			if state.Status == fileOpFailed && state.NumFailures < maxRetries {
+			if shard.FlushState(blockStart).Status != fileOpSuccess {
 				return true
 			}
 		}

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -51,9 +51,6 @@ import (
 )
 
 const (
-	// defaultMaxFlushRetries is the default number of retries when flush fails
-	defaultMaxFlushRetries = 3
-
 	// defaultBytesPoolBucketCapacity is the default bytes buffer capacity for the default bytes pool bucket
 	defaultBytesPoolBucketCapacity = 256
 
@@ -129,7 +126,6 @@ type options struct {
 	newDecoderFn                   encoding.NewDecoderFn
 	bootstrapProcessProvider       bootstrap.ProcessProvider
 	persistManager                 persist.Manager
-	maxFlushRetries                int
 	minSnapshotInterval            time.Duration
 	blockRetrieverManager          block.DatabaseBlockRetrieverManager
 	poolOpts                       pool.ObjectPoolOptions
@@ -178,7 +174,6 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 		repairEnabled:            defaultRepairEnabled,
 		repairOpts:               repair.NewOptions(),
 		bootstrapProcessProvider: defaultBootstrapProcessProvider,
-		maxFlushRetries:          defaultMaxFlushRetries,
 		minSnapshotInterval:      defaultMinSnapshotInterval,
 		poolOpts:                 poolOpts,
 		contextPool: context.NewPool(context.NewOptions().
@@ -475,16 +470,6 @@ func (o *options) SetPersistManager(value persist.Manager) Options {
 
 func (o *options) PersistManager() persist.Manager {
 	return o.persistManager
-}
-
-func (o *options) SetMaxFlushRetries(value int) Options {
-	opts := *o
-	opts.maxFlushRetries = value
-	return &opts
-}
-
-func (o *options) MaxFlushRetries() int {
-	return o.maxFlushRetries
 }
 
 func (o *options) SetDatabaseBlockRetrieverManager(value block.DatabaseBlockRetrieverManager) Options {

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2546,18 +2546,6 @@ func (mr *MockOptionsMockRecorder) PersistManager() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistManager", reflect.TypeOf((*MockOptions)(nil).PersistManager))
 }
 
-// SetMaxFlushRetries mocks base method
-func (m *MockOptions) SetMaxFlushRetries(value int) Options {
-	ret := m.ctrl.Call(m, "SetMaxFlushRetries", value)
-	ret0, _ := ret[0].(Options)
-	return ret0
-}
-
-// SetMaxFlushRetries indicates an expected call of SetMaxFlushRetries
-func (mr *MockOptionsMockRecorder) SetMaxFlushRetries(value interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxFlushRetries", reflect.TypeOf((*MockOptions)(nil).SetMaxFlushRetries), value)
-}
-
 // SetMinimumSnapshotInterval mocks base method
 func (m *MockOptions) SetMinimumSnapshotInterval(value time.Duration) Options {
 	ret := m.ctrl.Call(m, "SetMinimumSnapshotInterval", value)

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2558,18 +2558,6 @@ func (mr *MockOptionsMockRecorder) SetMaxFlushRetries(value interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxFlushRetries", reflect.TypeOf((*MockOptions)(nil).SetMaxFlushRetries), value)
 }
 
-// MaxFlushRetries mocks base method
-func (m *MockOptions) MaxFlushRetries() int {
-	ret := m.ctrl.Call(m, "MaxFlushRetries")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// MaxFlushRetries indicates an expected call of MaxFlushRetries
-func (mr *MockOptionsMockRecorder) MaxFlushRetries() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxFlushRetries", reflect.TypeOf((*MockOptions)(nil).MaxFlushRetries))
-}
-
 // SetMinimumSnapshotInterval mocks base method
 func (m *MockOptions) SetMinimumSnapshotInterval(value time.Duration) Options {
 	ret := m.ctrl.Call(m, "SetMinimumSnapshotInterval", value)

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -748,12 +748,6 @@ type Options interface {
 	// PersistManager returns the persistence manager.
 	PersistManager() persist.Manager
 
-	// SetMaxFlushRetries sets the maximum number of retries when data flushing fails.
-	SetMaxFlushRetries(value int) Options
-
-	// MaxFlushRetries returns the maximum number of retries when data flushing fails.
-	MaxFlushRetries() int
-
 	// SetMinimumSnapshotInterval sets the minimum amount of time that must elapse between snapshots.
 	SetMinimumSnapshotInterval(value time.Duration) Options
 


### PR DESCRIPTION
This change avoids potentially returning `false` from `NeedsFlush(...)` for a namespace when max retries have been exceeded for flushing.

There are two faults with this behavior:
1. If `false` returns from `NeedsFlush(...)` due to retries being exceeded for a given block time start, the cleanup code may believe that it was successful and can cleanup commit logs and snapshots - hence losing data on the local node.
1. Naturally if disk was not writeable for some time, we'd ideally like it to just natively recover and flush out blocks that haven't been flushed yet, rather than max retries being hit and then having to restart nodes to have them flush out their data.